### PR TITLE
fix(check-requirements): skip deleted channels

### DIFF
--- a/app/commands/checkRequirements.test.ts
+++ b/app/commands/checkRequirements.test.ts
@@ -1,0 +1,102 @@
+import {
+  buildHoneypotResult,
+  buildLogChannelResult,
+} from "./checkRequirements";
+
+describe("buildLogChannelResult", () => {
+  it("returns ok:false with unconfigured detail when channelId is undefined", () => {
+    const result = buildLogChannelResult(
+      "Mod Log Channel",
+      undefined,
+      null,
+      "Not configured",
+    );
+    expect(result).toEqual({
+      name: "Mod Log Channel",
+      ok: false,
+      detail: "Not configured",
+    });
+  });
+
+  it("returns null (skip) when channelId is configured but channel is deleted/missing", () => {
+    const result = buildLogChannelResult(
+      "Mod Log Channel",
+      "123456789",
+      null,
+      "Not configured",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns ok:true with channel mention when channel is found", () => {
+    const result = buildLogChannelResult(
+      "Mod Log Channel",
+      "123456789",
+      "123456789",
+      "Not configured",
+    );
+    expect(result).toEqual({
+      name: "Mod Log Channel",
+      ok: true,
+      detail: "<#123456789>",
+    });
+  });
+
+  it("works the same for Deletion Log Channel", () => {
+    const missingResult = buildLogChannelResult(
+      "Deletion Log Channel",
+      "987654321",
+      null,
+      "Not configured (optional but recommended)",
+    );
+    expect(missingResult).toBeNull();
+
+    const unconfiguredResult = buildLogChannelResult(
+      "Deletion Log Channel",
+      undefined,
+      null,
+      "Not configured (optional but recommended)",
+    );
+    expect(unconfiguredResult).toEqual({
+      name: "Deletion Log Channel",
+      ok: false,
+      detail: "Not configured (optional but recommended)",
+    });
+  });
+});
+
+describe("buildHoneypotResult", () => {
+  it("returns ok:false when no rows are configured", () => {
+    const result = buildHoneypotResult(0, []);
+    expect(result).toEqual({
+      name: "Honeypot",
+      ok: false,
+      detail: "No honeypot channels configured",
+    });
+  });
+
+  it("returns ok:true listing valid channels when at least one is found", () => {
+    const result = buildHoneypotResult(2, ["111", "222"]);
+    expect(result.ok).toBe(true);
+    expect(result.detail).toContain("<#111>");
+    expect(result.detail).toContain("<#222>");
+  });
+
+  it("returns ok:false when rows are configured but all channels are deleted/missing", () => {
+    // configuredCount > 0 but no valid channels — all were deleted
+    const result = buildHoneypotResult(3, []);
+    expect(result).toEqual({
+      name: "Honeypot",
+      ok: false,
+      detail: "No honeypot channels found",
+    });
+  });
+
+  it("does not mention missing channel IDs in the detail when some are deleted", () => {
+    // Only one of three configured channels survived; the deleted ones are silently skipped.
+    const result = buildHoneypotResult(3, ["555"]);
+    expect(result.ok).toBe(true);
+    expect(result.detail).toBe("<#555>");
+    expect(result.detail).not.toContain("missing");
+  });
+});

--- a/app/commands/checkRequirements.ts
+++ b/app/commands/checkRequirements.ts
@@ -17,10 +17,58 @@ import type { SlashCommand } from "#~/helpers/discord";
 import { commandStats } from "#~/helpers/metrics";
 import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
 
-interface CheckResult {
+export interface CheckResult {
   name: string;
   ok: boolean;
   detail: string;
+}
+
+/**
+ * Build a CheckResult for a configured log channel.
+ * Returns null when the channel ID is configured but the channel no longer
+ * exists — deleted channels are not actionable from this command, so callers
+ * should silently skip a null return value instead of surfacing a failure.
+ */
+export function buildLogChannelResult(
+  name: string,
+  channelId: string | undefined,
+  fetchedChannelId: string | null,
+  unconfiguredDetail: string,
+): CheckResult | null {
+  if (!channelId) {
+    return { name, ok: false, detail: unconfiguredDetail };
+  }
+  if (!fetchedChannelId) {
+    // Configured but deleted — not actionable here, skip silently.
+    return null;
+  }
+  return { name, ok: true, detail: `<#${fetchedChannelId}>` };
+}
+
+/**
+ * Build the honeypot CheckResult given the set of valid (fetched) channel IDs.
+ * Missing channel IDs (configured but deleted) are simply absent from
+ * `validChannelIds`; they are silently skipped rather than surfaced as failures.
+ */
+export function buildHoneypotResult(
+  configuredCount: number,
+  validChannelIds: string[],
+): CheckResult {
+  if (configuredCount === 0) {
+    return {
+      name: "Honeypot",
+      ok: false,
+      detail: "No honeypot channels configured",
+    };
+  }
+  return {
+    name: "Honeypot",
+    ok: validChannelIds.length > 0,
+    detail:
+      validChannelIds.length > 0
+        ? validChannelIds.map((id) => `<#${id}>`).join(", ")
+        : "No honeypot channels found",
+  };
 }
 
 export const Command = {
@@ -94,45 +142,35 @@ export const Command = {
       }
 
       // --- Mod-log channel ---
-      if (settings?.modLog) {
-        const ch = yield* fetchChannel(guild, settings.modLog).pipe(
-          Effect.catchAll(() => Effect.succeed(null)),
+      {
+        const ch = settings?.modLog
+          ? yield* fetchChannel(guild, settings.modLog).pipe(
+              Effect.catchAll(() => Effect.succeed(null)),
+            )
+          : null;
+        const result = buildLogChannelResult(
+          "Mod Log Channel",
+          settings?.modLog,
+          ch?.id ?? null,
+          "Not configured",
         );
-
-        results.push({
-          name: "Mod Log Channel",
-          ok: !!ch,
-          detail: ch
-            ? `<#${ch.id}>`
-            : `Channel \`${settings.modLog}\` not found`,
-        });
-      } else {
-        results.push({
-          name: "Mod Log Channel",
-          ok: false,
-          detail: "Not configured",
-        });
+        if (result) results.push(result);
       }
 
       // --- Deletion-log channel (optional) ---
-      if (settings?.deletionLog) {
-        const ch = yield* fetchChannel(guild, settings.deletionLog).pipe(
-          Effect.catchAll(() => Effect.succeed(null)),
+      {
+        const ch = settings?.deletionLog
+          ? yield* fetchChannel(guild, settings.deletionLog).pipe(
+              Effect.catchAll(() => Effect.succeed(null)),
+            )
+          : null;
+        const result = buildLogChannelResult(
+          "Deletion Log Channel",
+          settings?.deletionLog,
+          ch?.id ?? null,
+          "Not configured (optional but recommended)",
         );
-
-        results.push({
-          name: "Deletion Log Channel",
-          ok: !!ch,
-          detail: ch
-            ? `<#${ch.id}>`
-            : `Channel \`${settings.deletionLog}\` not found`,
-        });
-      } else {
-        results.push({
-          name: "Deletion Log Channel",
-          ok: false,
-          detail: "Not configured (optional but recommended)",
-        });
+        if (result) results.push(result);
       }
 
       // --- Restricted role (optional) ---
@@ -163,31 +201,18 @@ export const Command = {
         .selectAll()
         .where("guild_id", "=", guildId);
 
-      if (honeypotRows.length === 0) {
-        results.push({
-          name: "Honeypot",
-          ok: false,
-          detail: "No honeypot channels configured",
-        });
-      } else {
-        let validCount = 0;
-        const details: string[] = [];
+      {
+        const validChannelIds: string[] = [];
         for (const row of honeypotRows) {
           const ch = yield* fetchChannel(guild, row.channel_id).pipe(
             Effect.catchAll(() => Effect.succeed(null)),
           );
           if (ch) {
-            validCount++;
-            details.push(`<#${ch.id}>`);
-          } else {
-            details.push(`\`${row.channel_id}\` (missing)`);
+            validChannelIds.push(ch.id);
           }
+          // Silently skip deleted/missing channels — they're not actionable here.
         }
-        results.push({
-          name: "Honeypot",
-          ok: validCount > 0,
-          detail: details.join(", "),
-        });
+        results.push(buildHoneypotResult(honeypotRows.length, validChannelIds));
       }
 
       // --- Ticket configuration ---


### PR DESCRIPTION
## Problem

When a channel (mod-log, deletion-log, or honeypot) is configured in the guild settings but has since been deleted from Discord, `/check-requirements` was reporting it as a **failed** check with a message like `Channel \`<id>\` not found`.

This is unhelpful because:
- The only way to fix it is to reconfigure the bot — not something this command can do.
- It creates noise by surfacing non-actionable failures.

Fixes #294.

## Fix

- **Mod-log channel**: If the channel ID is configured but the channel can no longer be fetched (deleted), skip the result entry entirely instead of pushing `ok: false`.
- **Deletion-log channel**: Same treatment.
- **Honeypot channels**: Silently skip deleted channel IDs rather than appending `(missing)` to the detail string.

The principle: _a configured-but-deleted channel is not actionable from this command_. Users must reconfigure via `/setup`. Unconfigured channels (no ID in settings at all) still produce the expected `ok: false` result.

## Implementation

The result-building logic for log channels and honeypot channels was extracted into two pure, exported helper functions (`buildLogChannelResult` and `buildHoneypotResult`), making the behaviour directly unit-testable without mocking Effect or Discord.

## Tests

8 new unit tests in `app/commands/checkRequirements.test.ts` cover:
- Unconfigured channel → `ok: false` result
- Configured but deleted channel → `null` (skip)
- Configured and found channel → `ok: true` with channel mention
- Honeypot: no rows, all found, all deleted, partial deletion (deleted ones absent from output)

All 108 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)