### PR TITLE
fix: allow migrations to run without prior knex migrations

### DIFF
--- a/migrations/20240905213250_off-knex.ts
+++ b/migrations/20240905213250_off-knex.ts
@@ -61,7 +61,7 @@ export async function up(db: Kysely<any>): Promise<void> {
       .where("name", "=", "knex_migrations_lock")
       .execute();
   } catch {
-    /* fallthrough */
+    /* The above operations are expected to fail on a fresh repository clone */
   }
 }
 


### PR DESCRIPTION
currently, migrations will fail to run on a fresh clone since it attempts to drop a `knex_migrations` that won't exist

not sure how this will affect future deployments tho :grimacing: 