### PR TITLE
Fix middleware ordering so static assets load

### DIFF
--- a/index.prod.js
+++ b/index.prod.js
@@ -10,13 +10,13 @@ import { app as rrApp } from "./build/server/index.js";
 const app = express();
 
 console.log("Starting production webserver");
-app.use(rrApp);
 
 app.use(
   "/assets",
   express.static("build/client/assets", { immutable: true, maxAge: "1y" }),
 );
 app.use(express.static("build/client", { maxAge: "1h" }));
+app.use(rrApp);
 
 /** ERROR TRACKING
   Must go after route handlers


### PR DESCRIPTION
literally can't believe how dumb this fix was

Issue was that https://euno.reactiflux.com/ looked like this

<img width="499" alt="Screenshot 2025-04-18 at 4 59 55 PM" src="https://github.com/user-attachments/assets/83f549cb-ebd1-4884-afeb-c9ce820a0506" />

instead of like this

<img width="565" alt="Screenshot 2025-04-18 at 5 00 12 PM" src="https://github.com/user-attachments/assets/38b34bc6-63c4-4508-b297-dd4d475305f8" />

Should be fixed now