### PR TITLE
Don't track every `error`-level log as an error

### DIFF
--- a/app/helpers/observability.ts
+++ b/app/helpers/observability.ts
@@ -19,20 +19,6 @@ export const log = (
 
   // Use structured logging for better parsing
   console.log(JSON.stringify(logEntry));
-
-  // Also log to Sentry for error tracking and performance monitoring
-  if (level === "error") {
-    Sentry.captureException(new Error(message), {
-      tags: typeof service === "string" ? { service } : service,
-      extra: context,
-    });
-  } else if (level === "warn") {
-    Sentry.captureMessage(message, {
-      level: "warning",
-      tags: typeof service === "string" ? { service } : service,
-      extra: context,
-    });
-  }
 };
 
 // Performance tracking helper


### PR DESCRIPTION
We've burned out of Sentry errors two months in a row, and looking at them, I think this is the specific culprit. They're not particularly actionable either, so I think just tracking fewer is the right call here.