### PR TITLE
fix(check-requirements): ignore dead/deleted channels

### DIFF
--- a/app/commands/checkRequirements.ts
+++ b/app/commands/checkRequirements.ts
@@ -94,46 +94,38 @@ export const Command = {
       }
 
       // --- Mod-log channel ---
-      if (settings?.modLog) {
-        const ch = yield* fetchChannel(guild, settings.modLog).pipe(
-          Effect.catchAll(() => Effect.succeed(null)),
-        );
+      const modLogChannel = settings?.modLog
+        ? yield* fetchChannel(guild, settings.modLog).pipe(
+            Effect.catchAll(() => Effect.succeed(null)),
+          )
+        : null;
 
-        results.push({
-          name: "Mod Log Channel",
-          ok: !!ch,
-          detail: ch
-            ? `<#${ch.id}>`
-            : `Channel \`${settings.modLog}\` not found`,
-        });
-      } else {
-        results.push({
-          name: "Mod Log Channel",
-          ok: false,
-          detail: "Not configured",
-        });
-      }
+      results.push(
+        modLogChannel
+          ? { name: "Mod Log Channel", ok: true, detail: `<#${modLogChannel.id}>` }
+          : { name: "Mod Log Channel", ok: false, detail: "Not configured" },
+      );
 
       // --- Deletion-log channel (optional) ---
-      if (settings?.deletionLog) {
-        const ch = yield* fetchChannel(guild, settings.deletionLog).pipe(
-          Effect.catchAll(() => Effect.succeed(null)),
-        );
+      const deletionLogChannel = settings?.deletionLog
+        ? yield* fetchChannel(guild, settings.deletionLog).pipe(
+            Effect.catchAll(() => Effect.succeed(null)),
+          )
+        : null;
 
-        results.push({
-          name: "Deletion Log Channel",
-          ok: !!ch,
-          detail: ch
-            ? `<#${ch.id}>`
-            : `Channel \`${settings.deletionLog}\` not found`,
-        });
-      } else {
-        results.push({
-          name: "Deletion Log Channel",
-          ok: false,
-          detail: "Not configured (optional but recommended)",
-        });
-      }
+      results.push(
+        deletionLogChannel
+          ? {
+              name: "Deletion Log Channel",
+              ok: true,
+              detail: `<#${deletionLogChannel.id}>`,
+            }
+          : {
+              name: "Deletion Log Channel",
+              ok: false,
+              detail: "Not configured (optional but recommended)",
+            },
+      );
 
       // --- Restricted role (optional) ---
       if (settings?.restricted) {
@@ -179,8 +171,6 @@ export const Command = {
           if (ch) {
             validCount++;
             details.push(`<#${ch.id}>`);
-          } else {
-            details.push(`\`${row.channel_id}\` (missing)`);
           }
         }
         results.push({


### PR DESCRIPTION
## Summary

- `/check-requirements` was reporting channels as failures when their stored channel IDs no longer exist in Discord (deleted channels)
- Deleted channel IDs aren't actionable — you can't restore a deleted channel, only reconfigure. Flagging them as errors was misleading noise
- Now, channels that fail to resolve are silently ignored: Mod Log and Deletion Log fall back to "Not configured" state; Honeypot skips dead rows and only counts live channels

Closes #294

## Test plan

- [ ] Configure a mod log / deletion log channel, then delete the Discord channel. Run `/check-requirements` — the field should show "Not configured" rather than "Channel `<id>` not found"
- [ ] Configure a honeypot channel, then delete it. Run `/check-requirements` — the deleted channel ID should not appear in the Honeypot field
- [ ] Verify `/check-requirements` still works normally for all live configured channels
- [ ] Typecheck passes (`npm run typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)