### PR TITLE
Key message cache with guild ID

### DIFF
--- a/app/helpers/modLog.ts
+++ b/app/helpers/modLog.ts
@@ -46,9 +46,9 @@ const warningMessages = new Map<
 export const reportUser = async ({ reason, message, extra, staff }: Report) => {
   const { guild } = message;
   if (!guild) throw new Error("Tried to report a message without a guild");
-  const simplifiedContent = `${message.author.id}${simplifyString(
-    message.content,
-  )}`;
+  const simplifiedContent = `${message.guildId}${
+    message.author.id
+  }${simplifyString(message.content)}`;
   const cached = warningMessages.get(simplifiedContent);
 
   if (cached) {


### PR DESCRIPTION
Ran into a situation where someone got reported across multiple guilds, which caused a link to a different guild to show up in #mod-log. By keying on guild ID, we can make sure every report stays local