### PR TITLE
Member activity reports

### DIFF
--- a/app/db.d.ts
+++ b/app/db.d.ts
@@ -18,7 +18,7 @@ export interface MessageStats {
   message_id: string | null;
   react_count: Generated<number>;
   recipient_id: string | null;
-  sent_at: string;
+  sent_at: number;
   word_count: number;
 }
 

--- a/app/db.d.ts
+++ b/app/db.d.ts
@@ -18,7 +18,7 @@ export interface MessageStats {
   message_id: string | null;
   react_count: Generated<number>;
   recipient_id: string | null;
-  sent_at: number;
+  sent_at: string;
   word_count: number;
 }
 

--- a/app/models/activity.server.ts
+++ b/app/models/activity.server.ts
@@ -1,0 +1,173 @@
+import type { DB } from "~/db.server";
+import db from "~/db.server";
+
+export type MessageStats = DB["message_stats"];
+
+export async function getTopParticipants(
+  guildId: MessageStats["guild_id"],
+  intervalStart: string,
+  intervalEnd: string,
+  channels: string[],
+  channelCategories: string[],
+) {
+  const config = {
+    count: 100,
+    messageThreshold: 250,
+    wordThreshold: 2500,
+  };
+
+  const messageStatsWithinInterval = () =>
+    db.selectFrom((eb) =>
+      eb
+        .selectFrom("message_stats")
+        .select(({ fn, val, eb }) => [
+          "author_id",
+          "word_count",
+          "react_count",
+          "sent_at",
+          "channel_category",
+          "channel_id",
+          "react_count",
+          fn("date", [eb("sent_at", "/", 1000), val("unixepoch")]).as("date"),
+        ])
+        .where(({ between, and, or, eb }) =>
+          and([
+            between(
+              "sent_at",
+              new Date(intervalStart).getTime(),
+              new Date(intervalEnd).getTime(),
+            ),
+            or([
+              eb("channel_id", "in", channels),
+              eb("channel_category", "in", channelCategories),
+            ]),
+          ]),
+        )
+        .as("interval_message_stats"),
+    );
+
+  // get shortlist, volume threshold of 1000 words
+  const topMembers = await messageStatsWithinInterval()
+    .select(({ fn }) => [
+      "author_id",
+      fn.sum("word_count").as("word_count"),
+      fn.count("author_id").as("message_count"),
+      fn.sum("react_count").as("total_reaction_count"),
+    ])
+    .orderBy("message_count desc")
+    .groupBy("author_id")
+    .having((eb) =>
+      eb.or([
+        // @ts-expect-error this seems to be a type bug, which makes sense cuz
+        // it's a complex query
+        eb("message_count", ">=", config.messageThreshold),
+        eb("word_count", ">=", config.wordThreshold),
+      ]),
+    )
+    .limit(config.count)
+    .execute();
+
+  const dailyParticipation = await messageStatsWithinInterval()
+    .select(({ fn }) => [
+      "author_id",
+      "date",
+      fn.count<number>("author_id").as("message_count"),
+      fn.sum<number>("word_count").as("word_count"),
+    ])
+    .groupBy("date")
+    .groupBy("author_id")
+    .execute();
+
+  // const users = await db
+  //   .selectFrom("message_stats")
+  //   .select(({ fn, val, eb }) => [
+  //     "author_id",
+  //     fn.sum("word_count").as("word_count"),
+  //     fn.count(val("*")).as("message_count"),
+  //     "sent_at",
+  //     fn("date", [eb("sent_at", "/", "1000"), val("unixepoch")]).as("date"),
+  //   ])
+  //   .where((eb) =>
+  //     eb.and([eb("date", ">", intervalStart), eb("date", "<", intervalEnd)]),
+  //   )
+  //   // .orderBy("message_count desc")
+  //   .groupBy("author_id")
+  //   // .groupBy("date")
+  //   // .limit(200)
+  //   .execute();
+
+  return { dailyParticipation: groupByAuthor(dailyParticipation), topMembers };
+
+  // wordcount
+  /*
+SELECT author_id, channel_category, sum(word_count) 
+FROM 'message_stats' 
+WHERE author_id IN ('103525876892708864', '257929888864927745') AND channel_category IN ('Need Help', 'Community', 'Social') 
+GROUP BY author_id, channel_category
+*/
+  // db.selectFrom("message_stats")
+  //   .select(({ fn, val, ref }) => [
+  //     "author_id",
+  //     "channel_category",
+  //     fn.sum("word_count").as("total_words"),
+  //   ])
+  //   .groupBy(["author_id"])
+
+  // channel variety
+  /*
+SELECT 
+    author_id, 
+    GROUP_CONCAT(DISTINCT channel_id) AS distinct_channel_ids,
+    COUNT(DISTINCT channel_id) AS distinct_channel_count
+FROM 'message_stats' 
+WHERE author_id IN ('103525876892708864', '257929888864927745') AND channel_category IN ('Need Help', 'Community', 'Social') 
+GROUP BY author_id
+*/
+
+  // count/day
+  /*
+SELECT 
+    author_id, 
+    sent_at,
+    date(sent_at, 'unixepoch') as date // TODO: not working?
+FROM 'message_stats' where author_id in ('103525876892708864') AND channel_category IN ('Need Help', 'Community', 'Social') 
+GROUP BY author_id, date
+*/
+
+  return db
+    .selectFrom("message_stats")
+    .selectAll()
+    .where("guild_id", "=", guildId)
+    .execute();
+}
+
+type Record = {
+  author_id: string;
+  // hack fix for weird types coming out of query
+  date: string | unknown;
+  message_count: number;
+  word_count: number;
+};
+
+type GroupedResult = {
+  [authorId: string]: {
+    date: string;
+    message_count: number;
+    word_count: number;
+  }[];
+};
+
+function groupByAuthor(records: Record[]): GroupedResult {
+  return records.reduce((acc, record) => {
+    const { author_id, date } = record;
+
+    if (!acc[author_id]) {
+      acc[author_id] = [];
+    }
+
+    // hack fix for weird types coming out of query
+    acc[author_id].push({ ...record, date: date as string });
+
+    return acc;
+  }, {} as GroupedResult);
+}

