### PR TITLE
activity tracking: add code block stats

### DIFF
--- a/app/db.d.ts
+++ b/app/db.d.ts
@@ -15,6 +15,7 @@ export interface MessageStats {
   channel_category: string | null;
   channel_id: string;
   char_count: number;
+  code_stats: Generated<string>;
   guild_id: string;
   message_id: string | null;
   react_count: Generated<number>;

--- a/app/discord/activityTracker.ts
+++ b/app/discord/activityTracker.ts
@@ -1,6 +1,19 @@
 import { Events, ChannelType } from "discord.js";
 import type { Client, Message, PartialMessage, TextChannel } from "discord.js";
 import db from "#~/db.server";
+import {
+  parseMarkdownBlocks,
+  getChars,
+  getWords,
+} from "#~/helpers/messageParsing";
+import { partition } from "lodash-es";
+
+export type CodeStats = {
+  chars: number;
+  words: number;
+  lines: number;
+  lang: string | undefined;
+};
 
 export async function startActivityTracking(client: Client) {
   const channelCache = new Map<string, TextChannel>();
@@ -72,12 +85,53 @@ async function getMessageStats(msg: Message | PartialMessage) {
     return;
   }
   const { content } = await msg.fetch();
-  return {
-    char_count: getChars(content).length,
-    word_count: getWords(content).length,
+
+  const blocks = parseMarkdownBlocks(content);
+
+  const [textblocks, codeblocks] = partition(blocks, (b) => b.type === "text");
+
+  const { wordCount, charCount } = textblocks.reduce(
+    (acc, block) => {
+      const words = getWords(block.content).length;
+      const chars = getChars(block.content).length;
+      return {
+        wordCount: acc.wordCount + words,
+        charCount: acc.charCount + chars,
+      };
+    },
+    { wordCount: 0, charCount: 0 },
+  );
+
+  const codeStats = codeblocks.map((block): CodeStats => {
+    switch (block.type) {
+      case "fencedcode": {
+        const content = block.code.join("\n");
+        return {
+          chars: getChars(content).length,
+          words: getWords(content).length,
+          lines: block.code.length,
+          lang: block.lang,
+        };
+      }
+      case "inlinecode": {
+        return {
+          chars: getChars(block.code).length,
+          words: getWords(block.code).length,
+          lines: 1,
+          lang: undefined,
+        };
+      }
+    }
+  });
+
+  const values = {
+    char_count: charCount,
+    word_count: wordCount,
+    code_stats: JSON.stringify(codeStats),
     react_count: msg.reactions.cache.size,
     sent_at: msg.createdTimestamp,
   };
+  return values;
 }
 
 export async function reportByGuild(guildId: string) {
@@ -96,20 +150,4 @@ export async function reportByGuild(guildId: string) {
     .groupBy("author_id")
     .execute();
   return result;
-}
-
-// this is better than string.split(/\s+/) because it counts emojis as 1 word
-// and we can easily filter them, works much better in other languages too
-function getWords(content: string) {
-  return Array.from(
-    new Intl.Segmenter("en-us", { granularity: "word" }).segment(content),
-  ).filter((seg) => seg.isWordLike);
-}
-
-// string.split(/\s+/) will count most emojis as 2+ chars
-// this will count them as 1
-function getChars(content: string) {
-  return Array.from(
-    new Intl.Segmenter("en-us", { granularity: "grapheme" }).segment(content),
-  );
 }

--- a/app/helpers/messageParsing.test.ts
+++ b/app/helpers/messageParsing.test.ts
@@ -1,0 +1,60 @@
+import { parseMarkdownBlocks } from "./messageParsing";
+
+describe("markdown parser", () => {
+  test("matches fenced code blocks and inline text", () => {
+    const message = `here is some text
+
+This is inline code \`foo bar\`.
+
+ideal fenced code:
+
+\`\`\`js
+const x = 42;
+for (let i = 0; i < x; i++) {
+  console.log(i);
+}
+\`\`\``;
+    const result = parseMarkdownBlocks(message);
+    expect(result).toHaveLength(4);
+    expect(result[1]).toEqual({ type: "inlinecode", code: "foo bar" });
+    expect(result[3].type).toEqual("fencedcode");
+  });
+
+  test("matches fenced blocks starting inside a paragraph", () => {
+    const message = `sometimes i write \`\`\`sql
+select 1
+\`\`\` things like this`;
+    const result = parseMarkdownBlocks(message);
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ type: "text", content: "sometimes i write " });
+    expect(result[2]).toEqual({ type: "text", content: " things like this" });
+    const block = result.find((b) => b.type === "fencedcode");
+    expect(block?.lang).toEqual("sql");
+    expect(block?.code).toEqual(["select 1"]);
+  });
+
+  test("handles multiple fenced blocks", () => {
+    const message = `some text
+
+sometimes i write \`\`\`sql
+select 1
+\`\`\` code like this
+
+another example \`\`\`sql
+select 2
+\`\`\` like this`;
+    const result = parseMarkdownBlocks(message);
+    expect(result).toHaveLength(5);
+    expect(result[1]).toEqual({
+      type: "fencedcode",
+      lang: "sql",
+      code: ["select 1"],
+    });
+    expect(result[3]).toEqual({
+      type: "fencedcode",
+      lang: "sql",
+      code: ["select 2"],
+    });
+    expect(result[4]).toEqual({ type: "text", content: " like this" });
+  });
+});

--- a/app/helpers/messageParsing.ts
+++ b/app/helpers/messageParsing.ts
@@ -1,0 +1,80 @@
+export type MarkdownBlock =
+  | { type: "text"; content: string }
+  | { type: "fencedcode"; lang: undefined | string; code: string[] }
+  | { type: "inlinecode"; code: string };
+
+export function parseMarkdownBlocks(markdown: string): MarkdownBlock[] {
+  const blocks: MarkdownBlock[] = [];
+  // track string position
+  let idx = 0;
+
+  const matchers = {
+    fencedCode: /```[\s\S]+?\n^```/,
+    inlineCode: /`.+?`/,
+  };
+
+  // replaceAll gives easy access to the position of the match
+  markdown.replaceAll(
+    RegExp_or(Object.values(matchers), "gm"),
+    (match, ...captured) => {
+      // but it's quirky, capture groups are spread and the position and entire
+      // string are at the end of the args, we pop them off to get their values
+      // which leaves an array of capture groups
+      const orig = captured.pop();
+      const position = captured.pop();
+      // code blocks may be preceded by text, add those first
+      const prev = orig.slice(idx, position);
+      idx = position;
+      if (prev) blocks.push({ type: "text", content: prev });
+
+      // if first line starts with triple backticks, it's a fenced code block
+      if (match.startsWith("```")) {
+        // match is fenced code, strip backticks and split by line
+        const code = match.slice(3, -4).split("\n");
+        const lang = code.shift();
+        blocks.push({ type: "fencedcode", lang, code });
+      } else if (match.startsWith("`")) {
+        // match is inline code, return a string without backticks
+        const code = match.slice(1, -1);
+        blocks.push({ type: "inlinecode", code });
+      } else {
+        console.error("unknown match", match);
+        throw new Error("Unexpected match in markdown parsing");
+      }
+
+      // update our index to the end of the match
+      idx += match.length;
+
+      // this is only here to appease TS, value is unused
+      return "";
+    },
+  );
+
+  // after processing all known blocks, there may be text left
+  if (idx < markdown.length) {
+    blocks.push({ type: "text", content: markdown.slice(idx) });
+  }
+
+  return blocks;
+}
+
+// this is better than string.split(/\s+/) because it counts emojis as 1 word
+// and we can easily filter them, works much better in other languages too
+export function getWords(content: string) {
+  return Array.from(
+    new Intl.Segmenter("en-us", { granularity: "word" }).segment(content),
+  ).filter((seg) => seg.isWordLike);
+}
+
+// string.split(/\s+/) will count most emojis as 2+ chars
+// this will count them as 1
+export function getChars(content: string) {
+  return Array.from(
+    new Intl.Segmenter("en-us", { granularity: "grapheme" }).segment(content),
+  );
+}
+
+function RegExp_or(res: RegExp[], flags?: string): RegExp {
+  const re = res.map((r) => r.source).join("|");
+  return new RegExp(re, flags);
+}

--- a/app/helpers/messageParsing.ts
+++ b/app/helpers/messageParsing.ts
@@ -60,18 +60,20 @@ export function parseMarkdownBlocks(markdown: string): MarkdownBlock[] {
 
 // this is better than string.split(/\s+/) because it counts emojis as 1 word
 // and we can easily filter them, works much better in other languages too
+const wordSegmenter = new Intl.Segmenter("en-us", { granularity: "word" });
 export function getWords(content: string) {
-  return Array.from(
-    new Intl.Segmenter("en-us", { granularity: "word" }).segment(content),
-  ).filter((seg) => seg.isWordLike);
+  return Array.from(wordSegmenter.segment(content)).filter(
+    (seg) => seg.isWordLike,
+  );
 }
 
 // string.split(/\s+/) will count most emojis as 2+ chars
 // this will count them as 1
+const characterSegmenter = new Intl.Segmenter("en-us", {
+  granularity: "grapheme",
+});
 export function getChars(content: string) {
-  return Array.from(
-    new Intl.Segmenter("en-us", { granularity: "grapheme" }).segment(content),
-  );
+  return Array.from(characterSegmenter.segment(content));
 }
 
 function RegExp_or(res: RegExp[], flags?: string): RegExp {

--- a/migrations/20250531210224-message_code_stats.ts
+++ b/migrations/20250531210224-message_code_stats.ts
@@ -1,0 +1,14 @@
+import type { Kysely } from "kysely";
+
+const column = "code_stats";
+
+export async function up(db: Kysely<any>) {
+  return await db.schema
+    .alterTable("message_stats")
+    .addColumn(column, "text", (c) => c.notNull().defaultTo("[]"))
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  return db.schema.alterTable("message_stats").dropColumn(column).execute();
+}

--- a/migrations/20250531210224-message_code_stats.ts
+++ b/migrations/20250531210224-message_code_stats.ts
@@ -5,6 +5,12 @@ const column = "code_stats";
 export async function up(db: Kysely<any>) {
   return await db.schema
     .alterTable("message_stats")
+    // {
+    //   chars: number
+    //   words: number
+    //   lines: number
+    //   lang: string | undefined
+    // }[]
     .addColumn(column, "text", (c) => c.notNull().defaultTo("[]"))
     .execute();
 }


### PR DESCRIPTION
should close #98 and #133 by storing code stats as a json column on the message stats table
- [x] separate counts for words/chars in code blocks vs regular text
- [x] track lines of code
- [x] track what language code blocks are in