### PR TITLE
feat(spam): cross-guild timeout when flagged in 3+ servers

### DIFF
--- a/app/features/spam/spamResponseHandler.ts
+++ b/app/features/spam/spamResponseHandler.ts
@@ -14,11 +14,26 @@ import { featureStats } from "#~/helpers/metrics.ts";
 import { applyRestriction, timeout } from "#~/models/discord.server.ts";
 import {
   getSpamReportCount,
+  getSpamReportGuildCount,
   markMessageAsDeleted,
   ReportReasons,
 } from "#~/models/reportedMessages.ts";
 
 import { AUTO_KICK_THRESHOLD, type SpamVerdict } from "./spamScorer.ts";
+
+/**
+ * Number of guilds a user must be flagged in before triggering a cross-guild timeout.
+ * This threshold indicates an account is likely compromised and being used to spam
+ * across multiple communities simultaneously.
+ */
+const CROSS_GUILD_SPAM_THRESHOLD = 3;
+
+/**
+ * In-memory set tracking users who have already been sent a cross-guild DM this session.
+ * Prevents repeatedly DMing the same user on every subsequent spam event.
+ * Resets on bot restart, which is acceptable — the DM is informational, not critical.
+ */
+const crossGuildDmSent = new Set<string>();
 
 /** Execute the graduated response for a spam verdict. */
 export const executeResponse = (
@@ -76,7 +91,7 @@ export const executeResponse = (
     }
 
     if (verdict.tier === "high") {
-      // Timeout user
+      // Timeout user in the originating guild
       yield* Effect.tryPromise(() =>
         timeout(member, "Automated spam detection"),
       ).pipe(
@@ -116,6 +131,9 @@ export const executeResponse = (
 
         featureStats.spamKicked(guildId, userId, spamCount);
       }
+
+      // Check cross-guild spam threshold and timeout everywhere if met
+      yield* checkCrossGuildSpam(userId);
     }
 
     featureStats.spamDetected(
@@ -126,6 +144,78 @@ export const executeResponse = (
       verdict.totalScore,
     );
   }).pipe(Effect.withSpan("SpamResponse.executeResponse"));
+
+/**
+ * Check if a user has been flagged for spam across enough guilds to trigger a
+ * cross-guild response. When the threshold is met, times the user out in every
+ * guild the bot is in and sends them a DM warning that their account may be
+ * compromised.
+ */
+const checkCrossGuildSpam = (userId: string) =>
+  Effect.gen(function* () {
+    const guildCount = yield* getSpamReportGuildCount(userId);
+    if (guildCount < CROSS_GUILD_SPAM_THRESHOLD) return;
+
+    yield* logEffect(
+      "warn",
+      "SpamResponse",
+      "Cross-guild spam threshold reached — timing out in all guilds",
+      { userId, guildCount, threshold: CROSS_GUILD_SPAM_THRESHOLD },
+    );
+
+    const OVERNIGHT = 1000 * 60 * 60 * 20;
+    const reason = `Cross-guild spam: flagged in ${guildCount} servers — account likely compromised`;
+
+    // Timeout the user in every guild the bot is in (concurrently, limit 5)
+    const guilds = [...client.guilds.cache.values()];
+    yield* Effect.all(
+      guilds.map((guild) =>
+        Effect.tryPromise(async () => {
+          const targetMember = await guild.members
+            .fetch(userId)
+            .catch(() => null);
+          if (targetMember) {
+            await targetMember.timeout(OVERNIGHT, reason);
+          }
+        }).pipe(
+          Effect.catchAll((error) =>
+            logEffect(
+              "warn",
+              "SpamResponse",
+              "Failed to apply cross-guild timeout",
+              { error: String(error), guildId: guild.id, userId },
+            ),
+          ),
+        ),
+      ),
+      { concurrency: 5 },
+    );
+
+    // DM the user once per bot session to inform them their account may be compromised
+    if (!crossGuildDmSent.has(userId)) {
+      crossGuildDmSent.add(userId);
+      yield* Effect.tryPromise(() =>
+        client.users.send(
+          userId,
+          "⚠️ **Your account has been flagged for spam across multiple servers.**\n\n" +
+            "This usually means your account has been compromised. Please:\n" +
+            "• Change your Discord password immediately\n" +
+            "• Enable two-factor authentication\n" +
+            "• Revoke any suspicious authorized apps\n\n" +
+            "Your account has been temporarily restricted while you secure it.",
+        ),
+      ).pipe(
+        Effect.catchAll((error) =>
+          logEffect(
+            "warn",
+            "SpamResponse",
+            "Failed to send cross-guild DM to user",
+            { error: String(error), userId },
+          ),
+        ),
+      );
+    }
+  }).pipe(Effect.withSpan("SpamResponse.checkCrossGuildSpam"));
 
 /** Log a spam report to the mod thread */
 const logSpamReport = (message: Message, verdict: SpamVerdict) =>

--- a/app/models/reportedMessages.ts
+++ b/app/models/reportedMessages.ts
@@ -186,6 +186,24 @@ export const getUserReportStats = (userId: string, guildId: string) =>
   );
 
 /**
+ * Count distinct guilds where this user has spam reports (for cross-guild spam detection).
+ */
+export const getSpamReportGuildCount = (userId: string) =>
+  Effect.gen(function* () {
+    const kysely = yield* DatabaseService;
+
+    const [result] = yield* kysely
+      .selectFrom("reported_messages")
+      .select(({ fn }) => fn.count("guild_id").distinct().as("count"))
+      .where("reported_user_id", "=", userId)
+      .where("reason", "=", ReportReasons.spam);
+
+    return Number(result?.count ?? 0);
+  }).pipe(
+    Effect.withSpan("getSpamReportGuildCount", { attributes: { userId } }),
+  );
+
+/**
  * Count spam reports for a user in a guild (used for auto-kick threshold).
  */
 export const getSpamReportCount = (userId: string, guildId: string) =>


