### PR TITLE
Improve Track command

### DIFF
--- a/app/commands/track.tsx
+++ b/app/commands/track.tsx
@@ -16,7 +16,7 @@ export const handler = async (
 ) => {
   const { targetMessage: message, user } = interaction;
 
-  const { message: logMessage } = await reportUser({
+  const reportPromise = reportUser({
     reason: ReportReasons.track,
     message,
     staff: user,
@@ -30,6 +30,10 @@ export const handler = async (
         label="Delete message"
         style="danger"
         onClick={async () => {
+          // Need to ensure that we've finished reporting before we try to
+          // respond to a click event.
+          // Initiating at the top level and waiting here is a big UX win.
+          const { message: logMessage } = await reportPromise;
           await Promise.allSettled([
             message.delete(),
             logMessage.reply({

--- a/app/commands/track.tsx
+++ b/app/commands/track.tsx
@@ -34,7 +34,7 @@ export const handler = async (
             message.delete(),
             logMessage.reply({
               allowedMentions: { users: [] },
-              content: `Messaged deleted by <@${user.id}>`,
+              content: `Message in <#${message.channelId}> deleted by <@${user.id}>`,
             }),
           ]);
           instance.render("Tracked");

--- a/app/helpers/discord.test.ts
+++ b/app/helpers/discord.test.ts
@@ -13,4 +13,9 @@ test("escapeDisruptiveContent", () => {
   expect(escapeDisruptiveContent("https://example.com")).toBe(
     "<https://example.com>",
   );
+  expect(
+    escapeDisruptiveContent(
+      "some dumb text https://example.com with a link and text",
+    ),
+  ).toBe("some dumb text <https://example.com> with a link and text");
 });

--- a/app/helpers/discord.test.ts
+++ b/app/helpers/discord.test.ts
@@ -18,4 +18,7 @@ test("escapeDisruptiveContent", () => {
       "some dumb text https://example.com with a link and text",
     ),
   ).toBe("some dumb text <https://example.com> with a link and text");
+  expect(escapeDisruptiveContent("some dumb text https://example.com")).toBe(
+    "some dumb text <https://example.com>",
+  );
 });

--- a/app/helpers/discord.ts
+++ b/app/helpers/discord.ts
@@ -84,6 +84,7 @@ export const describeAttachments = (attachments: Message["attachments"]) => {
           .join("\n");
 };
 
+const urlRegex = /(https?:\/\/\S+)\b/g;
 /*
  * Escape content that Discord would otherwise do undesireable things with.
  * Sepecifically, suppresses @-mentions and link previews.
@@ -94,7 +95,7 @@ export const escapeDisruptiveContent = (content: string) => {
       // Silence pings
       .replace(/@(\S*)(\s)?/g, "@ $1$2")
       // Wrap links in <> so they don't make a preview
-      .replace(/(https?:\/\/.*)\s?/g, "<$1>")
+      .replace(urlRegex, "<$1>")
   );
 };
 

--- a/app/helpers/modLog.ts
+++ b/app/helpers/modLog.ts
@@ -91,6 +91,10 @@ export const reportUser = async ({
     });
 
     const warningMessage = await modLog.send(logBody);
+    const thread = await warningMessage.startThread({
+      name: message.content.slice(0, 50).toLocaleLowerCase().trim(),
+    });
+    await thread.send(quoteAndEscape(message.content).trim().slice(0, 2000));
 
     warningMessages.set(simplifiedContent, {
       logMessage: warningMessage,
@@ -124,15 +128,13 @@ const constructLog = async ({
   )} ago`;
   const extra = origExtra ? `\n${origExtra}\n` : "";
 
-  const reportedMessage = quoteAndEscape(lastReport.message.content).trim();
   const attachments = describeAttachments(lastReport.message.attachments);
 
   return {
     content: truncateMessage(`${preface}
 
 ${reports}
-${extra}
-${reportedMessage}`),
+${extra}`),
     embeds: attachments ? [{ description: `\n\n${attachments}` }] : undefined,
   };
 };


### PR DESCRIPTION
- #43 
  - Related, and in part because of additional slowdown this introduces, improve UX by initiating the `reportMessage` promise when reacting to the interaction, but `await` it in the click handler of the "Delete" button. This lets it finish creating the thread and sending the message after it responds to the interaction.
- Fix link escaping in tracked messages, which resolves an issue with pornographic Discord invites being rendered.
- Include which channel a message was deleted from in the log post