### PR TITLE
Scope auto-kick threshold to spam reports only

### DIFF
--- a/app/features/spam/spamResponseHandler.ts
+++ b/app/features/spam/spamResponseHandler.ts
@@ -13,6 +13,7 @@ import { logEffect } from "#~/effects/observability.ts";
 import { featureStats } from "#~/helpers/metrics.ts";
 import { applyRestriction, timeout } from "#~/models/discord.server.ts";
 import {
+  getSpamReportCount,
   markMessageAsDeleted,
   ReportReasons,
 } from "#~/models/reportedMessages.ts";
@@ -91,10 +92,11 @@ export const executeResponse = (
     // Log to mod thread for all medium/high tiers
     const logResult = yield* logSpamReport(message, verdict);
 
-    // Check for auto-kick on high tier
+    // Check for auto-kick on high tier (spam reports only)
     if (verdict.tier === "high" && logResult) {
-      const { warnings, message: logMessage } = logResult;
-      if (warnings >= AUTO_KICK_THRESHOLD) {
+      const { message: logMessage } = logResult;
+      const spamCount = yield* getSpamReportCount(userId, guildId);
+      if (spamCount >= AUTO_KICK_THRESHOLD) {
         yield* Effect.tryPromise(() =>
           member.kick("Autokicked for repeated spam"),
         ).pipe(
@@ -112,7 +114,7 @@ export const executeResponse = (
           }),
         ).pipe(Effect.catchAll(() => Effect.void));
 
-        featureStats.spamKicked(guildId, userId, warnings);
+        featureStats.spamKicked(guildId, userId, spamCount);
       }
     }
 

--- a/app/models/reportedMessages.ts
+++ b/app/models/reportedMessages.ts
@@ -188,6 +188,26 @@ export const getUserReportStats = (userId: string, guildId: string) =>
   );
 
 /**
+ * Count spam reports for a user in a guild (used for auto-kick threshold).
+ */
+export const getSpamReportCount = (userId: string, guildId: string) =>
+  Effect.gen(function* () {
+    const kysely = yield* DatabaseService;
+
+    const [result] = yield* kysely
+      .selectFrom("reported_messages")
+      .select((eb) => eb.fn.count("id").as("count"))
+      .where("reported_user_id", "=", userId)
+      .where("guild_id", "=", guildId)
+      .where("reason", "=", ReportReasons.spam)
+      .where("deleted_at", "is", null);
+
+    return Number(result?.count ?? 0);
+  }).pipe(
+    Effect.withSpan("getSpamReportCount", { attributes: { userId, guildId } }),
+  );
+
+/**
  * Delete a report from the database.
  */
 export const deleteReport = (reportId: string) =>


### PR DESCRIPTION
## Summary

- The auto-kick (3-strike) threshold was counting all report types — including manual `/report` and `/track` entries — toward the limit
- Added `getSpamReportCount` which filters by `reason = 'spam'`, and use that in the kick check instead of the total `warnings` from `logUserMessage`
- The mod thread still shows the full report count (useful context for mods); only the kick logic is scoped

## Test plan

- [ ] Verify a user with manual `/report` entries but no spam detections is not auto-kicked on their first high-tier spam hit
- [ ] Verify a user with 3+ high-tier spam reports is still auto-kicked