### PR TITLE
Use Discord global commands

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -2,6 +2,14 @@
 
 spammer joining by invites is pretty hard to discover and manage. an interface for tidying up invites to protect members might be helpful
 
+# "mod message" feature
+
+use for other things too, like a role menu + vetting process
+long-lived button to initialize
+create a thread (private if possible) with the user
+ask member to complete "application", onboarding-style series of responses maybe
+create a thread in #mod-log and share application with application deets, with approve button
+
 # admin onboarding and web experience
 
 should have a web-based onboarding flow to configure server where necessary. hand off between discord bot and web as appropriate

--- a/app/discord/api.ts
+++ b/app/discord/api.ts
@@ -1,0 +1,4 @@
+import { REST } from "discord.js";
+import { discordToken } from "~/helpers/env";
+
+export const rest = new REST({ version: "10" }).setToken(discordToken);

--- a/app/discord/deployCommands.server.ts
+++ b/app/discord/deployCommands.server.ts
@@ -1,10 +1,5 @@
-import type { APIApplicationCommand, Client, Guild } from "discord.js";
-import {
-  REST,
-  Routes,
-  InteractionType,
-  ApplicationCommandType,
-} from "discord.js";
+import type { APIApplicationCommand, Client } from "discord.js";
+import { Routes, InteractionType } from "discord.js";
 
 import type {
   MessageContextCommand,
@@ -16,8 +11,10 @@ import {
   isSlashCommand,
   isUserContextCommand,
 } from "~/helpers/discord";
-import { applicationId, discordToken } from "~/helpers/env";
-import { difference } from "~/helpers/sets";
+import { applicationId, isProd, testGuild } from "~/helpers/env";
+
+import { rest } from "~/discord/api";
+import { applyCommandChanges } from "~/helpers/discordCommands";
 
 /**
  * deployCommands notifies Discord of the latest commands to use and registers
@@ -25,10 +22,58 @@ import { difference } from "~/helpers/sets";
  * @param client A discord.js client
  */
 export const deployCommands = async (client: Client) => {
-  const guilds = await client.guilds.fetch();
-  await Promise.all(
-    guilds.map(async (guild) => deployCommandsToGuild(await guild.fetch())),
-  );
+  const localCommands = [...commands.values()].map(({ command }) => command);
+
+  if (isProd()) {
+    // Fetch test guild + global commands
+    const [remoteGuildCommands, remoteGlobalCommands] = await Promise.all([
+      (await rest.get(
+        Routes.applicationGuildCommands(applicationId, testGuild),
+      )) as APIApplicationCommand[],
+      (await rest.get(
+        Routes.applicationCommands(applicationId),
+      )) as APIApplicationCommand[],
+    ]);
+
+    // Deploy to test guild and globally
+    await Promise.all([
+      applyCommandChanges(
+        "Global",
+        localCommands,
+        remoteGlobalCommands,
+        () => Routes.applicationCommands(applicationId),
+        (commandId: string) =>
+          Routes.applicationCommand(applicationId, commandId),
+      ),
+      applyCommandChanges(
+        "Test Guild",
+        localCommands,
+        remoteGuildCommands,
+        () => Routes.applicationGuildCommands(applicationId, testGuild),
+        (commandId: string) =>
+          Routes.applicationGuildCommand(applicationId, testGuild, commandId),
+      ),
+    ]);
+  }
+  if (!isProd()) {
+    // Deploy directly to all connected guilds
+    const guilds = await client.guilds.fetch();
+    await Promise.all(
+      guilds.map(async (guild) => {
+        const remoteCommands = (await rest.get(
+          Routes.applicationGuildCommands(applicationId, guild.id),
+        )) as APIApplicationCommand[];
+        await applyCommandChanges(
+          `${guild.name.slice(0, 10)}…`,
+          localCommands,
+          remoteCommands,
+          () => Routes.applicationGuildCommands(applicationId, guild.id),
+          (commandId: string) =>
+            Routes.applicationGuildCommand(applicationId, guild.id, commandId),
+        );
+      }),
+    );
+  }
 
   client.on("interactionCreate", (interaction) => {
     if (
@@ -66,84 +111,4 @@ type Command = MessageContextCommand | UserContextCommand | SlashCommand;
 const commands = new Map<string, Command>();
 export const registerCommand = (config: Command) => {
   commands.set(config.command.name, config);
-};
-
-const rest = new REST({ version: "10" }).setToken(discordToken);
-
-// TODO: make this a global command in production
-export const deployCommandsToGuild = async (guild: Guild) => {
-  const remoteCommands = (await rest.get(
-    Routes.applicationGuildCommands(applicationId, guild.id),
-  )) as APIApplicationCommand[];
-  const names = new Set(commands.keys());
-
-  // Take the list of names to delete and swap it out for IDs to delete
-  const remoteNames = new Set(remoteCommands.map((c) => c.name));
-  const deleteNames = [...difference(remoteNames, names)];
-  const toDelete = deleteNames
-    .map((x) => remoteCommands.find((y) => y.name === x)?.id)
-    .filter((x): x is string => Boolean(x));
-
-  console.log(
-    "DEPLOY",
-    `local: [${[...names].join(",")}], remote: [${[...remoteNames].join(",")}]`,
-  );
-
-  await Promise.allSettled(
-    toDelete.map((commandId) =>
-      rest.delete(
-        Routes.applicationGuildCommand(applicationId, guild.id, commandId),
-      ),
-    ),
-  );
-
-  let localCommands = [...commands.values()].map(({ command }) => command);
-  // Grab a list of commands that need to be updated
-  const toUpdate = remoteCommands.filter(
-    (c) =>
-      // Check all necessary fields to see if any changed. User and Message
-      // commands don't have a description.
-      !localCommands
-        .map((x) => x.toJSON())
-        .find((x) => {
-          const { type = ApplicationCommandType.ChatInput, name } = x;
-          switch (x.type as ApplicationCommandType) {
-            case ApplicationCommandType.User:
-            case ApplicationCommandType.Message:
-              return name === c.name && type === c.type;
-            case ApplicationCommandType.ChatInput:
-            default:
-              return (
-                name === c.name &&
-                type === c.type &&
-                ("description" in x ? x.description === c.description : true) &&
-                c.options?.every((o) =>
-                  x.options?.some((o2) => o.name === o2.name),
-                ) &&
-                x.options?.every((o) =>
-                  c.options?.some((o2) => o.name === o2.name),
-                )
-              );
-          }
-        }),
-  );
-
-  console.log(
-    "DEPLOY",
-    `Found ${toUpdate.length} changes: [${toUpdate
-      .map((x) => x.name)
-      .join(",")}], and ${deleteNames.length} to delete: [${deleteNames.join(
-      ",",
-    )}]`,
-  );
-
-  if (toUpdate.length === 0 && remoteCommands.length === localCommands.length) {
-    console.log("DEPLOY", `No changes found, not upserting.`);
-    return;
-  }
-
-  console.log("DEPLOY", `Upserting ${localCommands.length} commands`);
-  await rest.put(Routes.applicationGuildCommands(applicationId, guild.id), {
-    body: localCommands,
-  });
 };

--- a/app/discord/onboardGuild.ts
+++ b/app/discord/onboardGuild.ts
@@ -3,14 +3,11 @@ import { ChannelType } from "discord.js";
 import { retry } from "~/helpers/misc";
 
 import { fetchGuild } from "~/models/guilds.server";
-import { deployCommandsToGuild } from "./deployCommands.server";
 
 export default async (bot: Client) => {
   // This is called any time the bot comes online, when a server becomes
   // available after downtime, or when actually added to a new guild
   bot.on("guildCreate", async (guild) => {
-    deployCommandsToGuild(guild);
-
     const appGuild = await fetchGuild(guild);
     if (!appGuild) {
       const welcomeMessage = `You've added automoderation! Configure the bot with the /onboard command or go to http://localhost:3000/onboard`;

--- a/app/helpers/discordCommands.test.ts
+++ b/app/helpers/discordCommands.test.ts
@@ -1,0 +1,260 @@
+import { calculateChangedCommands, compareCommands } from "./discordCommands";
+
+import {
+  ApplicationCommandType,
+  ContextMenuCommandBuilder,
+  SlashCommandBuilder,
+} from "discord.js";
+
+const l = {
+  slashCommand: new SlashCommandBuilder()
+    .setName("slash-demo")
+    .setDescription("slash description"),
+  userCommand: new ContextMenuCommandBuilder()
+    .setName("user demo")
+    .setType(ApplicationCommandType.User),
+  messageCommand: new ContextMenuCommandBuilder()
+    .setName("message demo")
+    .setType(ApplicationCommandType.Message),
+};
+
+const r = {
+  slashCommand: {
+    id: "100000000000000000",
+    name: "slash-demo",
+    description: "slash description",
+    application_id: "000000000000000001",
+    version: "000010000000000000",
+    guild_id: undefined,
+    default_member_permissions: null,
+    type: ApplicationCommandType.ChatInput,
+  },
+  slashCommandC: {
+    id: "100000000000000000",
+    name: "slash-demo",
+    description: "CHANGED slash description 1234",
+    application_id: "000000000000000001",
+    version: "000010000000000000",
+    guild_id: undefined,
+    default_member_permissions: "different",
+    type: ApplicationCommandType.ChatInput,
+  },
+  // with options
+  slashCommandO: {
+    id: "2000000000000000000",
+    name: "slash-with-options",
+    description: "",
+    application_id: "000000000000000001",
+    version: "000010000000000000",
+    guild_id: undefined,
+    default_member_permissions: null,
+    type: ApplicationCommandType.ChatInput,
+    options: [
+      {
+        type: 8,
+        name: "option",
+        description: "Some description",
+        required: true,
+      },
+    ],
+  },
+  // with options, changed
+  slashCommandOC: {
+    id: "2000000000000000000",
+    name: "slash-with-options",
+    description: "",
+    application_id: "000000000000000001",
+    version: "000010000000000000",
+    guild_id: undefined,
+    default_member_permissions: null,
+    type: ApplicationCommandType.ChatInput,
+    options: [
+      {
+        type: 8,
+        name: "option",
+        description: "DIFFERENT",
+        required: true,
+      },
+    ],
+  },
+  // with options, changed (new option)
+  slashCommandOC2: {
+    id: "2000000000000000000",
+    name: "slash-with-options",
+    description: "",
+    application_id: "000000000000000001",
+    version: "000010000000000000",
+    guild_id: undefined,
+    default_member_permissions: null,
+    type: ApplicationCommandType.ChatInput,
+    options: [
+      {
+        type: 8,
+        name: "option",
+        description: "Some description",
+        required: true,
+      },
+      {
+        type: 8,
+        name: "option2",
+        description: "Some description",
+        required: true,
+      },
+    ],
+  },
+  // with options, changed (not req)
+  slashCommandOC3: {
+    id: "2000000000000000000",
+    name: "slash-with-options",
+    description: "",
+    application_id: "000000000000000001",
+    version: "000010000000000000",
+    guild_id: undefined,
+    default_member_permissions: null,
+    type: ApplicationCommandType.ChatInput,
+    options: [
+      {
+        type: 8,
+        name: "option",
+        description: "Some description",
+      },
+    ],
+  },
+  userCommand: {
+    id: "300000000000000000",
+    name: "user demo",
+    description: "",
+    guild_id: undefined,
+    application_id: "000000000000000001",
+    version: "000010000000000000",
+    default_member_permissions: null,
+    type: ApplicationCommandType.User,
+  },
+  userCommandC: {
+    id: "300000000000000000",
+    name: "user demo",
+    description: "",
+    guild_id: undefined,
+    application_id: "000000000000000001",
+    version: "000010000000000000",
+    default_member_permissions: "changed",
+    type: ApplicationCommandType.User,
+  },
+  userCommandD: {
+    id: "400000000000000000",
+    name: "DIFFERENT user",
+    description: "",
+    guild_id: undefined,
+    application_id: "000000000000000001",
+    version: "000010000000000000",
+    default_member_permissions: null,
+    type: ApplicationCommandType.User,
+  },
+  messageCommand: {
+    id: "500000000000000000",
+    name: "message demo",
+    description: "",
+    application_id: "000000000000000001",
+    guild_id: undefined,
+    version: "000010000000000000",
+    default_member_permissions: null,
+    type: ApplicationCommandType.Message,
+  },
+  messageCommandC: {
+    id: "500000000000000000",
+    name: "message demo",
+    description: "",
+    application_id: "000000000000000001",
+    guild_id: undefined,
+    version: "000010000000000000",
+    default_member_permissions: "changed",
+    type: ApplicationCommandType.Message,
+  },
+  messageCommandD: {
+    id: "600000000000000000",
+    name: "DIFFERENT message demo",
+    description: "",
+    application_id: "000000000000000001",
+    guild_id: undefined,
+    version: "000010000000000000",
+    default_member_permissions: null,
+    type: ApplicationCommandType.Message,
+  },
+};
+
+describe("compareCommands", () => {
+  it("spots simple differences", () => {
+    // local slash commands
+    expect(compareCommands(l.slashCommand, r.slashCommand)).toBe(true);
+    expect(compareCommands(l.slashCommand, r.slashCommandC)).toBe(false);
+    expect(compareCommands(l.slashCommand, r.slashCommandO)).toBe(false);
+    expect(compareCommands(l.slashCommand, r.slashCommandOC)).toBe(false);
+    expect(compareCommands(l.slashCommand, r.slashCommandOC2)).toBe(false);
+    expect(compareCommands(l.slashCommand, r.slashCommandOC3)).toBe(false);
+    expect(compareCommands(l.slashCommand, r.messageCommand)).toBe(false);
+    expect(compareCommands(l.slashCommand, r.userCommand)).toBe(false);
+    expect(compareCommands(l.slashCommand, r.messageCommandD)).toBe(false);
+    expect(compareCommands(l.slashCommand, r.userCommandD)).toBe(false);
+    // local user commands
+    expect(compareCommands(l.userCommand, r.userCommand)).toBe(true);
+    expect(compareCommands(l.userCommand, r.userCommandC)).toBe(false);
+    expect(compareCommands(l.userCommand, r.userCommandD)).toBe(false);
+    expect(compareCommands(l.userCommand, r.slashCommand)).toBe(false);
+    expect(compareCommands(l.userCommand, r.slashCommandO)).toBe(false);
+    expect(compareCommands(l.userCommand, r.messageCommand)).toBe(false);
+    expect(compareCommands(l.userCommand, r.messageCommandD)).toBe(false);
+    // local message commands
+    expect(compareCommands(l.messageCommand, r.messageCommand)).toBe(true);
+    expect(compareCommands(l.messageCommand, r.messageCommandC)).toBe(false);
+    expect(compareCommands(l.messageCommand, r.messageCommandD)).toBe(false);
+    expect(compareCommands(l.messageCommand, r.slashCommand)).toBe(false);
+    expect(compareCommands(l.messageCommand, r.slashCommandO)).toBe(false);
+    expect(compareCommands(l.messageCommand, r.userCommand)).toBe(false);
+    expect(compareCommands(l.messageCommand, r.userCommandD)).toBe(false);
+  });
+});
+
+test("calculateChangedCommands", () => {
+  expect(
+    calculateChangedCommands(
+      [l.slashCommand, l.messageCommand, l.userCommand],
+      [r.slashCommand, r.messageCommand, r.userCommand],
+    ),
+  ).toEqual({ toDelete: [], didCommandsChange: false });
+  expect(
+    calculateChangedCommands(
+      [l.slashCommand, l.messageCommand, l.userCommand],
+      [r.slashCommandC, r.messageCommand, r.userCommand],
+    ),
+  ).toEqual({ toDelete: [], didCommandsChange: true });
+  expect(
+    calculateChangedCommands(
+      [l.slashCommand, l.messageCommand, l.userCommand],
+      [r.slashCommand, r.messageCommandC, r.userCommand],
+    ),
+  ).toEqual({ toDelete: [], didCommandsChange: true });
+  expect(
+    calculateChangedCommands(
+      [l.slashCommand, l.messageCommand, l.userCommand],
+      [r.slashCommand, r.messageCommand, r.userCommandC],
+    ),
+  ).toEqual({ toDelete: [], didCommandsChange: true });
+  expect(
+    calculateChangedCommands(
+      [],
+      [r.slashCommand, r.messageCommand, r.userCommand],
+    ),
+  ).toEqual({
+    toDelete: [r.slashCommand.id, r.messageCommand.id, r.userCommand.id],
+    didCommandsChange: false,
+  });
+  expect(
+    calculateChangedCommands(
+      [l.slashCommand, l.messageCommand, l.userCommand],
+      [],
+    ),
+  ).toEqual({
+    toDelete: [],
+    didCommandsChange: true,
+  });
+});

--- a/app/helpers/discordCommands.ts
+++ b/app/helpers/discordCommands.ts
@@ -1,0 +1,100 @@
+import type {
+  APIApplicationCommand,
+  ContextMenuCommandBuilder,
+  SlashCommandBuilder,
+} from "discord.js";
+import { ApplicationCommandType } from "discord.js";
+import { rest } from "~/discord/api";
+
+import { difference } from "~/helpers/sets";
+
+const calculateChangedCommands = (
+  deplayStage: string,
+  localCommands: (ContextMenuCommandBuilder | SlashCommandBuilder)[],
+  remoteCommands: APIApplicationCommand[],
+) => {
+  const names = new Set(localCommands.map((c) => c.name));
+
+  // Take the list of names to delete and swap it out for IDs to delete
+  const remoteNames = new Set(remoteCommands.map((c) => c.name));
+  const deleteNames = [...difference(remoteNames, names)];
+  const toDelete = deleteNames
+    .map((x) => remoteCommands.find((y) => y.name === x)?.id)
+    .filter((x): x is string => Boolean(x));
+
+  // Grab a list of commands that need to be updated
+  const toUpdate = remoteCommands.filter(
+    (c) =>
+      // Check all necessary fields to see if any changed. User and Message
+      // commands don't have a description.
+      !localCommands
+        .map((x) => x.toJSON())
+        .find((x) => {
+          const { type = ApplicationCommandType.ChatInput, name } = x;
+          switch (x.type as ApplicationCommandType) {
+            case ApplicationCommandType.User:
+            case ApplicationCommandType.Message:
+              return name === c.name && type === c.type;
+            case ApplicationCommandType.ChatInput:
+            default:
+              return (
+                name === c.name &&
+                type === c.type &&
+                ("description" in x ? x.description === c.description : true) &&
+                c.options?.every((o) =>
+                  x.options?.some((o2) => o.name === o2.name),
+                ) &&
+                x.options?.every((o) =>
+                  c.options?.some((o2) => o.name === o2.name),
+                )
+              );
+          }
+        }),
+  );
+
+  console.log(
+    "DEPLOY",
+    deplayStage,
+    `local: [${[...names].join(",")}], remote: [${[...remoteNames].join(",")}]`,
+  );
+
+  return { toDelete, toUpdate };
+};
+
+export const applyCommandChanges = async (
+  deployStage: string,
+  localCommands: (ContextMenuCommandBuilder | SlashCommandBuilder)[],
+  remoteCommands: APIApplicationCommand[],
+  put: () => `/${string}`,
+  del: (id: string) => `/${string}`,
+) => {
+  const { toDelete, toUpdate } = calculateChangedCommands(
+    deployStage,
+    localCommands,
+    remoteCommands,
+  );
+
+  await Promise.allSettled(
+    toDelete.map((commandId) => rest.delete(del(commandId))),
+  );
+
+  console.log(
+    "DEPLOY",
+    deployStage,
+    `Found ${toUpdate.length} changes: [${toUpdate
+      .map((x) => x.name)
+      .join(",")}], and ${toDelete.length} to delete: [${toDelete.join(",")}]`,
+  );
+
+  if (toUpdate.length === 0 && remoteCommands.length === localCommands.length) {
+    console.log("DEPLOY", deployStage, `No changes found, not upserting.`);
+    return;
+  }
+
+  console.log(
+    "DEPLOY",
+    deployStage,
+    `Upserting ${localCommands.length} commands`,
+  );
+  await rest.put(put(), { body: localCommands });
+};


### PR DESCRIPTION
We've used local commands so far, which has worked fine because the bot isn't in many servers. For the future and for good practice, this changes over to use global commands.

Specifics:

* For compatibility reasons, if any guild has "guild commands" active, iterate through all guilds and remove all guild commands. We need to do this to avoid duplicated commands in the Apps list.
* In test mode, deploy guild commands to a specified test server. This is [recommended in the Discord dev docs](https://discord.com/developers/docs/interactions/application-commands#making-a-guild-command)
* Adds automated tests for the command diffing logic used to keep commands up to date. I kept running into subtle bugs with this logic, so now there are tests with a much more exhaustive set of combinations than I could conveniently manually test