### PR TITLE
Fix default command permissions

### DIFF
--- a/app/commands/convene.tsx
+++ b/app/commands/convene.tsx
@@ -3,6 +3,7 @@ import {
   ApplicationCommandType,
   ChannelType,
   ContextMenuCommandBuilder,
+  PermissionFlagsBits,
 } from "discord.js";
 import type {
   MessageContextMenuCommandInteraction,
@@ -20,7 +21,8 @@ import { Confirmation, ModResponse } from "~/commands/reacord/ModResponse";
 
 export const command = new ContextMenuCommandBuilder()
   .setName("Convene mods")
-  .setType(ApplicationCommandType.Message);
+  .setType(ApplicationCommandType.Message)
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages);
 
 export const handler = async (
   interaction: MessageContextMenuCommandInteraction,

--- a/app/commands/report.ts
+++ b/app/commands/report.ts
@@ -1,10 +1,12 @@
 import type { MessageContextMenuCommandInteraction } from "discord.js";
+import { PermissionFlagsBits } from "discord.js";
 import { ApplicationCommandType, ContextMenuCommandBuilder } from "discord.js";
 import { ReportReasons, reportUser } from "~/helpers/modLog";
 
 export const command = new ContextMenuCommandBuilder()
   .setName("Report")
-  .setType(ApplicationCommandType.Message);
+  .setType(ApplicationCommandType.Message)
+  .setDefaultMemberPermissions(PermissionFlagsBits.SendMessages);
 
 export const handler = async (
   interaction: MessageContextMenuCommandInteraction,

--- a/app/commands/setup.ts
+++ b/app/commands/setup.ts
@@ -1,4 +1,5 @@
 import type { ChatInputCommandInteraction } from "discord.js";
+import { PermissionFlagsBits } from "discord.js";
 import { SlashCommandBuilder } from "discord.js";
 
 import { SETTINGS, setSettings, registerGuild } from "~/models/guilds.server";
@@ -6,6 +7,7 @@ import { SETTINGS, setSettings, registerGuild } from "~/models/guilds.server";
 export const command = new SlashCommandBuilder()
   .setName("setup")
   .setDescription("Set up necessities for using the bot")
+  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
   // TODO: update permissions so non-mods can never use it
   // maybe implement as "adder must init immediately"?
   // .setDefaultPermission(true);

--- a/app/commands/track.tsx
+++ b/app/commands/track.tsx
@@ -1,4 +1,5 @@
 import type { MessageContextMenuCommandInteraction } from "discord.js";
+import { PermissionFlagsBits } from "discord.js";
 import { ApplicationCommandType, ContextMenuCommandBuilder } from "discord.js";
 import { Button } from "reacord";
 import { reacord } from "~/discord/client.server";
@@ -7,7 +8,8 @@ import { ReportReasons, reportUser } from "~/helpers/modLog";
 
 export const command = new ContextMenuCommandBuilder()
   .setName("Track")
-  .setType(ApplicationCommandType.Message);
+  .setType(ApplicationCommandType.Message)
+  .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages);
 
 export const handler = async (
   interaction: MessageContextMenuCommandInteraction,

--- a/app/discord/deployCommands.server.ts
+++ b/app/discord/deployCommands.server.ts
@@ -77,7 +77,7 @@ const applyCommandChanges = async (
     toDelete.map((commandId) => rest.delete(del(commandId))),
   );
 
-  if (didCommandsChange && remoteCount === localCommands.length) {
+  if (!didCommandsChange && remoteCount === localCommands.length) {
     return;
   }
 


### PR DESCRIPTION
I didn't realize this, but the "default permissions" exists as a separate level of requirement from the "permissions" in the Integrations UI. By setting these, we can enforce that members must a certain level of access within the server, which should do well enough for our needs for limiting use

* Add a default permission for all commands:
  * Convene Mods needs "manage messages"
  * Report needs "send messages"
  * Track needs "manage messages"
  * Setup needs "admin"

Also fixes a bug with command diffing that inverted change detection, whoops! Caused upserts to bail early in some cases.