### PR DESCRIPTION
## Summary

Implements #291: when a user is flagged for high-tier spam across **3 or more distinct guilds**, the bot now:

1. **Times them out in every guild** it's a member of (20-hour timeout, concurrent with limit 5)
2. **DMs them** a message explaining that their account may be compromised and what steps to take

This targets the scenario where a bad actor — or more commonly a compromised account — is used to spam multiple communities simultaneously.

## Changes

- **`app/models/reportedMessages.ts`**: Adds `getSpamReportGuildCount(userId)` — queries `reported_messages` for the number of *distinct* guilds where a user has spam reports (no guild filter, intentionally cross-guild)

- **`app/features/spam/spamResponseHandler.ts`**: Adds `checkCrossGuildSpam(userId)` — called after a high-tier verdict is logged. Fetches the cross-guild count, and if the threshold is met, uses `client.guilds.cache` to concurrently timeout the user in all guilds. Sends a one-time DM per bot session via a `crossGuildDmSent` in-memory set to avoid spamming the user with repeated DMs.

## Design decisions

- **Threshold of 3 guilds**: Low enough to catch active attacks, high enough to avoid false positives from legitimate users who happened to post spam-like content in two servers
- **In-memory DM dedup**: The DM set resets on restart, which is acceptable — re-sending the "your account may be compromised" warning after a restart is harmless, and the alternative (a DB table just for DM tracking) adds disproportionate complexity
- **Guild cache**: Uses `client.guilds.cache` rather than fetching all guilds from the API to avoid rate-limiting during an active spam event. The cache is kept warm by the gateway connection.
- **`member.fetch()` per guild**: Necessary because we can't use the originating `GuildMember` for other guilds; `null` is handled gracefully (user not in that guild)

## Test plan

- [x] TypeScript typecheck passes
- [x] All 100 existing tests pass
- [ ] Manual: trigger high-tier spam verdict in 3 different guilds, verify timeout is applied in all guilds and DM is sent
- [ ] Manual: verify second spam event doesn't send a second DM (in-memory dedup)
- [ ] Manual: verify user not in a guild is gracefully skipped (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)