### PR TITLE
Move escalation ping outside of Reacord

### DIFF
--- a/app/commands/reacord/ModResponse.tsx
+++ b/app/commands/reacord/ModResponse.tsx
@@ -7,18 +7,15 @@ import {
   resolutions,
   useVotes,
 } from "#~/helpers/modResponse";
-import type { User } from "discord.js";
 
 const VOTES_TO_APPROVE = 3;
 
 export const ModResponse = ({
-  initiator,
   votesRequired = VOTES_TO_APPROVE,
   onVote,
   onResolve,
   modRoleId,
 }: {
-  initiator: User;
   votesRequired?: number;
   onVote: (result: { vote: Resolution; user: ComponentEventUser }) => void;
   onResolve: (result: Resolution, event: ComponentEvent) => Promise<void>;
@@ -67,7 +64,7 @@ export const ModResponse = ({
 
   return (
     <>
-      {`Report escalated by <@${initiator.id}>, <@&${modRoleId}> please respond. After ${votesRequired} or more votes, the leading resolution will be automatically enforced.`}
+      {`After ${votesRequired} or more votes, the leading resolution will be automatically enforced.`}
       {/* TODO: show vote in progress, reveal votes and unvoted mods */}
       <ActionRow>
         {renderButton(

--- a/app/helpers/escalate.tsx
+++ b/app/helpers/escalate.tsx
@@ -87,7 +87,12 @@ export async function escalationControls(
       <Button
         onClick={async (e) => {
           const member = await thread.guild.members.fetch(e.user.id);
-          escalate(e.reply, member.user, reportedMessage, thread, modRoleId);
+          await Promise.all([
+            thread.send(
+              `Report escalated by <@${member.id}>, <@& ${modRoleId}> please respond.`,
+            ),
+            escalate(e.reply, member.user, reportedMessage, thread, modRoleId),
+          ]);
         }}
         style="primary"
         label="Escalate"
@@ -106,11 +111,11 @@ export async function escalate(
   thread: ThreadChannel,
   modRoleId: string,
 ) {
-  const originalChannel =
-    (await reportedMessage.channel.fetch()) as TextChannel;
+  const [originalChannel] = await Promise.all([
+    reportedMessage.channel.fetch() as Promise<TextChannel>,
+  ]);
   const pollInstance = reply(
     <ModResponse
-      initiator={staff}
       modRoleId={modRoleId}
       onVote={async (newVote) => {
         await thread.send(`<@${newVote.user.id}> voted to ${newVote.vote}`);


### PR DESCRIPTION
There appears to be an issue with the mod ping where it's not correctly notifying pinged members. Since that role ping is sent through Reacord currently, I'm wondering if that's a contributing factor here. Gonna move it out and see if that changes what we're seeing