--- a/app/models/activity.server.ts
+++ b/app/models/activity.server.ts
@@ -20,14 +20,14 @@ export async function getTopParticipants(
     .selectFrom("message_stats")
     .selectAll()
     .select(({ fn, val, eb }) => [
-      fn("date", [eb("sent_at", "/", 1000), val("unixepoch")]).as("date"),
+      fn("date", [eb("sent_at", "/", "1000"), val("unixepoch")]).as("date"),
     ])
     .where(({ between, and, or, eb }) =>
       and([
         between(
           "sent_at",
-          new Date(intervalStart).getTime(),
-          new Date(intervalEnd).getTime(),
+          new Date(intervalStart).getTime().toString(),
+          new Date(intervalEnd).getTime().toString(),
         ),
         or([
           eb("channel_id", "in", channels),

--- a/app/models/activity.server.ts
+++ b/app/models/activity.server.ts
@@ -1,7 +1,7 @@
 import type { DB } from "~/db.server";
 import db from "~/db.server";
 
-export type MessageStats = DB["message_stats"];
+type MessageStats = DB["message_stats"];
 
 export async function getTopParticipants(
   guildId: MessageStats["guild_id"],
@@ -13,140 +13,93 @@ export async function getTopParticipants(
   const config = {
     count: 100,
     messageThreshold: 250,
-    wordThreshold: 2500,
+    wordThreshold: 2200,
   };
 
-  const messageStatsWithinInterval = () =>
-    db.selectFrom((eb) =>
-      eb
-        .selectFrom("message_stats")
-        .select(({ fn, val, eb }) => [
-          "author_id",
-          "word_count",
-          "react_count",
+  const baseQuery = db
+    .selectFrom("message_stats")
+    .selectAll()
+    .select(({ fn, val, eb }) => [
+      fn("date", [eb("sent_at", "/", 1000), val("unixepoch")]).as("date"),
+    ])
+    .where(({ between, and, or, eb }) =>
+      and([
+        between(
           "sent_at",
-          "channel_category",
-          "channel_id",
-          "react_count",
-          fn("date", [eb("sent_at", "/", 1000), val("unixepoch")]).as("date"),
-        ])
-        .where(({ between, and, or, eb }) =>
-          and([
-            between(
-              "sent_at",
-              new Date(intervalStart).getTime(),
-              new Date(intervalEnd).getTime(),
-            ),
-            or([
-              eb("channel_id", "in", channels),
-              eb("channel_category", "in", channelCategories),
-            ]),
-          ]),
-        )
-        .as("interval_message_stats"),
+          new Date(intervalStart).getTime(),
+          new Date(intervalEnd).getTime(),
+        ),
+        or([
+          eb("channel_id", "in", channels),
+          eb("channel_category", "in", channelCategories),
+        ]),
+      ]),
     );
 
   // get shortlist, volume threshold of 1000 words
-  const topMembers = await messageStatsWithinInterval()
+  const topMembersQuery = db
+    .with("interval_message_stats", () => baseQuery)
+    .selectFrom("interval_message_stats")
     .select(({ fn }) => [
       "author_id",
-      fn.sum("word_count").as("word_count"),
-      fn.count("author_id").as("message_count"),
-      fn.sum("react_count").as("total_reaction_count"),
+      fn.sum<number>("word_count").as("total_word_count"),
+      fn.count<number>("author_id").as("message_count"),
+      fn.sum<number>("react_count").as("total_reaction_count"),
+      fn.count<number>("channel_category").distinct().as("category_count"),
+      fn.count<number>("channel_id").distinct().as("channel_count"),
     ])
     .orderBy("message_count desc")
     .groupBy("author_id")
-    .having((eb) =>
-      eb.or([
-        // @ts-expect-error this seems to be a type bug, which makes sense cuz
-        // it's a complex query
-        eb("message_count", ">=", config.messageThreshold),
-        eb("word_count", ">=", config.wordThreshold),
+    .having(({ eb, or, fn }) =>
+      or([
+        eb(fn.count("author_id"), ">=", config.messageThreshold),
+        eb(fn.sum("word_count"), ">=", config.wordThreshold),
       ]),
     )
-    .limit(config.count)
-    .execute();
+    .limit(config.count);
+  console.log(topMembersQuery.compile().sql);
+  const topMembers = await topMembersQuery.execute();
 
-  const dailyParticipation = await messageStatsWithinInterval()
+  const dailyParticipationQuery = db
+    .with("interval_message_stats", () => baseQuery)
+    .selectFrom("interval_message_stats")
     .select(({ fn }) => [
       "author_id",
       "date",
       fn.count<number>("author_id").as("message_count"),
       fn.sum<number>("word_count").as("word_count"),
+      fn.count<number>("channel_id").distinct().as("channel_count"),
+      fn.count<number>("channel_category").distinct().as("category_count"),
     ])
+    .distinct()
     .groupBy("date")
     .groupBy("author_id")
-    .execute();
+    .where(
+      "author_id",
+      "in",
+      topMembers.map((m) => m.author_id),
+    );
+  console.log(dailyParticipationQuery.compile().sql);
+  const dailyParticipation = fillDateGaps(
+    groupByAuthor(await dailyParticipationQuery.execute()),
+    intervalStart,
+    intervalEnd,
+  );
 
-  // const users = await db
-  //   .selectFrom("message_stats")
-  //   .select(({ fn, val, eb }) => [
-  //     "author_id",
-  //     fn.sum("word_count").as("word_count"),
-  //     fn.count(val("*")).as("message_count"),
-  //     "sent_at",
-  //     fn("date", [eb("sent_at", "/", "1000"), val("unixepoch")]).as("date"),
-  //   ])
-  //   .where((eb) =>
-  //     eb.and([eb("date", ">", intervalStart), eb("date", "<", intervalEnd)]),
-  //   )
-  //   // .orderBy("message_count desc")
-  //   .groupBy("author_id")
-  //   // .groupBy("date")
-  //   // .limit(200)
-  //   .execute();
-
-  return { dailyParticipation: groupByAuthor(dailyParticipation), topMembers };
-
-  // wordcount
-  /*
-SELECT author_id, channel_category, sum(word_count) 
-FROM 'message_stats' 
-WHERE author_id IN ('103525876892708864', '257929888864927745') AND channel_category IN ('Need Help', 'Community', 'Social') 
-GROUP BY author_id, channel_category
-*/
-  // db.selectFrom("message_stats")
-  //   .select(({ fn, val, ref }) => [
-  //     "author_id",
-  //     "channel_category",
-  //     fn.sum("word_count").as("total_words"),
-  //   ])
-  //   .groupBy(["author_id"])
-
-  // channel variety
-  /*
-SELECT 
-    author_id, 
-    GROUP_CONCAT(DISTINCT channel_id) AS distinct_channel_ids,
-    COUNT(DISTINCT channel_id) AS distinct_channel_count
-FROM 'message_stats' 
-WHERE author_id IN ('103525876892708864', '257929888864927745') AND channel_category IN ('Need Help', 'Community', 'Social') 
-GROUP BY author_id
-*/
-
-  // count/day
-  /*
-SELECT 
-    author_id, 
-    sent_at,
-    date(sent_at, 'unixepoch') as date // TODO: not working?
-FROM 'message_stats' where author_id in ('103525876892708864') AND channel_category IN ('Need Help', 'Community', 'Social') 
-GROUP BY author_id, date
-*/
-
-  return db
-    .selectFrom("message_stats")
-    .selectAll()
-    .where("guild_id", "=", guildId)
-    .execute();
+  return topMembers.map((m) => ({
+    ...m,
+    participation: dailyParticipation[m.author_id],
+  }));
 }
 
-type Record = {
+type ParticipationData = {
   author_id: string;
   // hack fix for weird types coming out of query
   date: string | unknown;
   message_count: number;
   word_count: number;
+  channel_count: number;
+  category_count: number;
 };
 
 type GroupedResult = {
@@ -154,10 +107,11 @@ type GroupedResult = {
     date: string;
     message_count: number;
     word_count: number;
+    channel_count: number;
+    category_count: number;
   }[];
 };
-
-function groupByAuthor(records: Record[]): GroupedResult {
+function groupByAuthor(records: ParticipationData[]): GroupedResult {
   return records.reduce((acc, record) => {
     const { author_id, date } = record;
 
@@ -170,4 +124,52 @@ function groupByAuthor(records: Record[]): GroupedResult {
 
     return acc;
   }, {} as GroupedResult);
+}
+
+const generateDateRange = (start: string, end: string): string[] => {
+  const dates: string[] = [];
+  let currentDate = new Date(start);
+
+  while (currentDate <= new Date(end)) {
+    dates.push(currentDate.toISOString().split("T")[0]);
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+  return dates;
+};
+
+function fillDateGaps(
+  groupedResult: GroupedResult,
+  startDate: string,
+  endDate: string,
+): GroupedResult {
+  // Helper to generate a date range in YYYY-MM-DD format
+
+  const dateRange = generateDateRange(startDate, endDate);
+
+  const filledResult: GroupedResult = {};
+
+  for (const authorId in groupedResult) {
+    const authorData = groupedResult[authorId];
+    const dateToEntryMap: Record<string, typeof authorData[number]> = {};
+
+    // Map existing entries by date
+    authorData.forEach((entry) => {
+      dateToEntryMap[entry.date] = entry;
+    });
+
+    // Fill missing dates with zeroed-out data
+    filledResult[authorId] = dateRange.map((date) => {
+      return (
+        dateToEntryMap[date] || {
+          date,
+          message_count: 0,
+          word_count: 0,
+          channel_count: 0,
+          category_count: 0,
+        }
+      );
+    });
+  }
+
+  return filledResult;
 }

--- a/app/routes/__auth.tsx
+++ b/app/routes/__auth.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useLocation } from "@remix-run/react";
 
 import { Login } from "~/components/login";
+import { isProd } from "~/helpers/env";
 import { getUser } from "~/models/session.server";
 import { useOptionalUser } from "~/utils";
 
@@ -11,6 +12,10 @@ export function loader({ request }: { request: Request }) {
 export default function Auth() {
   const user = useOptionalUser();
   const location = useLocation();
+
+  if (!isProd()) {
+    return <div>nope</div>;
+  }
 
   if (!user) {
     return (

--- a/app/routes/__auth.tsx
+++ b/app/routes/__auth.tsx
@@ -13,7 +13,7 @@ export default function Auth() {
   const user = useOptionalUser();
   const location = useLocation();
 
-  if (!isProd()) {
+  if (isProd()) {
     return <div>nope</div>;
   }
 

--- a/app/routes/__auth/dashboard.tsx
+++ b/app/routes/__auth/dashboard.tsx
@@ -1,0 +1,92 @@
+import type { LoaderArgs, ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import type { LabelHTMLAttributes } from "react";
+import { getTopParticipants } from "~/models/activity.server";
+
+export const loader = async ({ request, context, params }: LoaderArgs) => {
+  // const user = await getUser(request);
+  const url = new URL(request.url);
+  const start = url.searchParams.get("start");
+  const end = url.searchParams.get("end");
+
+  if (!start || !end) {
+    return json({});
+  }
+
+  // convert times to unix stamps (tz? utc i guess)
+  // query DB
+
+  const REACTIFLUX_GUILD_ID = "102860784329052160";
+  const output = await getTopParticipants(
+    REACTIFLUX_GUILD_ID,
+    start,
+    end,
+    [],
+    ["Need Help", "React General", "Advanced Topics"],
+  );
+  console.log(output);
+
+  return json(output);
+};
+
+export const action: ActionFunction = async ({ request }) => {
+  console.log({ request });
+};
+
+const Label = (props: LabelHTMLAttributes<Element>) => (
+  <label {...props} className={`${props.className ?? ""} m-4`}>
+    {props.children}
+  </label>
+);
+
+export default function DashboardPage() {
+  const data = useLoaderData<typeof loader>();
+
+  console.log(data);
+  return (
+    <div>
+      <div className="flex min-h-full justify-center">
+        <div>test butts</div>
+        <form method="GET">
+          <Label>
+            Start date
+            <input name="start" type="date" />
+          </Label>
+          <Label>
+            End date
+            <input name="end" type="date" />
+          </Label>
+          <input type="submit" value="Submit" />
+        </form>
+      </div>
+      <div>
+        <ShittyTable data={data.topMembers} />
+        <ShittyTable data={data.dailyParticipation} />
+      </div>
+    </div>
+  );
+}
+
+const ShittyTable = ({ data }) => {
+  const keys = Object.keys(data[0]);
+  return (
+    <div>
+      <p>{data.length} entries</p>
+      <table>
+        <tr>
+          {keys.map((k) => (
+            <th key={k}>{k}</th>
+          ))}
+        </tr>
+        {data.map((d) => (
+          <tr key={keys.reduce((o, k) => o + d[k], "")}>
+            {keys.map((k) => (
+              <td key={d[k]}>{d[k]}</td>
+            ))}
+          </tr>
+        ))}
+      </table>
+    </div>
+  );
+};

--- a/app/routes/__auth/dashboard.tsx
+++ b/app/routes/__auth/dashboard.tsx
@@ -2,6 +2,11 @@ import type { LoaderArgs, ActionFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import type { LabelHTMLAttributes } from "react";
+import {
+  Sparklines,
+  SparklinesBars,
+  SparklinesReferenceLine,
+} from "react-sparklines";
 import { getTopParticipants } from "~/models/activity.server";
 
 export const loader = async ({ request, context, params }: LoaderArgs) => {
@@ -57,8 +62,8 @@ export default function DashboardPage() {
         </form>
       </div>
       <div>
-        <ShittyTable data={data.topMembers} />
-        <ShittyTable data={data.dailyParticipation} />
+        <ShittyTable data={data} />
+        {/* <ShittyTable data={data.dailyParticipation} /> */}
       </div>
     </div>
   );
@@ -70,18 +75,41 @@ const ShittyTable = ({ data }) => {
     <div>
       <p>{data.length} entries</p>
       <table>
-        <tr>
-          {keys.map((k) => (
-            <th key={k}>{k}</th>
-          ))}
-        </tr>
-        {data.map((d) => (
-          <tr key={keys.reduce((o, k) => o + d[k], "")}>
+        <thead>
+          <tr>
             {keys.map((k) => (
-              <td key={d[k]}>{d[k]}</td>
+              <th key={k}>{k}</th>
             ))}
           </tr>
-        ))}
+        </thead>
+        <tbody>
+          {data.map((d) => (
+            <tr key={keys.reduce((o, k) => o + d[k], "")}>
+              {keys.map((k) => (
+                <td key={d[k].toString() + k}>
+                  {Array.isArray(d[k]) ? (
+                    <Sparklines
+                      svgHeight={26}
+                      svgWidth={240}
+                      data={d[k].map(({ word_count }) => word_count)}
+                    >
+                      <SparklinesBars barWidth={5} />
+                      <SparklinesReferenceLine
+                        type="median"
+                        style={{ strokeWidth: 3 }}
+                      />
+                    </Sparklines>
+                  ) : (
+                    // <pre className="max-w-xs  overflow-scroll">
+                    //   <code>{JSON.stringify(d[k])}</code>
+                    // </pre>
+                    d[k]
+                  )}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
       </table>
     </div>
   );

--- a/app/routes/__auth/dashboard.tsx
+++ b/app/routes/__auth/dashboard.tsx
@@ -11,11 +11,8 @@ export const loader = async ({ request, context, params }: LoaderArgs) => {
   const end = url.searchParams.get("end");
 
   if (!start || !end) {
-    return json({});
+    return json(null, { status: 400 });
   }
-
-  // convert times to unix stamps (tz? utc i guess)
-  // query DB
 
   const REACTIFLUX_GUILD_ID = "102860784329052160";
   const output = await getTopParticipants(
@@ -25,7 +22,6 @@ export const loader = async ({ request, context, params }: LoaderArgs) => {
     [],
     ["Need Help", "React General", "Advanced Topics"],
   );
-  console.log(output);
 
   return json(output);
 };

--- a/app/styles/tailwind.css
+++ b/app/styles/tailwind.css
@@ -510,6 +510,10 @@ video {
   --tw-backdrop-sepia:  ;
 }
 
+.visible {
+  visibility: visible;
+}
+
 .invisible {
   visibility: hidden;
 }
@@ -533,17 +537,39 @@ video {
   left: 0px;
 }
 
+.col-span-2 {
+  grid-column: span 2 / span 2;
+}
+
+.col-span-3 {
+  grid-column: span 3 / span 3;
+}
+
+.m-4 {
+  margin: 1rem;
+}
+
 .mx-auto {
   margin-left: auto;
   margin-right: auto;
 }
 
-.mt-6 {
-  margin-top: 1.5rem;
+.my-2 {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.mx-4 {
+  margin-left: 1rem;
+  margin-right: 1rem;
 }
 
 .mt-10 {
   margin-top: 2.5rem;
+}
+
+.mt-6 {
+  margin-top: 1.5rem;
 }
 
 .block {
@@ -562,12 +588,20 @@ video {
   display: table;
 }
 
+.grid {
+  display: grid;
+}
+
 .hidden {
   display: none;
 }
 
 .h-full {
   height: 100%;
+}
+
+.h-6 {
+  height: 1.5rem;
 }
 
 .min-h-full {
@@ -580,6 +614,10 @@ video {
 
 .w-full {
   width: 100%;
+}
+
+.w-6 {
+  width: 1.5rem;
 }
 
 .max-w-md {
@@ -598,12 +636,40 @@ video {
   max-width: 24rem;
 }
 
+.max-w-xs {
+  max-width: 20rem;
+}
+
+.auto-cols-fr {
+  grid-auto-columns: minmax(0, 1fr);
+}
+
+.auto-cols-min {
+  grid-auto-columns: min-content;
+}
+
+.grid-cols-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.grid-cols-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
 .flex-col {
   flex-direction: column;
 }
 
 .justify-center {
   justify-content: center;
+}
+
+.gap-8 {
+  gap: 2rem;
+}
+
+.gap-6 {
+  gap: 1.5rem;
 }
 
 .space-y-6 > :not([hidden]) ~ :not([hidden]) {
@@ -618,8 +684,25 @@ video {
   margin-bottom: calc(1rem * var(--tw-space-y-reverse));
 }
 
+.overflow-scroll {
+  overflow: scroll;
+}
+
 .rounded {
   border-radius: 0.25rem;
+}
+
+.border {
+  border-width: 1px;
+}
+
+.border-solid {
+  border-style: solid;
+}
+
+.border-gray-700 {
+  --tw-border-opacity: 1;
+  border-color: rgb(55 65 81 / var(--tw-border-opacity));
 }
 
 .bg-blue-500 {
@@ -636,18 +719,17 @@ video {
   background-color: rgba(254,204,27,0.5);
 }
 
-.bg-slate-700 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(51 65 85 / var(--tw-bg-opacity));
-}
-
-.bg-opacity-40 {
-  --tw-bg-opacity: 0.4;
-}
-
 .object-cover {
   -o-object-fit: cover;
      object-fit: cover;
+}
+
+.p-2 {
+  padding: 0.5rem;
+}
+
+.p-4 {
+  padding: 1rem;
 }
 
 .px-4 {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@sentry/node": "^7.5.1",
         "@sentry/tracing": "^7.5.1",
         "@types/lodash": "^4.14.182",
+        "@types/react-sparklines": "^1.7.5",
         "better-sqlite3": "^9.5.0",
         "body-parser": "^1.20.3",
         "date-fns": "^2.27.0",
@@ -38,6 +39,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.3.0",
+        "react-sparklines": "^1.7.0",
         "remix": "^1.7.2",
         "simple-oauth2": "^4.3.0",
         "tiny-invariant": "^1.2.0"
@@ -4854,6 +4856,15 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.0.tgz",
       "integrity": "sha512-5cjk9ottZAj7eaTsqzPUIlrVbh3hBAO2YaEL1rkjHKB3xNAId7oU8GhzvAX+gfmlfoxTwJnBjPxEHyxkEA1Ffg==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-sparklines": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@types/react-sparklines/-/react-sparklines-1.7.5.tgz",
+      "integrity": "sha512-rIAmNyRKUqWWnaQMjNrxMNkgEFi5f9PrdczSNxj5DscAa48y4i9P0fRKZ72FmNcFsdg6Jx4o6CXWZtIaC0OJOg==",
+      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
       }
@@ -16535,7 +16546,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17609,7 +17619,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -17621,7 +17630,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/property-information": {
@@ -18020,6 +18028,19 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-sparklines": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/react-sparklines/-/react-sparklines-1.7.0.tgz",
+      "integrity": "sha512-bJFt9K4c5Z0k44G8KtxIhbG+iyxrKjBZhdW6afP+R7EnIq+iKjbWbEFISrf3WKNFsda+C46XAfnX0StS5fbDcg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.5.10"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/read-cache": {
@@ -25530,6 +25551,14 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.0.tgz",
       "integrity": "sha512-5cjk9ottZAj7eaTsqzPUIlrVbh3hBAO2YaEL1rkjHKB3xNAId7oU8GhzvAX+gfmlfoxTwJnBjPxEHyxkEA1Ffg==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-sparklines": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@types/react-sparklines/-/react-sparklines-1.7.5.tgz",
+      "integrity": "sha512-rIAmNyRKUqWWnaQMjNrxMNkgEFi5f9PrdczSNxj5DscAa48y4i9P0fRKZ72FmNcFsdg6Jx4o6CXWZtIaC0OJOg==",
       "requires": {
         "@types/react": "*"
       }
@@ -33412,8 +33441,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-hash": {
       "version": "3.0.0",
@@ -34147,7 +34175,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -34157,8 +34184,7 @@
         "react-is": {
           "version": "16.13.1",
           "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-          "dev": true
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },
@@ -34446,6 +34472,14 @@
       "requires": {
         "@remix-run/router": "1.7.2",
         "react-router": "6.14.2"
+      }
+    },
+    "react-sparklines": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/react-sparklines/-/react-sparklines-1.7.0.tgz",
+      "integrity": "sha512-bJFt9K4c5Z0k44G8KtxIhbG+iyxrKjBZhdW6afP+R7EnIq+iKjbWbEFISrf3WKNFsda+C46XAfnX0StS5fbDcg==",
+      "requires": {
+        "prop-types": "^15.5.10"
       }
     },
     "read-cache": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:css": "npm run generate:css --minify",
     "build:remix": "remix build",
     "dev:init": "run-s start:migrate kysely:seed generate:db-types",
-    "dev:css": "npm run generate:css --watch",
+    "dev:css": "npm run generate:css -- --watch",
     "dev:express": "nodemon build/index.js",
     "dev:remix": "cross-env NODE_ENV=development binode --require ./mocks -- @remix-run/dev:remix watch",
     "kysely:seed": "kysely seed:run",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@sentry/node": "^7.5.1",
     "@sentry/tracing": "^7.5.1",
     "@types/lodash": "^4.14.182",
+    "@types/react-sparklines": "^1.7.5",
     "better-sqlite3": "^9.5.0",
     "body-parser": "^1.20.3",
     "date-fns": "^2.27.0",
@@ -63,6 +64,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.3.0",
+    "react-sparklines": "^1.7.0",
     "remix": "^1.7.2",
     "simple-oauth2": "^4.3.0",
     "tiny-invariant": "^1.2.0"


### PR DESCRIPTION
This is an early draft PR of a first revision of a feature to support the Reactiflux Star Helper program — tho it will be useful for other types of roles as well! That's the whole point of automating this.

<img width="567" alt="Screenshot 2024-12-16 at 2 15 19 AM" src="https://github.com/user-attachments/assets/de4e3cad-daba-44eb-9539-78e0bebe1b22" />

This is ~ a proof of concept to get a query together for examining the data, which it accomplishes. There's a lot lot lot of supporting code needed to turn this into "a feature", my intentions with this PR are to get enough code together to support the 2024 Q4 Star Helper program, then productize in the next few months.

Some examples of work that will need to be done before this is a production feature:

- Add configurable channels/categories, and intervals
- Flexible scoring criteria
- Clearer details around data collection (privacy policy — I believe we're very light here, as we don't store any content, just metadata)
- Inline scoring/member review? (I don't think it's feasible to pull in user history here, as I don't want to store it and Discord doesn't make it convenient to retrieve)
- Exploration into the best reporting options (inline discord messages from the bot? attached PDFs/PNGs? web app?)