### PR TITLE
Add delete button after Track, make Convene Mods ping optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Remix session
+SESSION_SECRET=
+
+# Discord
+DISCORD_PUBLIC_KEY=
+DISCORD_APP_ID=
+DISCORD_SECRET=
+DISCORD_HASH=
+
+# Not necessary to run
+## Deploy token
+DIGITALOCEAN_TOKEN=
+## Error reporting
+SENTRY_INGEST=
+SENTRY_RELEASES=

--- a/app/commands/convene.tsx
+++ b/app/commands/convene.tsx
@@ -17,7 +17,7 @@ import { resolutions } from "~/helpers/modResponse";
 
 import { fetchSettings, SETTINGS } from "~/models/guilds.server";
 import { applyRestriction, ban, kick, timeout } from "~/models/discord.server";
-import { ModResponse } from "~/commands/reacord/ModResponse";
+import { Confirmation, ModResponse } from "~/commands/reacord/ModResponse";
 
 export const command = new ContextMenuCommandBuilder()
   .setName("Convene mods")
@@ -55,12 +55,12 @@ export const handler = async (
     name: `${message.author.username} mod response ${format(new Date(), "P")}`,
   });
   const originalChannel = (await message.channel.fetch()) as TextChannel;
-  const instance = await reacord.send(
+  const pollInstance = reacord.send(
     thread.id,
     <ModResponse
       modRoleId={moderator}
       onResolve={async (resolution) => {
-        instance.deactivate();
+        pollInstance.deactivate();
         switch (resolution) {
           case resolutions.restrict:
             reportUser({
@@ -162,5 +162,15 @@ This isn't a formal warning, but your message concerned the moderators enough th
   );
 
   // reply
-  await interaction.reply({ ephemeral: true, content: "Notification sent" });
+  const ackInstance = reacord.ephemeralReply(
+    interaction,
+    <Confirmation
+      modRoleId={moderator}
+      thread={thread}
+      onNotify={() => {
+        ackInstance.render("Mods notified");
+        ackInstance.deactivate();
+      }}
+    />,
+  );
 };

--- a/app/commands/reacord/ModResponse.tsx
+++ b/app/commands/reacord/ModResponse.tsx
@@ -26,6 +26,10 @@ export const ModResponse = ({
       label={label}
       style={style}
       onClick={async (event) => {
+        if (!event.guild?.member.roles?.includes(modRoleId)) {
+          return;
+        }
+
         const { leader, voteCount } = recordVote(
           votes,
           resolution,

--- a/app/commands/reacord/ModResponse.tsx
+++ b/app/commands/reacord/ModResponse.tsx
@@ -1,3 +1,4 @@
+import type { AnyThreadChannel } from "discord.js";
 import { Button } from "reacord";
 
 import type { Resolution } from "~/helpers/modResponse";
@@ -45,7 +46,7 @@ export const ModResponse = ({
 
   return (
     <>
-      {`<@&${modRoleId}> after ${votesRequired} or more votes, the leading resolution will be automatically enforced.
+      {`After ${votesRequired} or more votes, the leading resolution will be automatically enforced.
 ${Object.entries(votes)
   .map(
     ([resolution, voterIds]) =>
@@ -61,6 +62,32 @@ ${Object.entries(votes)
       {renderButton(votes, resolutions.restrict, "Restrict")}
       {renderButton(votes, resolutions.kick, "Kick")}
       {renderButton(votes, resolutions.ban, "Ban", "danger")}
+    </>
+  );
+};
+
+export const Confirmation = ({
+  thread,
+  modRoleId,
+  onNotify,
+}: {
+  thread: AnyThreadChannel;
+  modRoleId: string;
+  onNotify: () => void;
+}) => {
+  return (
+    <>
+      Discussion thread created
+      <Button
+        label="Notify mods"
+        style="success"
+        onClick={async (event) => {
+          await thread.send(
+            `<@${event.user.id}> indicated this is urgent. <@&${modRoleId}> please respond`,
+          );
+          await onNotify();
+        }}
+      />
     </>
   );
 };

--- a/app/commands/track.tsx
+++ b/app/commands/track.tsx
@@ -4,6 +4,8 @@ import {
   ContextMenuCommandBuilder,
   Message,
 } from "discord.js";
+import { Button } from "reacord";
+import { reacord } from "~/discord/client.server";
 
 import { ReportReasons, reportUser } from "~/helpers/modLog";
 
@@ -25,5 +27,18 @@ export const handler = async (
     staff: [member],
   });
 
-  await interaction.reply({ ephemeral: true, content: "Tracked" });
+  const instance = await reacord.ephemeralReply(
+    interaction,
+    <>
+      Tracked
+      <Button
+        label="Delete message"
+        style="danger"
+        onClick={async () => {
+          await message.delete();
+          instance.render("Tracked");
+        }}
+      />
+    </>,
+  );
 };


### PR DESCRIPTION
A few small changes:

* Add a "delete message" button to the ephemeral response after Track
* Change Convene Mods behavior so `@moderator` ping is optional
  * The thinking here is to lower the stakes for what messages could trigger a poll. Pinging the entire mod team is disruptive if done too frequently, and I think this is a useful tool for decision making; using it more often seems helpful for making sure everyone is on the same page.
* Add missing `.env.example` file

<img width="369" alt="Screen Shot 2022-09-27 at 4 51 21 PM" src="https://user-images.githubusercontent.com/1551487/192932674-537baa03-be26-4b83-ab2d-00c3ee48c129.png">
<img width="364" alt="Screen Shot 2022-09-28 at 11 50 25 PM" src="https://user-images.githubusercontent.com/1551487/192934602-9872377d-9051-4c12-aba1-6ea5b2c02609.png">
<img width="627" alt="Screen Shot 2022-09-27 at 4 52 52 PM" src="https://user-images.githubusercontent.com/1551487/192932677-03a8519a-6d9a-494e-9e5f-43cf527237da.png">
