### PR TITLE
Fix potential cause of db corruption

### DIFF
--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -8,8 +8,13 @@ export { SqliteError } from "better-sqlite3";
 
 console.log(`Connecting to database at ${databaseUrl}`);
 
+const sqliteDb = new SQLite(databaseUrl);
+// Enable WAL mode to match @effect/sql-sqlite-node's default.
+// Both connections MUST use the same journal mode to prevent corruption.
+sqliteDb.pragma("journal_mode = WAL");
+
 export const dialect = new SqliteDialect({
-  database: new SQLite(databaseUrl),
+  database: sqliteDb,
 });
 
 const db = new Kysely<DB>({


### PR DESCRIPTION
We've had 2 instances of db corruption lately, which appears to be because of the Effect/non-Effect db access code. They're both connecting to the same file, but have been using different Journal modes. In the right circumstances, that will cause the file to become corrupt. AI fix explanation:

When Connection A (rollback) and Connection B (WAL) both access the same database:

  1. Connection B writes in WAL mode - appends to -wal file, updates -shm coordination
  2. Connection A doesn't know about WAL - it's looking for a -journal file and using file locks designed for rollback mode
  3. Connection A writes in rollback mode - modifies database pages directly, creates a rollback journal
  4. Conflict occurs:
    - Connection A may overwrite pages that Connection B expects to be at a certain state
    - Connection B's WAL entries reference page states that Connection A has modified
    - The -shm shared memory state becomes inconsistent with actual file state
    - B-tree page references become invalid ("2nd reference to page" errors we saw)