### PR TITLE
Add "track" command for moderators

### DIFF
--- a/app/commands/report.ts
+++ b/app/commands/report.ts
@@ -4,7 +4,7 @@ import type { MessageContextMenuInteraction } from "discord.js";
 import { Message } from "discord.js";
 import { ReportReasons, reportUser } from "../helpers/modLog";
 
-export default new ContextMenuCommandBuilder()
+export const command = new ContextMenuCommandBuilder()
   .setName("Report")
   .setType(ApplicationCommandType.Message);
 

--- a/app/commands/setup.ts
+++ b/app/commands/setup.ts
@@ -3,7 +3,7 @@ import type { CommandInteraction } from "discord.js";
 
 import { SETTINGS, setSettings, registerGuild } from "~/models/guilds.server";
 
-export default new SlashCommandBuilder()
+export const command = new SlashCommandBuilder()
   .setName("setup")
   .setDescription("Set up necessities for using the bot")
   // TODO: update permissions so non-mods can never use it
@@ -20,7 +20,7 @@ export default new SlashCommandBuilder()
       .setName("mod-log-channel")
       .setDescription("The channel where moderation reports will be sent")
       .setRequired(true),
-  );
+  ) as SlashCommandBuilder;
 
 export const handler = async (interaction: CommandInteraction) => {
   try {

--- a/app/commands/track.ts
+++ b/app/commands/track.ts
@@ -5,7 +5,7 @@ import { ApplicationCommandType } from "discord-api-types/v10";
 
 import { ReportReasons, reportUser } from "~/helpers/modLog";
 
-export default new ContextMenuCommandBuilder()
+export const command = new ContextMenuCommandBuilder()
   .setName("Track")
   .setType(ApplicationCommandType.Message);
 

--- a/app/commands/track.ts
+++ b/app/commands/track.ts
@@ -1,0 +1,25 @@
+import { Message } from "discord.js";
+import type { MessageContextMenuInteraction } from "discord.js";
+import { ContextMenuCommandBuilder } from "@discordjs/builders";
+import { ApplicationCommandType } from "discord-api-types/v10";
+
+import { ReportReasons, reportUser } from "~/helpers/modLog";
+
+export default new ContextMenuCommandBuilder()
+  .setName("Track")
+  .setType(ApplicationCommandType.Message);
+
+export const handler = async (interaction: MessageContextMenuInteraction) => {
+  const { targetMessage: message, member } = interaction;
+  if (!(message instanceof Message) || !member) {
+    return;
+  }
+
+  await reportUser({
+    reason: ReportReasons.track,
+    message,
+    staff: [member],
+  });
+
+  await interaction.reply({ ephemeral: true, content: "Tracked" });
+};

--- a/app/discord/deployCommands.server.ts
+++ b/app/discord/deployCommands.server.ts
@@ -1,4 +1,14 @@
-import type { Client, Guild } from "discord.js";
+import type {
+  Client,
+  CommandInteraction,
+  Guild,
+  MessageContextMenuInteraction,
+  UserContextMenuInteraction,
+} from "discord.js";
+import {
+  ContextMenuCommandBuilder,
+  SlashCommandBuilder,
+} from "@discordjs/builders";
 import { REST } from "@discordjs/rest";
 import { ApplicationCommandType, Routes } from "discord-api-types/v10";
 import type { APIApplicationCommand } from "discord-api-types/v10";
@@ -6,19 +16,93 @@ import type { APIApplicationCommand } from "discord-api-types/v10";
 import { applicationId, discordToken } from "~/helpers/env";
 import { difference } from "~/helpers/sets";
 
-import setup from "~/commands/setup";
-import report from "~/commands/report";
-import track from "~/commands/track";
+//
+// Types and type helpers for command configs
+//
 
+/**
+ * MessageContextCommand
+ */
+type MessageContextCommand = {
+  command: ContextMenuCommandBuilder;
+  handler: (interaction: MessageContextMenuInteraction) => void;
+};
+const isMessageContextCommand = (
+  config: MessageContextCommand | UserContextCommand | SlashCommand,
+): config is MessageContextCommand =>
+  config.command instanceof ContextMenuCommandBuilder &&
+  config.command.type === ApplicationCommandType.Message;
+
+/**
+ * UserContextCommand
+ */
+type UserContextCommand = {
+  command: ContextMenuCommandBuilder;
+  handler: (interaction: UserContextMenuInteraction) => void;
+};
+const isUserContextCommand = (
+  config: MessageContextCommand | UserContextCommand | SlashCommand,
+): config is UserContextCommand =>
+  config.command instanceof ContextMenuCommandBuilder &&
+  config.command.type === ApplicationCommandType.User;
+
+/**
+ * SlashCommand
+ */
+type SlashCommand = {
+  command: SlashCommandBuilder;
+  handler: (interaction: CommandInteraction) => void;
+};
+const isSlashCommand = (
+  config: MessageContextCommand | UserContextCommand | SlashCommand,
+): config is SlashCommand => config.command instanceof SlashCommandBuilder;
+
+/**
+ * deployCommands notifies Discord of the latest commands to use and registers
+ * interaction event handlers.
+ * @param client A discord.js client
+ */
 export const deployCommands = async (client: Client) => {
   const guilds = await client.guilds.fetch();
   await Promise.all(
     guilds.map(async (guild) => deployCommandsToGuild(await guild.fetch())),
   );
+
+  client.on("interactionCreate", (interaction) => {
+    if (
+      !interaction ||
+      (!interaction.isMessageContextMenu() && !interaction.isCommand())
+    ) {
+      return;
+    }
+    const config = commands.get(interaction.commandName);
+    if (!config) {
+      throw new Error(`No command found for ${interaction.commandName}`);
+    }
+    if (isMessageContextCommand(config) && interaction.isMessageContextMenu()) {
+      config.handler(interaction);
+    } else if (
+      isUserContextCommand(config) &&
+      interaction.isUserContextMenu()
+    ) {
+      config.handler(interaction);
+    } else if (isSlashCommand(config) && interaction.isCommand()) {
+      config.handler(interaction);
+    } else {
+      throw new Error("Didn't find a handler for an interaction");
+    }
+  });
 };
 
-const commands = [setup, report, track].map((x) => x.toJSON());
-const names = new Set(commands.map((c) => c.name));
+const commands = new Map<
+  string,
+  MessageContextCommand | UserContextCommand | SlashCommand
+>();
+export const registerCommand = (
+  config: MessageContextCommand | UserContextCommand | SlashCommand,
+) => {
+  commands.set(config.command.name, config);
+};
 
 const rest = new REST({ version: "10" }).setToken(discordToken);
 const upsertUrl = (guildId: string) =>
@@ -31,6 +115,7 @@ export const deployCommandsToGuild = async (guild: Guild) => {
   const remoteCommands = (await rest.get(
     upsertUrl(guild.id),
   )) as APIApplicationCommand[];
+  const names = new Set(commands.keys());
 
   // Take the list of names to delete and swap it out for IDs to delete
   const remoteNames = new Set(remoteCommands.map((c) => c.name));
@@ -48,35 +133,32 @@ export const deployCommandsToGuild = async (guild: Guild) => {
     toDelete.map((commandId) => rest.delete(deleteUrl(guild.id, commandId))),
   );
 
+  let localCommands = [...commands.values()].map(({ command }) => command);
   // Grab a list of commands that need to be updated
   const toUpdate = remoteCommands.filter(
     (c) =>
       // Check all necessary fields to see if any changed. User and Message
       // commands don't have a description.
-      !commands.find((x) => {
-        const {
-          type = ApplicationCommandType.ChatInput,
-          name,
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-expect-error Unions are weird
-          description = "",
-        } = x;
-        switch (type as ApplicationCommandType) {
-          case ApplicationCommandType.User:
-          case ApplicationCommandType.Message:
-            return name === c.name && type === c.type;
-          case ApplicationCommandType.ChatInput:
-          default:
-            return (
-              name === c.name &&
-              type === c.type &&
-              description === c.description &&
-              c.options?.every((o) =>
-                x.options?.some((o2) => o.name === o2.name),
-              )
-            );
-        }
-      }),
+      !localCommands
+        .map((x) => x.toJSON())
+        .find((x) => {
+          const { type = ApplicationCommandType.ChatInput, name } = x;
+          switch (x.type as ApplicationCommandType) {
+            case ApplicationCommandType.User:
+            case ApplicationCommandType.Message:
+              return name === c.name && type === c.type;
+            case ApplicationCommandType.ChatInput:
+            default:
+              return (
+                name === c.name &&
+                type === c.type &&
+                ("description" in x ? x.description === c.description : true) &&
+                c.options?.every((o) =>
+                  x.options?.some((o2) => o.name === o2.name),
+                )
+              );
+          }
+        }),
   );
 
   console.log(
@@ -88,10 +170,11 @@ export const deployCommandsToGuild = async (guild: Guild) => {
     )}]`,
   );
 
-  if (toUpdate.length === 0 && remoteCommands.length === commands.length) {
+  if (toUpdate.length === 0 && remoteCommands.length === localCommands.length) {
     console.log("DEPLOY", `No changes found, not upserting.`);
     return;
   }
 
-  await rest.put(upsertUrl(guild.id), { body: commands });
+  console.log("DEPLOY", `Upserting ${localCommands.length} commands`);
+  await rest.put(upsertUrl(guild.id), { body: localCommands });
 };

--- a/app/discord/deployCommands.server.ts
+++ b/app/discord/deployCommands.server.ts
@@ -8,6 +8,7 @@ import { difference } from "~/helpers/sets";
 
 import setup from "~/commands/setup";
 import report from "~/commands/report";
+import track from "~/commands/track";
 
 export const deployCommands = async (client: Client) => {
   const guilds = await client.guilds.fetch();
@@ -16,7 +17,7 @@ export const deployCommands = async (client: Client) => {
   );
 };
 
-const commands = [setup, report].map((x) => x.toJSON());
+const commands = [setup, report, track].map((x) => x.toJSON());
 const names = new Set(commands.map((c) => c.name));
 
 const rest = new REST({ version: "10" }).setToken(discordToken);

--- a/app/discord/gateway.ts
+++ b/app/discord/gateway.ts
@@ -1,13 +1,21 @@
 import Sentry from "~/helpers/sentry.server";
 
-import onboardCommand, { handler as onboardHandler } from "~/commands/setup";
-import reportCommand, { handler as reportHandler } from "~/commands/report";
-import trackCommand, { handler as trackHandler } from "~/commands/track";
+import { client, login } from "~/discord/client";
+import {
+  deployCommands,
+  registerCommand,
+} from "~/discord/deployCommands.server";
 
 import automod from "~/discord/automod";
 import onboardGuild from "~/discord/onboardGuild";
-import { client, login } from "~/discord/client";
-import { deployCommands } from "~/discord/deployCommands.server";
+
+import * as setup from "~/commands/setup";
+import * as report from "~/commands/report";
+import * as track from "~/commands/track";
+
+registerCommand(setup);
+registerCommand(report);
+registerCommand(track);
 
 export default function init() {
   login();
@@ -18,22 +26,6 @@ export default function init() {
       automod(client),
       deployCommands(client),
     ]);
-  });
-
-  client.on("interactionCreate", (interaction) => {
-    if (interaction.isCommand()) {
-      switch (interaction.commandName) {
-        case onboardCommand.name:
-          return onboardHandler(interaction);
-      }
-    } else if (interaction.isMessageContextMenu()) {
-      switch (interaction.commandName) {
-        case reportCommand.name:
-          return reportHandler(interaction);
-        case trackCommand.name:
-          return trackHandler(interaction);
-      }
-    }
   });
 
   // client.on("messageReactionAdd", () => {});

--- a/app/discord/gateway.ts
+++ b/app/discord/gateway.ts
@@ -2,6 +2,7 @@ import Sentry from "~/helpers/sentry.server";
 
 import onboardCommand, { handler as onboardHandler } from "~/commands/setup";
 import reportCommand, { handler as reportHandler } from "~/commands/report";
+import trackCommand, { handler as trackHandler } from "~/commands/track";
 
 import automod from "~/discord/automod";
 import onboardGuild from "~/discord/onboardGuild";
@@ -29,21 +30,23 @@ export default function init() {
       switch (interaction.commandName) {
         case reportCommand.name:
           return reportHandler(interaction);
+        case trackCommand.name:
+          return trackHandler(interaction);
       }
     }
   });
 
-  client.on("messageReactionAdd", () => {});
+  // client.on("messageReactionAdd", () => {});
 
   client.on("threadCreate", (thread) => {
     thread.join();
   });
 
-  client.on("messageCreate", async (msg) => {
-    if (msg.author?.id === client.user?.id) return;
+  // client.on("messageCreate", async (msg) => {
+  //   if (msg.author?.id === client.user?.id) return;
 
-    //
-  });
+  //   //
+  // });
 
   const errorHandler = (error: unknown) => {
     Sentry.captureException(error);

--- a/app/helpers/discord.ts
+++ b/app/helpers/discord.ts
@@ -6,6 +6,7 @@ import type {
   MessageReaction,
   PartialMessageReaction,
 } from "discord.js";
+import { truncateMessage } from "./string";
 
 const staffRoles = ["mvp", "moderator", "admin", "admins"];
 const helpfulRoles = ["mvp", "star helper"];
@@ -67,4 +68,8 @@ export const escapeDisruptiveContent = (content: string) => {
       // Wrap links in <> so they don't make a preview
       .replace(/(https?:\/\/.*)\s?/g, "<$1>")
   );
+};
+
+export const quoteAndEscape = (content: string) => {
+  return truncateMessage(escapeDisruptiveContent(quoteMessageContent(content)));
 };

--- a/app/helpers/modLog.ts
+++ b/app/helpers/modLog.ts
@@ -2,11 +2,7 @@ import type { GuildMember, Message, Role, TextChannel } from "discord.js";
 import type { APIInteractionGuildMember } from "discord-api-types/v10";
 
 import { fetchSettings, SETTINGS } from "~/models/guilds.server";
-import {
-  constructDiscordLink,
-  escapeDisruptiveContent,
-  quoteMessageContent,
-} from "~/helpers/discord";
+import { constructDiscordLink, quoteAndEscape } from "~/helpers/discord";
 import { simplifyString } from "~/helpers/string";
 import { format, formatDistanceToNowStrict } from "date-fns";
 
@@ -89,17 +85,6 @@ export const reportUser = async ({
   }
 };
 
-// Discord's limit for message length
-const maxMessageLength = 2000;
-export const truncateMessage = (
-  message: string,
-  maxLength = maxMessageLength - 500,
-) => {
-  if (message.length > maxLength) return `${message.slice(0, maxLength)}…`;
-
-  return message;
-};
-
 const constructLog = ({
   reason,
   message,
@@ -123,9 +108,7 @@ ${
       : ""
   }
 `;
-  const reportedMessage = truncateMessage(
-    escapeDisruptiveContent(quoteMessageContent(message.content)),
-  );
+  const reportedMessage = quoteAndEscape(message.content);
 
   switch (reason) {
     case ReportReasons.mod:

--- a/app/helpers/string.ts
+++ b/app/helpers/string.ts
@@ -10,3 +10,14 @@ export const simplifyString = (s: string) =>
     .replace(NORMALIZED_CODEPOINTS, "")
     .replace(EMOJI_RANGE, "")
     .replace(SPECIAL_CHARACTERS, "");
+
+// Discord's limit for message length
+const maxMessageLength = 2000;
+export const truncateMessage = (
+  content: string,
+  maxLength = maxMessageLength - 300,
+) => {
+  if (content.length > maxLength) return `${content.slice(0, maxLength)}…`;
+
+  return content;
+};


### PR DESCRIPTION
"Report" is a great way for members to alert mods of something, but it's not appropriate for use by moderators due to the anonymous nature. This adds "Track", which can be used to log messages. Logged messages are useful for identifying patterns of abuse over periods of time — Discord search can be powerful here, searching the mod log channel for `mentions:user#1234` can show how often someone's messages have been noted by moderators as problematic.

<img width="479" alt="Screen Shot 2022-07-17 at 12 34 42 PM" src="https://user-images.githubusercontent.com/1551487/179417769-4758af93-cf0b-499b-bcd0-ccaa909d964d.png">

The bot logs their username at time of report separately from pinging them, so that's capture separately. If someone changes their nickname, that could be lost context when reviewing the report.