### PR TITLE
Improvements to Track

### DIFF
--- a/app/helpers/discord.ts
+++ b/app/helpers/discord.ts
@@ -107,7 +107,9 @@ export const describeReactions = (
         title: "Reactions",
         fields: reactions.map((r) => ({
           name: "",
-          value: `${r.count} ${r.emoji.name}`,
+          value: `${r.count} ${
+            r.emoji.id ? `<:${r.emoji.name}:${r.emoji.id}>` : r.emoji.name
+          }`,
           inline: true,
         })),
       };

--- a/app/helpers/modLog.ts
+++ b/app/helpers/modLog.ts
@@ -113,37 +113,37 @@ export const reportUser = async ({
       ),
     ]);
     return { warnings, message: cachedMessage, latestReport, thread };
-  } else {
-    // If this is new, send a new message
-    const { modLog: modLogId } = await fetchSettings(guild, [SETTINGS.modLog]);
-    const modLog = await guild.channels.fetch(modLogId);
-    if (!modLog) {
-      throw new Error("Channel configured for use as mod log not found");
-    }
-    if (modLog.type !== ChannelType.GuildText) {
-      throw new Error(
-        "Invalid channel configured for use as mod log, must be guild text",
-      );
-    }
-    const newLogs: Report[] = [{ message, reason, staff }];
-
-    const logBody = await constructLog({
-      extra,
-      logs: newLogs,
-      previousWarnings: cachedWarnings,
-      staff,
-    });
-
-    const warningMessage = await modLog.send(logBody);
-    const thread = await makeLogThread(warningMessage, message.author);
-    const latestReport = await thread.send(makeReportString(newReport));
-
-    cachedWarnings.set(simplifiedContent, {
-      logMessage: warningMessage,
-      logs: newLogs,
-    });
-    return { warnings: 1, message: warningMessage, latestReport, thread };
   }
+
+  // If this is new, send a new message
+  const { modLog: modLogId } = await fetchSettings(guild, [SETTINGS.modLog]);
+  const modLog = await guild.channels.fetch(modLogId);
+  if (!modLog) {
+    throw new Error("Channel configured for use as mod log not found");
+  }
+  if (modLog.type !== ChannelType.GuildText) {
+    throw new Error(
+      "Invalid channel configured for use as mod log, must be guild text",
+    );
+  }
+  const newLogs: Report[] = [{ message, reason, staff }];
+
+  const logBody = await constructLog({
+    extra,
+    logs: newLogs,
+    previousWarnings: cachedWarnings,
+    staff,
+  });
+
+  const warningMessage = await modLog.send(logBody);
+  const thread = await makeLogThread(warningMessage, message.author);
+  const latestReport = await thread.send(makeReportString(newReport));
+
+  cachedWarnings.set(simplifiedContent, {
+    logMessage: warningMessage,
+    logs: newLogs,
+  });
+  return { warnings: 1, message: warningMessage, latestReport, thread };
 };
 
 const makeReportString = ({ message, reason, staff }: Report) =>


### PR DESCRIPTION
- Don't count multiple Track calls on the same message as separate reports
- Fix emoji rendering, at least for same-server emoji
- Move reaction tracking to thread:

Much clearer, and lets us track reactions over time
<img width="568" alt="Screenshot 2024-10-24 at 10 40 38 AM" src="https://github.com/user-attachments/assets/bcd9f2d5-cd55-40cf-aa1c-9dbf6655f1c6">
