### PR TITLE
feat: persist star-helper user info in a json file

### DIFF
--- a/app/helpers/userInfoCache.ts
+++ b/app/helpers/userInfoCache.ts
@@ -1,6 +1,7 @@
 import { LRUCache } from "lru-cache";
 import { rest } from "#~/discord/api.js";
 import { Routes } from "discord.js";
+import fs from "node:fs/promises";
 
 type DiscordUser = { username: string; global_name: string; id: string };
 
@@ -10,14 +11,30 @@ const cache = new LRUCache<string, DiscordUser>({
   max: 150,
 });
 
+const cachefile = "./userInfoCache.json";
+load();
+
 export async function getOrFetchUser(id: string) {
   if (cache.has(id)) return cache.get(id);
 
-  console.log("Fetching user from Discord API:", id);
-  const { username, global_name } = (await rest.get(
-    Routes.user(id),
-  )) as DiscordUser;
-  const result = { username, global_name, id };
+  // @ts-expect-error FIXME: are there types available? schema validation?
+  const { username, global_name } = await rest.get(Routes.user(id));
+  const result = { id, username, global_name } as DiscordUser;
   cache.set(id, result);
+  console.log("Fetched user from Discord API:", id);
+  dump();
   return result;
+}
+
+export function dump() {
+  return fs.writeFile(cachefile, JSON.stringify(cache.dump()), "utf8");
+}
+
+export async function load() {
+  try {
+    const raw = await fs.readFile(cachefile, "utf8");
+    cache.load(JSON.parse(raw));
+  } catch {
+    // ignore errors, file might not exist yet
+  }
 }


### PR DESCRIPTION
this should make it less annoying to deploy without losing cache state