### PR TITLE
Track links

### DIFF
--- a/app/db.d.ts
+++ b/app/db.d.ts
@@ -23,6 +23,7 @@ export interface MessageStats {
   char_count: number;
   code_stats: Generated<string>;
   guild_id: string;
+  link_stats: Generated<string>;
   message_id: string | null;
   react_count: Generated<number>;
   recipient_id: string | null;

--- a/app/helpers/messageParsing.test.ts
+++ b/app/helpers/messageParsing.test.ts
@@ -1,6 +1,39 @@
 import { parseMarkdownBlocks } from "./messageParsing";
 
 describe("markdown parser", () => {
+  test("matches bare link", () => {
+    const message = `bold claim (source https://trustme.bro)`;
+    const result = parseMarkdownBlocks(message);
+    expect(result[1]).toEqual({ type: "link", url: "https://trustme.bro" });
+  });
+
+  test("matches link with label", () => {
+    const message = `check out this [link](<https://example.com>)`;
+    const result = parseMarkdownBlocks(message);
+    expect(result[1]).toEqual({
+      type: "link",
+      url: "https://example.com",
+      label: "link",
+    });
+  });
+
+  test("matches many links", () => {
+    const message = `bare link https://asdf.com
+(see also https://links.com)
+* [*bold*](<https://foo.xyz>)
+* [*bold*](<https://bar.xyz>)
+words and things [\`foo()\`](<https://links.xom>) asdfasdf`;
+    const result = parseMarkdownBlocks(message);
+    const links = result.filter((x) => x.type === "link").map((x) => x.url);
+    expect(links).toEqual([
+      "https://asdf.com",
+      "https://links.com",
+      "https://foo.xyz",
+      "https://bar.xyz",
+      "https://links.xom",
+    ]);
+  });
+
   test("matches fenced code blocks and inline text", () => {
     const message = `here is some text
 

--- a/migrations/20250612220730_message_links.ts
+++ b/migrations/20250612220730_message_links.ts
@@ -1,0 +1,14 @@
+import type { Kysely } from "kysely";
+
+const column = "link_stats";
+
+export async function up(db: Kysely<any>) {
+  return await db.schema
+    .alterTable("message_stats")
+    .addColumn(column, "text", (c) => c.notNull().defaultTo("[]"))
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  return db.schema.alterTable("message_stats").dropColumn(column).execute();
+}


### PR DESCRIPTION
stores a json array of urls in a new `link_stats` column
it was right there, and easy enough, but I have mixed feelings about it

there's a duplicate commit of #140 since it depends on that, should go away if/when merged