### PR TITLE
Improve spam detection: cross-channel spam and reduce noise

### DIFF
--- a/app/features/spam/behaviorAnalyzer.ts
+++ b/app/features/spam/behaviorAnalyzer.ts
@@ -26,7 +26,7 @@ export function analyzeBehavior(
   if (accountAge < ONE_DAY_MS) {
     signals.push({
       name: "account_age_lt_1d",
-      score: 3,
+      score: 2,
       description: "Acct <1 day",
     });
   } else if (accountAge < 7 * ONE_DAY_MS) {
@@ -50,7 +50,7 @@ export function analyzeBehavior(
     if (serverTenure < ONE_HOUR_MS) {
       signals.push({
         name: "server_tenure_lt_1h",
-        score: 3,
+        score: 2,
         description: "Joined < 1hr ago",
       });
     } else if (serverTenure < ONE_DAY_MS) {

--- a/app/features/spam/contentAnalyzer.test.ts
+++ b/app/features/spam/contentAnalyzer.test.ts
@@ -10,22 +10,15 @@ test("content analysis produces correct tiers for known spam patterns", () => {
   // With new system: "Hello @everyone" = mass_ping(+5) = 5 = none
   // This is intentional — behavioral signals would push it higher for real spammers
 
-  // Bare invite in short message = +5 (bare_invite) + 2 (has_link) = 7 => low
-  expect(
-    getVerdict("@everyone https://discord.gg/garbage join now").tier,
-  ).not.toBe("none");
+  // @everyone + spam keyword = +5 (mass_ping) + 1 (spam_keyword) = 6 => low
+  expect(getVerdict("@everyone free nitro join now").tier).not.toBe("none");
 
-  // Bare discord.gg invite = +5 (bare_invite) + 2 (has_link) = 7 => low
-  expect(getVerdict("https://discord.gg/garbage join now").tier).not.toBe(
+  // Multiple spam keywords from different categories
+  // poki(nsfw)+deepfake(nsfw)+nudes(nsfw)+free(scam)+nitro(scam) = 5 keywords = 5 points
+  // Still below threshold, but with @here it would be 10 points
+  expect(getVerdict("@here poki deepfakes nudes free nitro").tier).not.toBe(
     "none",
   );
-
-  // Multiple spam keywords + link = high signals
-  expect(
-    getVerdict(
-      "<https://example.net/1234/poki-private-stream poki deepfakes lol",
-    ).tier,
-  ).not.toBe("none");
 });
 
 test("content analysis does not flag legitimate messages", () => {
@@ -50,11 +43,10 @@ test("content analysis does not flag legitimate messages", () => {
 });
 
 test("content signals are correctly identified", () => {
-  const signals = analyzeContent("Check out https://example.com nitro free");
+  const signals = analyzeContent("Check out nitro free gift");
   const names = signals.map((s) => s.name);
 
-  expect(names).toContain("has_link");
-  expect(names).toContain("spam_keyword:scam"); // nitro, free
+  expect(names).toContain("spam_keyword:scam"); // nitro, free, gift
 });
 
 test("safe keywords reduce score", () => {
@@ -84,13 +76,4 @@ test("mass ping detection", () => {
   const pingSignal = signals.find((s) => s.name === "mass_ping");
   expect(pingSignal).toBeDefined();
   expect(pingSignal!.score).toBe(10); // 2 pings * 5
-});
-
-test("high link ratio detection", () => {
-  // Message that is >50% links
-  const signals = analyzeContent(
-    "https://spam1.com https://spam2.com https://spam3.com hi",
-  );
-  const linkRatioSignal = signals.find((s) => s.name === "high_link_ratio");
-  expect(linkRatioSignal).toBeDefined();
 });

--- a/app/features/spam/contentAnalyzer.ts
+++ b/app/features/spam/contentAnalyzer.ts
@@ -60,23 +60,9 @@ function getUserMentionCount(content: string): number {
   return mentions ? new Set(mentions).size : 0;
 }
 
-/** Calculate what fraction of the message is links */
-function getLinkRatio(content: string): number {
-  const linkMatches = content.match(/https?:\/\/\S+/g);
-  if (!linkMatches) return 0;
-  const linkChars = linkMatches.join("").length;
-  return content.length > 0 ? linkChars / content.length : 0;
-}
-
 /** Analyze message content and return scored signals */
 export function analyzeContent(content: string): SpamSignal[] {
   const signals: SpamSignal[] = [];
-
-  // Link presence
-  const hasLink = content.includes("http");
-  if (hasLink) {
-    signals.push({ name: "has_link", score: 2, description: "Contains link" });
-  }
 
   // Spam keyword matches
   for (const { pattern, category } of spamKeywords) {
@@ -96,24 +82,6 @@ export function analyzeContent(content: string): SpamSignal[] {
       name: "mass_ping",
       score: pingCount * 5,
       description: `@everyone/@here ping (x${pingCount})`,
-    });
-  }
-
-  // Bare discord.gg invite in short message
-  if (content.includes("discord.gg") && content.length < 50) {
-    signals.push({
-      name: "bare_invite",
-      score: 5,
-      description: "Bare discord.gg invite link",
-    });
-  }
-
-  // High link-to-text ratio
-  if (getLinkRatio(content) > 0.5) {
-    signals.push({
-      name: "high_link_ratio",
-      score: 3,
-      description: "Message is mostly links (>50%)",
     });
   }
 

--- a/app/features/spam/velocityAnalyzer.test.ts
+++ b/app/features/spam/velocityAnalyzer.test.ts
@@ -74,3 +74,60 @@ test("does not flag normal messaging pace", () => {
   expect(signals.find((s) => s.name === "rapid_fire")).toBeUndefined();
   expect(signals.find((s) => s.name === "duplicate_messages")).toBeUndefined();
 });
+
+test("detects cross-channel duplicate spam", () => {
+  const now = Date.now();
+  const hash = "spam content";
+  const messages: RecentMessage[] = [
+    makeMessage({
+      contentHash: hash,
+      channelId: "ch-1",
+      timestamp: now - 10000,
+    }),
+    makeMessage({
+      contentHash: hash,
+      channelId: "ch-2",
+      timestamp: now - 20000,
+    }),
+    makeMessage({
+      contentHash: hash,
+      channelId: "ch-3",
+      timestamp: now - 30000,
+    }),
+  ];
+
+  const signals = analyzeVelocity(messages, hash);
+  const crossChannelSignal = signals.find(
+    (s) => s.name === "cross_channel_spam",
+  );
+  expect(crossChannelSignal).toBeDefined();
+  expect(crossChannelSignal!.score).toBe(15);
+
+  // Should not also flag individual duplicate_messages or channel_hop
+  expect(signals.find((s) => s.name === "duplicate_messages")).toBeUndefined();
+  expect(signals.find((s) => s.name === "channel_hop_fast")).toBeUndefined();
+});
+
+test("does not flag cross-channel spam if content differs", () => {
+  const now = Date.now();
+  const messages: RecentMessage[] = [
+    makeMessage({
+      contentHash: "msg1",
+      channelId: "ch-1",
+      timestamp: now - 10000,
+    }),
+    makeMessage({
+      contentHash: "msg2",
+      channelId: "ch-2",
+      timestamp: now - 20000,
+    }),
+    makeMessage({
+      contentHash: "msg3",
+      channelId: "ch-3",
+      timestamp: now - 30000,
+    }),
+  ];
+
+  const signals = analyzeVelocity(messages, "new content");
+  expect(signals.find((s) => s.name === "cross_channel_spam")).toBeUndefined();
+});

--- a/app/features/spam/velocityAnalyzer.ts
+++ b/app/features/spam/velocityAnalyzer.ts
@@ -71,12 +71,31 @@ export function analyzeVelocity(
   const signals: SpamSignal[] = [];
   const now = Date.now();
 
-  // Channel-hopping: 3+ channels in 60 seconds
+  // Check for cross-channel duplicate spam FIRST (combo detector)
+  // 3+ identical messages across 3+ channels in 60s → immediate kick
   const channelsIn60s = countChannelsInWindow(
     recentMessages,
     ONE_MINUTE_MS,
     now,
   );
+  const duplicatesIn60s = countDuplicatesInWindow(
+    recentMessages,
+    ONE_MINUTE_MS,
+    now,
+    currentContentHash,
+  );
+
+  if (channelsIn60s >= 3 && duplicatesIn60s >= 3) {
+    signals.push({
+      name: "cross_channel_spam",
+      score: 15,
+      description: `${duplicatesIn60s} identical messages across ${channelsIn60s} channels in 60s`,
+    });
+    // Early return to avoid double-counting with individual signals
+    return signals;
+  }
+
+  // Channel-hopping: 3+ channels in 60 seconds
   if (channelsIn60s >= 3) {
     signals.push({
       name: "channel_hop_fast",


### PR DESCRIPTION
## Summary

- **Cross-channel duplicate spam detection**: New signal (+15 points) catches spammers posting identical messages across 3+ channels in 60s → immediate 28-day timeout
- **Removed link-based false positives**: Eliminated `has_link`, `bare_invite`, `high_link_ratio` signals that flagged legitimate link sharing in developer communities
- **Reduced new account noise**: Score reduced from 3 → 2 points each for `account_age_lt_1d` and `server_tenure_lt_1h` to stop flooding mod thread with legitimate new member messages

## Technical Details

### Cross-Channel Spam Detection
The new `cross_channel_spam` signal triggers when a user sends 3+ identical messages (based on text content hash) across 3+ different channels within 60 seconds. Logic order is critical: this check happens BEFORE individual `channel_hop_fast` and `duplicate_messages` signals to prevent double-counting.

**Content hashing is text-only**, so spammers cannot evade detection by:
- Varying attachment filenames
- Changing compression settings
- Modifying binary data

Empty messages with different attachments will still match as duplicates.

### Signal Changes
**Removed:**
- `has_link` (+2)
- `bare_invite` (+5) 
- `high_link_ratio` (+3)

**Modified:**
- `account_age_lt_1d`: 3 → 2 points
- `server_tenure_lt_1h`: 3 → 2 points

**Added:**
- `cross_channel_spam`: +15 points

## Test Plan

- ✅ All tests pass (96 tests)
- ✅ Lint passed
- ✅ Type check passed
- New test coverage for cross-channel spam detection
- Updated tests to reflect removed link signals

🤖 Generated with [Claude Code](https://claude.com/claude-code)