### PR TITLE
Improve message tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lint-staged": "^12.4.1",
     "node-cron": "^3.0.0",
     "node-fetch": "^2.6.7",
+    "pretty-bytes": "^5.6.0",
     "query-string": "^6.2.0",
     "reacord": "^0.3.6",
     "react": "^18.0.0",


### PR DESCRIPTION
Adds an embed with a link to the original message, and details about any attachments. File sizes, names, and if it’s a video or image, a link to the content

<img width="407" alt="Screen Shot 2022-07-22 at 4 24 28 PM" src="https://user-images.githubusercontent.com/1551487/180572215-1681cf99-378e-4303-b2b9-c92bf3def13a.png">