### PR TITLE
Fix Track command when logging messages without attachments

### DIFF
--- a/app/helpers/modLog.ts
+++ b/app/helpers/modLog.ts
@@ -5,7 +5,6 @@ import type {
   User,
   ClientUser,
 } from "discord.js";
-import { EmbedType } from "discord.js";
 
 import { fetchSettings, SETTINGS } from "~/models/guilds.server";
 import {
@@ -130,11 +129,6 @@ const constructLog = async ({
 ${reports}
 ${extra}
 ${reportedMessage}`,
-    embeds: [
-      {
-        type: EmbedType.Rich,
-        description: `${attachments ? `\n\n${attachments}` : ""}`,
-      },
-    ],
+    embeds: attachments ? [{ description: `\n\n${attachments}` }] : undefined,
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@types/lodash": "^4.14.182",
         "better-sqlite3": "^7.5.1",
         "date-fns": "^2.27.0",
-        "discord.js": "^14.4.0",
+        "discord.js": "^14.6.0",
         "dotenv": "^16.0.1",
         "express": "^4.18.1",
         "knex": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@types/lodash": "^4.14.182",
     "better-sqlite3": "^7.5.1",
     "date-fns": "^2.27.0",
-    "discord.js": "^14.4.0",
+    "discord.js": "^14.6.0",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "knex": "^2.0.0",


### PR DESCRIPTION
I changed logic so that it no longer uses anything in the embed if there aren't attachments, but the Discord API doesn't like receiving an empty string for an embed description. This fixes that by only including the embed if there are attachments