### PR TITLE
Fine tune spam filter

### DIFF
--- a/app/discord/automod.test.ts
+++ b/app/discord/automod.test.ts
@@ -7,6 +7,7 @@ test("isSpam has a reasonable threshold", () => {
   );
   expect(isSpam("free nitro https://example.ru")).toBe(true);
   expect(isSpam("@everyone https://discord.gg/garbage join now")).toBe(true);
+  expect(isSpam("https://discord.gg/garbage join now")).toBe(true);
   expect(isSpam("Hello")).toBe(false);
   expect(isSpam("Hello https://google.com")).toBe(false);
   expect(isSpam("Hello https://google.com discord")).toBe(false);
@@ -15,4 +16,5 @@ test("isSpam has a reasonable threshold", () => {
       "Hey guys, I have a project where a user can purchase gift and use gift cards, so how do I store a decrypted gift url`",
     ),
   ).toBe(false);
+  expect(isSpam("free free free free free")).toBe(false);
 });

--- a/app/discord/automod.ts
+++ b/app/discord/automod.ts
@@ -26,23 +26,25 @@ export const isSpam = (content: string, threshold = 3) => {
   const pingCount = getPingCount(content);
 
   const words = content.split(" ");
-  const includedSpamKeywords = words
-    .map((word) => spamKeywords.includes(word))
-    .filter(Boolean);
+  const numberOfSpamKeywords = spamKeywords.reduce(
+    (accum, spamTrigger) => (words.includes(spamTrigger) ? accum + 1 : accum),
+    0,
+  );
 
   const hasSafeKeywords = checkWords(content, safeKeywords);
-
+  const hasBareInvite = content.includes("discord.gg") && content.length < 50;
   const hasLink = content.includes("http");
 
-  return (
-    threshold <=
+  const score =
     Number(hasLink) +
-      includedSpamKeywords.length +
-      // Pinging everyone is always treated as spam
-      Number(pingCount) * 5 -
-      // If it's a job post, then it's probably  not spam
-      Number(hasSafeKeywords) * 10
-  );
+    numberOfSpamKeywords +
+    // Pinging everyone is always treated as spam
+    pingCount * 5 +
+    Number(hasBareInvite) * 5 -
+    // If it's a job post, then it's probably not spam
+    Number(hasSafeKeywords) * 10;
+
+  return threshold <= score;
 };
 
 export default async (bot: Client) => {


### PR DESCRIPTION
Messages that used "free" 3 or more times were being caught unintentionally, and bare discord invites without an @ everyone ping weren't being caught. This should offer us better coverage with fewer false positives.