### PR TITLE
Update k8s to enable HTTP ingress to the service

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -74,15 +74,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Setup cache
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -108,8 +99,6 @@ jobs:
           push: ${{github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/feature/actions'}}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
   deployment:
     needs: build

--- a/cluster/cluster-issuer.yaml
+++ b/cluster/cluster-issuer.yaml
@@ -1,0 +1,17 @@
+# I believe this only needed to be run once on the cluster as a whole, to make
+# a LetsEncrypt service available. That was done with:
+# kubectl apply -f cluster/cluster-issuer.yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: vcarl@reactiflux.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/cluster/ingress.yaml
+++ b/cluster/ingress.yaml
@@ -3,9 +3,14 @@ kind: Ingress
 metadata:
   name: mod-bot-ingress
   annotations:
-    nginx.ingress.kubernetes.io/rewrite-target: /
-    cert-manager.io/cluster-issuer: letsencrypt-prod # Optional, for TLS
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/hsts-max-age: "31536000"
+    nginx.ingress.kubernetes.io/hsts-include-subdomains: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
+  ingressClassName: nginx
   rules:
     - host: euno.reactiflux.com
       http:
@@ -14,10 +19,10 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: mod-bot
+                name: mod-bot-service
                 port:
                   number: 80
   tls:
     - hosts:
         - euno.reactiflux.com
-      secretName: my-tls-secret # Used for HTTPS
+      secretName: letsencrypt-prod-key


### PR DESCRIPTION
This lets us run a regular-ol website, for instance, and use Discord interaction webhooks. Interaction webhooks will unblock #59 and resolve #84