### PR TITLE
Fix "track" attachment display and improve spam detection

### DIFF
--- a/app/discord/automod.test.ts
+++ b/app/discord/automod.test.ts
@@ -8,6 +8,9 @@ test("isSpam has a reasonable threshold", () => {
   expect(isSpam("free nitro https://example.ru")).toBe(true);
   expect(isSpam("@everyone https://discord.gg/garbage join now")).toBe(true);
   expect(isSpam("https://discord.gg/garbage join now")).toBe(true);
+  expect(
+    isSpam("<https://example.net/1234/poki-private-stream poki deepfakes lol"),
+  ).toBe(true);
   expect(isSpam("Hello")).toBe(false);
   expect(isSpam("Hello https://google.com")).toBe(false);
   expect(isSpam("Hello https://google.com discord")).toBe(false);

--- a/app/discord/automod.ts
+++ b/app/discord/automod.ts
@@ -8,7 +8,7 @@ import { reportUser, ReportReasons } from "~/helpers/modLog";
 
 const AUTO_SPAM_THRESHOLD = 3;
 
-const spamKeywords = ["nitro", "steam", "free", "airdrop"];
+const spamKeywords = ["nitro", "steam", "free", "airdrop", "deepfake", "poki"];
 const spamPings = ["@everyone", "@here"];
 const safeKeywords = ["forhire", "hiring", "remote", "onsite"];
 

--- a/app/discord/automod.ts
+++ b/app/discord/automod.ts
@@ -8,7 +8,14 @@ import { reportUser, ReportReasons } from "~/helpers/modLog";
 
 const AUTO_SPAM_THRESHOLD = 3;
 
-const spamKeywords = ["nitro", "steam", "free", "airdrop", "deepfake", "poki"];
+const spamKeywords = [
+  "nitro",
+  "steam",
+  "free",
+  "airdrop",
+  "deepfake",
+  "poki",
+].map((x) => new RegExp(x));
 const spamPings = ["@everyone", "@here"];
 const safeKeywords = ["forhire", "hiring", "remote", "onsite"];
 
@@ -22,12 +29,11 @@ const getPingCount = (content: string) => {
   );
 };
 
-export const isSpam = (content: string, threshold = 3) => {
+export const isSpam = (content: string, threshold = 4) => {
   const pingCount = getPingCount(content);
 
-  const words = content.split(" ");
   const numberOfSpamKeywords = spamKeywords.reduce(
-    (accum, spamTrigger) => (words.includes(spamTrigger) ? accum + 1 : accum),
+    (accum, spamTrigger) => (spamTrigger.test(content) ? accum + 1 : accum),
     0,
   );
 
@@ -36,7 +42,7 @@ export const isSpam = (content: string, threshold = 3) => {
   const hasLink = content.includes("http");
 
   const score =
-    Number(hasLink) +
+    Number(hasLink) * 2 +
     numberOfSpamKeywords +
     // Pinging everyone is always treated as spam
     pingCount * 5 +

--- a/app/helpers/modLog.ts
+++ b/app/helpers/modLog.ts
@@ -116,11 +116,14 @@ const constructLog = ({
   const link = `[Original message](${constructDiscordLink(message)})`;
   const attachments =
     message.attachments.size === 0
-      ? undefined
+      ? ""
       : "\n\nAttachments:\n" +
         message.attachments
           .map(
             (a) =>
+              // Include size of the file and the filename
+              // If it's a video or image, include a link.
+              // Renders as `1.12mb: [some-image.jpg](<original image url>)`
               `${prettyBytes(a.size)}: ${
                 a.contentType?.match(/(image|video)/)
                   ? `[${a.name}](${a.url})`


### PR DESCRIPTION
* Adds some new keywords to spam detection, `"poki"` and `"deepfake"`
* Loosens matching to "contains substring" instead of "contains exact word", because `deepfake` wasn't matching on `deepfakes`
* Bumps up the "spam score" weight of links to 2 per link, from 1
* Adjust required threshold for being spam to 4