### PR TITLE
Don't calculate stats for deleted messages

### DIFF
--- a/app/discord/activityTracker.ts
+++ b/app/discord/activityTracker.ts
@@ -146,9 +146,6 @@ export async function startActivityTracking(client: Client) {
     await trackPerformance(
       "processMessageDelete",
       async () => {
-        const info = await getMessageStats(msg);
-        if (!info) return;
-
         await db
           .deleteFrom("message_stats")
           .where("message_id", "=", msg.id)


### PR DESCRIPTION
I believe this is the root of recent issues with deleting tracked messages, but am not 100% sure. This is what was being logged when I tested locally, and I do see an awful lot of errors stemming from this.