### PR TITLE
Shuffle mod log tracking to be more legible

### DIFF
--- a/app/commands/convene.tsx
+++ b/app/commands/convene.tsx
@@ -1,4 +1,3 @@
-import { format } from "date-fns";
 import {
   ApplicationCommandType,
   ChannelType,
@@ -56,25 +55,13 @@ export const handler = async (
     return;
   }
 
-  const { message: logMessage } = await reportUser({
+  const { thread } = await reportUser({
     message,
     reason: ReportReasons.mod,
     staff: interaction.user,
     extra: `‼️ <@${interaction.user.id}> requested mods respond`,
   });
 
-  if (logMessage.hasThread) {
-    console.log("Ignoring a redundant Convene Mods call");
-    await interaction.reply({
-      content: `Already active: <#${logMessage.thread?.id}>`,
-      ephemeral: true,
-    });
-    return;
-  }
-
-  const thread = await logMessage.startThread({
-    name: `${message.author.username} mod response ${format(new Date(), "P")}`,
-  });
   const staff = interaction.user;
   const originalChannel = (await message.channel.fetch()) as TextChannel;
   const pollInstance = reacord.send(

--- a/app/commands/track.tsx
+++ b/app/commands/track.tsx
@@ -33,10 +33,10 @@ export const handler = async (
           // Need to ensure that we've finished reporting before we try to
           // respond to a click event.
           // Initiating at the top level and waiting here is a big UX win.
-          const { message: logMessage } = await reportPromise;
+          const { latestReport } = await reportPromise;
           await Promise.allSettled([
             message.delete(),
-            logMessage.reply({
+            latestReport.reply({
               allowedMentions: { users: [] },
               content: `Message in <#${message.channelId}> deleted by <@${user.id}>`,
             }),

--- a/app/helpers/string.ts
+++ b/app/helpers/string.ts
@@ -16,7 +16,8 @@ export const truncateMessage = (
   // Discord's limit for message length
   maxLength = 2000,
 ) => {
-  if (content.length > maxLength) return `${content.slice(0, maxLength - 1)}…`;
+  if (content.length > maxLength)
+    return `${content.trim().slice(0, maxLength - 1)}…`;
 
   return content;
 };


### PR DESCRIPTION
In #50 I moved some logs to a thread, but it got super noisy because of how the top-level worked, with replies on deletion and such. This improves on that by moving the message back out to the top level, and putting the individual log actions into the thread
<img width="555" alt="Screenshot 2024-05-18 at 1 39 51 PM" src="https://github.com/reactiflux/mod-bot/assets/1551487/49b97259-2506-40d0-9154-7711a78c6b62">
<img width="574" alt="Screenshot 2024-05-18 at 1 39 56 PM" src="https://github.com/reactiflux/mod-bot/assets/1551487/0f8bd51c-853a-45c5-8a47-595a8a8a3960">
