### PR TITLE
Disable broken e2e tests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -261,144 +261,144 @@ jobs:
             }
 
   # --- E2E Tests after deployment ---
-  e2e:
-    needs: deployment
-    if: needs.deployment.outputs.preview_url != '' || needs.deployment.outputs.is_production == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    env:
-      TARGET_URL: ${{ needs.deployment.outputs.preview_url || 'https://euno.reactiflux.com' }}
-      PR_NUMBER: ${{ needs.deployment.outputs.pr_number }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
+  # e2e:
+  #   needs: deployment
+  #   if: needs.deployment.outputs.preview_url != '' || needs.deployment.outputs.is_production == 'true'
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 10
+  #   env:
+  #     TARGET_URL: ${{ needs.deployment.outputs.preview_url || 'https://euno.reactiflux.com' }}
+  #     PR_NUMBER: ${{ needs.deployment.outputs.pr_number }}
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@v4
 
-      - name: Setup node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
+  #     - name: Setup node
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 24
 
-      - run: npm ci
+  #     - run: npm ci
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+  #     - name: Cache Playwright browsers
+  #       uses: actions/cache@v4
+  #       with:
+  #         path: ~/.cache/ms-playwright
+  #         key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Install Playwright browsers
-        run: npx playwright install chromium
+  #     - name: Install Playwright browsers
+  #       run: npx playwright install chromium
 
-      - name: Wait for service to be ready
-        run: |
-          for i in {1..30}; do
-            if curl -sf "$TARGET_URL" > /dev/null; then
-              echo "Service is ready"
-              exit 0
-            fi
-            echo "Waiting for service... ($i/30)"
-            sleep 10
-          done
-          echo "Service did not become ready in time"
-          exit 1
+  #     - name: Wait for service to be ready
+  #       run: |
+  #         for i in {1..30}; do
+  #           if curl -sf "$TARGET_URL" > /dev/null; then
+  #             echo "Service is ready"
+  #             exit 0
+  #           fi
+  #           echo "Waiting for service... ($i/30)"
+  #           sleep 10
+  #         done
+  #         echo "Service did not become ready in time"
+  #         exit 1
 
-      - name: Run Playwright tests
-        run: npm run test:e2e
-        env:
-          E2E_PREVIEW_URL: ${{ env.TARGET_URL }}
+  #     - name: Run Playwright tests
+  #       run: npm run test:e2e
+  #       env:
+  #         E2E_PREVIEW_URL: ${{ env.TARGET_URL }}
 
-      - name: Upload test artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report-${{ github.run_id }}
-          path: |
-            playwright-report/
-            test-results/
-          retention-days: 30
+  #     - name: Upload test artifacts
+  #       if: always()
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: playwright-report-${{ github.run_id }}
+  #         path: |
+  #           playwright-report/
+  #           test-results/
+  #         retention-days: 30
 
-      - name: Deploy test report to GitHub Pages
-        if: always()
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./playwright-report
-          destination_dir: reports/${{ github.run_number }}
-          keep_files: true
+  #     - name: Deploy test report to GitHub Pages
+  #       if: always()
+  #       uses: peaceiris/actions-gh-pages@v4
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         publish_dir: ./playwright-report
+  #         destination_dir: reports/${{ github.run_number }}
+  #         keep_files: true
 
-      - name: Comment PR with test results
-        if: ${{ always() && env.PR_NUMBER != '' }}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const prNumber = parseInt('${{ env.PR_NUMBER }}');
-            const targetUrl = '${{ env.TARGET_URL }}';
-            const reportUrl = `https://reactiflux.github.io/mod-bot/reports/${{ github.run_number }}`;
-            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+  #     - name: Comment PR with test results
+  #       if: ${{ always() && env.PR_NUMBER != '' }}
+  #       uses: actions/github-script@v7
+  #       with:
+  #         script: |
+  #           const fs = require('fs');
+  #           const prNumber = parseInt('${{ env.PR_NUMBER }}');
+  #           const targetUrl = '${{ env.TARGET_URL }}';
+  #           const reportUrl = `https://reactiflux.github.io/mod-bot/reports/${{ github.run_number }}`;
+  #           const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
 
-            // Parse test results
-            let stats = { passed: 0, failed: 0, flaky: 0, skipped: 0 };
-            try {
-              const results = JSON.parse(fs.readFileSync('test-results/results.json', 'utf8'));
-              const countTests = (suites) => {
-                for (const suite of suites) {
-                  for (const spec of suite.specs || []) {
-                    for (const test of spec.tests || []) {
-                      if (test.status === 'expected') stats.passed++;
-                      else if (test.status === 'unexpected') stats.failed++;
-                      else if (test.status === 'flaky') stats.flaky++;
-                      else if (test.status === 'skipped') stats.skipped++;
-                    }
-                  }
-                  if (suite.suites) countTests(suite.suites);
-                }
-              };
-              countTests(results.suites || []);
-            } catch (e) {
-              console.log('Could not parse test results:', e.message);
-            }
+  #           // Parse test results
+  #           let stats = { passed: 0, failed: 0, flaky: 0, skipped: 0 };
+  #           try {
+  #             const results = JSON.parse(fs.readFileSync('test-results/results.json', 'utf8'));
+  #             const countTests = (suites) => {
+  #               for (const suite of suites) {
+  #                 for (const spec of suite.specs || []) {
+  #                   for (const test of spec.tests || []) {
+  #                     if (test.status === 'expected') stats.passed++;
+  #                     else if (test.status === 'unexpected') stats.failed++;
+  #                     else if (test.status === 'flaky') stats.flaky++;
+  #                     else if (test.status === 'skipped') stats.skipped++;
+  #                   }
+  #                 }
+  #                 if (suite.suites) countTests(suite.suites);
+  #               }
+  #             };
+  #             countTests(results.suites || []);
+  #           } catch (e) {
+  #             console.log('Could not parse test results:', e.message);
+  #           }
 
-            const emoji = stats.failed > 0 ? '❌' : stats.flaky > 0 ? '⚠️' : '✅';
-            const status = stats.failed > 0 ? 'Failed' : stats.flaky > 0 ? 'Flaky' : 'Passed';
-            const statsParts = [
-              stats.passed > 0 && `**${stats.passed}** passed`,
-              stats.flaky > 0 && `**${stats.flaky}** flaky`,
-              stats.failed > 0 && `**${stats.failed}** failed`,
-              stats.skipped > 0 && `**${stats.skipped}** skipped`,
-            ].filter(Boolean).join(' · ');
+  #           const emoji = stats.failed > 0 ? '❌' : stats.flaky > 0 ? '⚠️' : '✅';
+  #           const status = stats.failed > 0 ? 'Failed' : stats.flaky > 0 ? 'Flaky' : 'Passed';
+  #           const statsParts = [
+  #             stats.passed > 0 && `**${stats.passed}** passed`,
+  #             stats.flaky > 0 && `**${stats.flaky}** flaky`,
+  #             stats.failed > 0 && `**${stats.failed}** failed`,
+  #             stats.skipped > 0 && `**${stats.skipped}** skipped`,
+  #           ].filter(Boolean).join(' · ');
 
-            const body = `## ${emoji} E2E Tests ${status}
+  #           const body = `## ${emoji} E2E Tests ${status}
 
-            ${statsParts}
+  #           ${statsParts}
 
-            [View Report](${reportUrl}) · [View Run](${runUrl})
+  #           [View Report](${reportUrl}) · [View Run](${runUrl})
 
-            Tested against: ${targetUrl}`;
+  #           Tested against: ${targetUrl}`;
 
-            // Find existing E2E comment to update
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber
-            });
+  #           // Find existing E2E comment to update
+  #           const { data: comments } = await github.rest.issues.listComments({
+  #             owner: context.repo.owner,
+  #             repo: context.repo.repo,
+  #             issue_number: prNumber
+  #           });
 
-            const existingComment = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes('E2E Tests')
-            );
+  #           const existingComment = comments.find(c =>
+  #             c.user.type === 'Bot' && c.body.includes('E2E Tests')
+  #           );
 
-            if (existingComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existingComment.id,
-                body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body
-              });
-            }
+  #           if (existingComment) {
+  #             await github.rest.issues.updateComment({
+  #               owner: context.repo.owner,
+  #               repo: context.repo.repo,
+  #               comment_id: existingComment.id,
+  #               body
+  #             });
+  #           } else {
+  #             await github.rest.issues.createComment({
+  #               owner: context.repo.owner,
+  #               repo: context.repo.repo,
+  #               issue_number: prNumber,
+  #               body
+  #             });
+  #           }


### PR DESCRIPTION
I’d love to get these functional but they aren’t right now. Will need a solution for oauth redirects in staging, which perhaps means carving out a separate auth service with a stable domain to have as a Discord redirect target, which has its own more flexible redirection logic