### PR TITLE
fix(spam): include attachment IDs in content hash to prevent false positives

### DIFF
--- a/app/features/spam/service.ts
+++ b/app/features/spam/service.ts
@@ -156,7 +156,10 @@ export const SpamDetectionServiceLive = Layer.effect(
           const hasLink = content.includes("http");
 
           // Record in activity tracker
-          const contentHash = content.toLowerCase().trim();
+          const attachmentIds = Array.from(message.attachments.keys()).sort().join(",");
+          const contentHash = attachmentIds
+            ? `${content.toLowerCase().trim()}::attachments:${attachmentIds}`
+            : content.toLowerCase().trim();
           recordMessage(tracker, guildId, userId, {
             messageId: message.id,
             channelId: message.channelId,

--- a/app/features/spam/velocityAnalyzer.test.ts
+++ b/app/features/spam/velocityAnalyzer.test.ts
@@ -108,6 +108,23 @@ test("detects cross-channel duplicate spam", () => {
   expect(signals.find((s) => s.name === "channel_hop_fast")).toBeUndefined();
 });
 
+test("should not flag duplicate messages when empty content but different attachments", () => {
+  const now = Date.now();
+  // Simulate two messages with empty text but different attachments.
+  // In the fixed service.ts, each gets a unique hash like "::attachments:<id>".
+  const hash1 = "::attachments:attachment-id-1";
+  const hash2 = "::attachments:attachment-id-2";
+  const messages: RecentMessage[] = [
+    makeMessage({ contentHash: hash1, timestamp: now - 30000 }),
+    makeMessage({ contentHash: hash2, timestamp: now - 15000 }),
+  ];
+
+  // Current message also has a unique attachment hash
+  const signals = analyzeVelocity(messages, "::attachments:attachment-id-3");
+  expect(signals.find((s) => s.name === "duplicate_messages")).toBeUndefined();
+  expect(signals.find((s) => s.name === "cross_channel_spam")).toBeUndefined();
+});
+
 test("does not flag cross-channel spam if content differs", () => {
   const now = Date.now();
   const messages: RecentMessage[] = [


### PR DESCRIPTION
## Problem

Closes #290.

Users sending multiple messages with empty text but distinct attachments (e.g. sharing several images) were incorrectly flagged as spammers. The `duplicate_messages` signal fires when 2+ messages share the same content hash within 5 minutes, but the hash was computed from text only — so all attachment-only messages hashed to the same empty string.

## Fix

Include sorted attachment IDs in the content hash when attachments are present. This gives each set of distinct attachments a unique hash, so legitimate multi-attachment sharing is never mistaken for duplicate spam.

Text-only messages are unaffected — the hash computation is unchanged when there are no attachments.

## Testing

- Added a test to `velocityAnalyzer.test.ts` demonstrating that messages with distinct hashes (representing different attachments) do not trigger the duplicate signal.
- All existing spam tests continue to pass.