### PR TITLE
Actually pass through Sentry env vars to production deployment

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -141,6 +141,8 @@ jobs:
             --from-literal=DISCORD_SECRET=${{ secrets.DISCORD_SECRET }} \
             --from-literal=DISCORD_HASH=${{ secrets.DISCORD_HASH }} \
             --from-literal=DISCORD_TEST_GUILD=${{ secrets.DISCORD_TEST_GUILD }} \
+            --from-literal=SENTRY_INGEST=${{ secrets.SENTRY_INGEST }} \
+            --from-literal=SENTRY_RELEASES=${{ secrets.SENTRY_RELEASES }} \ 
             --from-literal=DATABASE_URL=${{ secrets.DATABASE_URL }}
           kubectl apply -k .
 

--- a/app/helpers/env.server.ts
+++ b/app/helpers/env.server.ts
@@ -34,6 +34,8 @@ export const discordSecret = getEnv("DISCORD_SECRET");
 export const applicationId = getEnv("DISCORD_APP_ID");
 export const discordToken = getEnv("DISCORD_HASH");
 export const testGuild = getEnv("DISCORD_TEST_GUILD");
+export const sentryIngest = getEnv("SENTRY_INGEST");
+export const sentryReleases = getEnv("SENTRY_RELEASES");
 
 export const amplitudeKey = getEnv("AMPLITUDE_API_KEY", true);
 

--- a/app/helpers/sentry.server.ts
+++ b/app/helpers/sentry.server.ts
@@ -1,9 +1,9 @@
 import * as Sentry from "@sentry/node";
-import { isProd } from "#~/helpers/env.server";
+import { isProd, sentryIngest } from "#~/helpers/env.server";
 
 Sentry.init({
-  dsn: process.env.SENTRY_INGEST,
-  environment: process.env.NODE_ENV || "development",
+  dsn: sentryIngest,
+  environment: isProd() ? "production" : "development",
   integrations: [
     new Sentry.Integrations.OnUncaughtException(),
     new Sentry.Integrations.OnUnhandledRejection(),

--- a/app/helpers/sentry.server.ts
+++ b/app/helpers/sentry.server.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/node";
 import { isProd, sentryIngest } from "#~/helpers/env.server";
 
-Sentry.init({
+const sentryOptions = {
   dsn: sentryIngest,
   environment: isProd() ? "production" : "development",
   integrations: [
@@ -14,6 +14,10 @@ Sentry.init({
   // We recommend adjusting this value in production
   tracesSampleRate: isProd() ? 0.2 : 1,
   sendDefaultPii: true,
-});
+};
+
+console.log("Sentry initialized:", sentryOptions);
+
+Sentry.init(sentryOptions);
 
 export default Sentry;

--- a/app/models/session.server.ts
+++ b/app/models/session.server.ts
@@ -22,6 +22,7 @@ import {
   applicationId,
   discordSecret,
   sessionSecret,
+  isProd,
 } from "#~/helpers/env.server";
 
 export type Sessions = DB["sessions"];
@@ -57,7 +58,7 @@ const {
     path: "/",
     sameSite: "lax",
     secrets: [sessionSecret],
-    secure: process.env.NODE_ENV === "production",
+    secure: isProd(),
   },
 });
 export type CookieSession = Awaited<ReturnType<typeof getCookieSession>>;


### PR DESCRIPTION
I had observed that no production events were being ingested into Sentry, which is definitely not correct. This should resolve it, and will log configuration details so we can inspect what's happening