### PR TITLE
Redesign /setup into a 3-step onboarding wizard

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -12,11 +12,21 @@ permissions:
 jobs:
   create-rc:
     runs-on: ubuntu-latest
+    environment: CI
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: Euno-HQ
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Ensure release branch exists
         run: |

--- a/app/Database.ts
+++ b/app/Database.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, Schedule } from "effect";
+import { Context, Effect, Layer } from "effect";
 
 import * as Reactivity from "@effect/experimental/Reactivity";
 import { SqlClient } from "@effect/sql";
@@ -7,7 +7,6 @@ import { SqliteClient } from "@effect/sql-sqlite-node";
 import { ResultLengthMismatch, SqlError } from "@effect/sql/SqlError";
 
 import type { DB } from "./db";
-import { DatabaseCorruptionError } from "./effects/errors";
 import { logEffect } from "./effects/observability";
 import { databaseUrl, emergencyWebhook } from "./helpers/env.server";
 import { log } from "./helpers/observability";
@@ -71,40 +70,3 @@ const sendWebhookAlert = (message: string) =>
     Effect.ignore, // Don't fail the whole check if webhook fails
   );
 
-/** Run SQLite integrity check using the existing database connection */
-export const runIntegrityCheck = Effect.gen(function* () {
-  log("info", "IntegrityCheck", "Running scheduled integrity check", {});
-
-  const sql = yield* SqlClient.SqlClient;
-  const result = yield* sql.unsafe<{ integrity_check: string }>(
-    "PRAGMA integrity_check",
-  );
-
-  if (result[0]?.integrity_check === "ok") {
-    log("info", "IntegrityCheck", "Database integrity check passed", {});
-    return "ok" as const;
-  }
-
-  const errors = result.map((r) => r.integrity_check).join("\n");
-  log("error", "IntegrityCheck", "Database corruption detected!", { errors });
-
-  yield* sendWebhookAlert(
-    `🚨 **Database Corruption Detected**\n\`\`\`\n${errors.slice(0, 1800)}\n\`\`\``,
-  );
-
-  return yield* new DatabaseCorruptionError({ errors });
-}).pipe(
-  Effect.repeat(Schedule.fixed("6 hours")),
-  Effect.catchTag("SqlError", (error) =>
-    Effect.all([
-      logEffect("error", "IntegrityCheck", "Integrity check failed to run", {
-        error,
-      }),
-      sendWebhookAlert(
-        `🚨 **Database Integrity Check Failed**\n\`\`\`\n${error.message}\n${String(error.cause)}\n${error.stack}\n\`\`\``,
-      ),
-    ]),
-  ),
-  Effect.catchAll(() => Effect.succeed(null)),
-  Effect.withSpan("runIntegrityCheck"),
-);

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -21,12 +21,18 @@ import { CREATE_SENTINEL, setupAll } from "#~/helpers/setupAll.server.ts";
 // --- State management ---
 
 interface PendingSetup {
-  modRoleId?: string; // undefined until selected (required)
+  step: 1 | 2 | 3;
+  // Step 1: Required
+  modRoleId?: string;
   modLogChannel: string; // channel ID or CREATE_SENTINEL
+  // Step 2: Recommended
   deletionLogChannel: string | null; // channel ID, CREATE_SENTINEL, or null (disabled)
-  honeypotChannel: string | null; // channel ID, CREATE_SENTINEL, or null (disabled)
-  ticketChannel: string | null; // channel ID, CREATE_SENTINEL, or null (disabled)
-  restrictedRoleId?: string; // undefined = skip
+  honeypotChannel: string | null;
+  ticketChannel: string | null;
+  // Step 3: Continue configuring
+  selectedFeature?: string;
+  restrictedRoleId?: string;
+  quorum?: number;
   createdAt: number;
 }
 
@@ -48,12 +54,15 @@ function cleanupStaleSetups() {
 
 function defaultSetup(): Omit<PendingSetup, "createdAt"> {
   return {
+    step: 1,
     modRoleId: undefined,
     modLogChannel: CREATE_SENTINEL,
     deletionLogChannel: CREATE_SENTINEL,
     honeypotChannel: CREATE_SENTINEL,
     ticketChannel: CREATE_SENTINEL,
     restrictedRoleId: undefined,
+    quorum: undefined,
+    selectedFeature: undefined,
   };
 }
 
@@ -64,17 +73,13 @@ const FIELD_MAP = {
   honeypot: "honeypotChannel",
   tickets: "ticketChannel",
   restrictedRole: "restrictedRoleId",
+  quorum: "quorum",
+  feature: "selectedFeature",
 } as const;
 
 type FieldKey = keyof typeof FIELD_MAP;
 
 // --- Helper functions ---
-
-function channelValue(value: string | null, createLabel: string): string {
-  if (value === null) return "Disabled";
-  if (value === CREATE_SENTINEL) return `Create new #${createLabel}`;
-  return `<#${value}>`;
-}
 
 const OPTIONAL_CHANNELS = [
   { field: "deletionLog", label: "Deletion Log" },
@@ -104,8 +109,54 @@ function v2Payload(payload: object) {
   return payload as unknown as InteractionUpdateOptions;
 }
 
-// Alias for update interactions — same cast, named for clarity at call sites
 const v2Update = v2Payload;
+
+function navButtons(
+  guildId: string,
+  opts: { back?: boolean; next?: boolean; confirm?: boolean },
+) {
+  const buttons: object[] = [];
+  if (opts.back) {
+    buttons.push({
+      type: ComponentType.Button,
+      custom_id: `setup-back|${guildId}`,
+      label: "← Back",
+      style: ButtonStyle.Secondary,
+    });
+  }
+  if (opts.next) {
+    buttons.push({
+      type: ComponentType.Button,
+      custom_id: `setup-next|${guildId}`,
+      label: "Next →",
+      style: ButtonStyle.Primary,
+    });
+  }
+  if (opts.confirm) {
+    buttons.push({
+      type: ComponentType.Button,
+      custom_id: `setup-exec|${guildId}`,
+      label: "Confirm ✓",
+      style: ButtonStyle.Success,
+    });
+  }
+  return {
+    type: ComponentType.ActionRow,
+    components: buttons,
+  };
+}
+
+// --- Step builders ---
+
+function channelDefaultValues(value: string | null) {
+  return value !== null && value !== CREATE_SENTINEL
+    ? [{ id: value, type: "channel" as const }]
+    : undefined;
+}
+
+function roleDefaultValues(roleId: string | undefined) {
+  return roleId ? [{ id: roleId, type: "role" as const }] : undefined;
+}
 
 // --- Public: initialize state and return the form payload for slash command use ---
 
@@ -113,24 +164,29 @@ export function initSetupForm(guildId: string, userId: string): object {
   cleanupStaleSetups();
   const state: PendingSetup = { ...defaultSetup(), createdAt: Date.now() };
   pendingSetups.set(setupKey(guildId, userId), state);
-  return buildSetupFormMessage(guildId, state);
+  return buildStepMessage(guildId, state);
 }
 
-function buildSetupFormMessage(
+function buildStepMessage(
+  guildId: string,
+  state: PendingSetup,
+  errorText?: string,
+): object {
+  switch (state.step) {
+    case 1:
+      return buildStep1Message(guildId, state, errorText);
+    case 2:
+      return buildStep2Message(guildId, state, errorText);
+    case 3:
+      return buildStep3Message(guildId, state, errorText);
+  }
+}
+
+function buildStep1Message(
   guildId: string,
   state: PendingSetup,
   errorText?: string,
 ) {
-  function channelDefaultValues(value: string | null) {
-    return value !== null && value !== CREATE_SENTINEL
-      ? [{ id: value, type: "channel" as const }]
-      : undefined;
-  }
-
-  function roleDefaultValues(roleId: string | undefined) {
-    return roleId ? [{ id: roleId, type: "role" as const }] : undefined;
-  }
-
   return v2Update({
     flags: MessageFlags.IsComponentsV2,
     components: [
@@ -139,20 +195,15 @@ function buildSetupFormMessage(
         components: [
           {
             type: ComponentType.TextDisplay,
-            content: "## Configure Euno",
+            content: "## Set up required functionality (1/3)",
           },
           {
             type: ComponentType.TextDisplay,
             content:
-              "Select your channels and roles below. Channels left on 'Create new' will be auto-created with sensible defaults.",
+              "These are required for Euno to work. Select a moderator role and a channel for the mod log.",
           },
           ...(errorText
-            ? [
-                {
-                  type: ComponentType.TextDisplay,
-                  content: `⚠ ${errorText}`,
-                },
-              ]
+            ? [{ type: ComponentType.TextDisplay, content: `⚠ ${errorText}` }]
             : []),
           { type: ComponentType.Separator, spacing: 2 },
           {
@@ -194,6 +245,38 @@ function buildSetupFormMessage(
               },
             ],
           },
+          { type: ComponentType.Separator },
+          navButtons(guildId, { next: true, confirm: true }),
+        ],
+      },
+    ],
+  });
+}
+
+function buildStep2Message(
+  guildId: string,
+  state: PendingSetup,
+  errorText?: string,
+) {
+  return v2Update({
+    flags: MessageFlags.IsComponentsV2,
+    components: [
+      {
+        type: ComponentType.Container,
+        components: [
+          {
+            type: ComponentType.TextDisplay,
+            content: "## Set up recommended options (2/3)",
+          },
+          {
+            type: ComponentType.TextDisplay,
+            content:
+              "These features are recommended but optional. Toggle them on or off, and select channels for each.",
+          },
+          ...(errorText
+            ? [{ type: ComponentType.TextDisplay, content: `⚠ ${errorText}` }]
+            : []),
+          { type: ComponentType.Separator, spacing: 2 },
           {
             type: ComponentType.TextDisplay,
             content:
@@ -276,57 +359,94 @@ function buildSetupFormMessage(
           { type: ComponentType.Separator },
           {
             type: ComponentType.TextDisplay,
-            content:
-              "**Restricted Role** *(optional)* — Role assigned to muted or restricted members.",
-          },
-          {
-            type: ComponentType.ActionRow,
-            components: [
-              {
-                type: ComponentType.RoleSelect,
-                custom_id: `setup-sel|${guildId}|restrictedRole`,
-                placeholder: "None — skip (default)",
-                ...(state.restrictedRoleId
-                  ? {
-                      default_values: roleDefaultValues(state.restrictedRoleId),
-                    }
-                  : {}),
-              },
-            ],
-          },
-          { type: ComponentType.Separator },
-          {
-            type: ComponentType.TextDisplay,
             content: "**Enabled features**",
           },
           buildFeatureToggleRow(guildId, state),
           { type: ComponentType.Separator },
-          {
-            type: ComponentType.ActionRow,
-            components: [
-              {
-                type: ComponentType.Button,
-                custom_id: `setup-continue|${guildId}`,
-                label: "Continue →",
-                style: ButtonStyle.Primary,
-              },
-            ],
-          },
+          navButtons(guildId, { back: true, next: true, confirm: true }),
         ],
       },
     ],
   });
 }
 
-function buildSetupConfirmMessage(guildId: string, state: PendingSetup) {
-  const summaryLines = [
-    `**Moderator Role:** <@&${state.modRoleId}>`,
-    `**Mod Log:** ${channelValue(state.modLogChannel, "mod-log")}`,
-    `**Deletion Log:** ${channelValue(state.deletionLogChannel, "deletion-log")}`,
-    `**Honeypot:** ${channelValue(state.honeypotChannel, "honeypot")}`,
-    `**Ticket Channel:** ${channelValue(state.ticketChannel, "contact-mods")}`,
-    `**Restricted Role:** ${state.restrictedRoleId ? `<@&${state.restrictedRoleId}>` : "None"}`,
-  ];
+const STEP3_FEATURES = [
+  {
+    value: "restrictedRole",
+    label: "Restricted Role",
+    description: "Role assigned to muted or restricted members",
+  },
+  {
+    value: "quorum",
+    label: "Escalation Quorum",
+    description: "Number of votes needed to resolve an escalation",
+  },
+] as const;
+
+function buildStep3Message(
+  guildId: string,
+  state: PendingSetup,
+  errorText?: string,
+) {
+  const featureComponents: object[] = [];
+
+  if (state.selectedFeature === "restrictedRole") {
+    featureComponents.push(
+      { type: ComponentType.Separator },
+      {
+        type: ComponentType.TextDisplay,
+        content:
+          "**Restricted Role** — Role assigned to muted or restricted members. Enables the 'Restrict' action in escalation votes.",
+      },
+      {
+        type: ComponentType.ActionRow,
+        components: [
+          {
+            type: ComponentType.RoleSelect,
+            custom_id: `setup-sel|${guildId}|restrictedRole`,
+            placeholder: "None — skip (default)",
+            ...(state.restrictedRoleId
+              ? {
+                  default_values: roleDefaultValues(state.restrictedRoleId),
+                }
+              : {}),
+          },
+        ],
+      },
+    );
+  } else if (state.selectedFeature === "quorum") {
+    const quorumValue = state.quorum ?? 3;
+    featureComponents.push(
+      { type: ComponentType.Separator },
+      {
+        type: ComponentType.TextDisplay,
+        content: `**Escalation Quorum** — Number of moderator votes needed to resolve an escalation. Currently: **${quorumValue}**`,
+      },
+      {
+        type: ComponentType.ActionRow,
+        components: [
+          {
+            type: ComponentType.StringSelect,
+            custom_id: `setup-sel|${guildId}|quorum`,
+            options: [2, 3, 4, 5, 6, 7].map((n) => ({
+              label: `${n} votes`,
+              value: String(n),
+              default: n === quorumValue,
+            })),
+          },
+        ],
+      },
+    );
+  }
+
+  // Build status indicators for each feature
+  const statusParts: string[] = [];
+  if (state.restrictedRoleId) {
+    statusParts.push(`Restricted Role: <@&${state.restrictedRoleId}>`);
+  }
+  if (state.quorum !== undefined) {
+    statusParts.push(`Quorum: ${state.quorum} votes`);
+  }
 
   return v2Update({
     flags: MessageFlags.IsComponentsV2,
@@ -336,36 +456,44 @@ function buildSetupConfirmMessage(guildId: string, state: PendingSetup) {
         components: [
           {
             type: ComponentType.TextDisplay,
-            content: "## Confirm Setup",
+            content: "## Continue configuring (3/3)",
           },
           {
             type: ComponentType.TextDisplay,
             content:
-              "Review your configuration. Click **Confirm** to apply, or go back to make changes.",
+              "Select a feature from the dropdown to configure it. You can configure multiple features before confirming.",
           },
+          ...(errorText
+            ? [{ type: ComponentType.TextDisplay, content: `⚠ ${errorText}` }]
+            : []),
+          ...(statusParts.length > 0
+            ? [
+                {
+                  type: ComponentType.TextDisplay,
+                  content: statusParts.map((s) => `✓ ${s}`).join("\n"),
+                },
+              ]
+            : []),
           { type: ComponentType.Separator, spacing: 2 },
-          {
-            type: ComponentType.TextDisplay,
-            content: summaryLines.join("\n"),
-          },
-          { type: ComponentType.Separator },
           {
             type: ComponentType.ActionRow,
             components: [
               {
-                type: ComponentType.Button,
-                custom_id: `setup-back|${guildId}`,
-                label: "← Go Back",
-                style: ButtonStyle.Secondary,
-              },
-              {
-                type: ComponentType.Button,
-                custom_id: `setup-exec|${guildId}`,
-                label: "Confirm ✓",
-                style: ButtonStyle.Primary,
+                type: ComponentType.StringSelect,
+                custom_id: `setup-sel|${guildId}|feature`,
+                placeholder: "Select a feature to configure…",
+                options: STEP3_FEATURES.map((f) => ({
+                  label: f.label,
+                  value: f.value,
+                  description: f.description,
+                  default: state.selectedFeature === f.value,
+                })),
               },
             ],
           },
+          ...featureComponents,
+          { type: ComponentType.Separator },
+          navButtons(guildId, { back: true, confirm: true }),
         ],
       },
     ],
@@ -383,7 +511,7 @@ const button = (name: string) => ({
 });
 
 export const SetupComponentCommands: MessageComponentCommand[] = [
-  // 1. setup-sel — update one state field, deferUpdate to preserve UI
+  // 1. setup-sel — update one state field, re-render current step
   {
     command: button("setup-sel"),
     handler: (interaction) =>
@@ -412,11 +540,34 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
             action === "disable" ? null : CREATE_SENTINEL;
           yield* interactionUpdate(
             interaction,
-            buildSetupFormMessage(guildId, state),
+            buildStepMessage(guildId, state),
           );
           return;
         }
 
+        // String selects (feature dropdown, quorum)
+        if (
+          interaction.isStringSelectMenu() &&
+          (field === "feature" || field === "quorum")
+        ) {
+          const value = interaction.values[0];
+          if (field === "feature") {
+            state.selectedFeature = value;
+            yield* interactionUpdate(
+              interaction,
+              buildStepMessage(guildId, state),
+            );
+          } else if (field === "quorum") {
+            state.quorum = parseInt(value, 10);
+            yield* interactionUpdate(
+              interaction,
+              buildStepMessage(guildId, state),
+            );
+          }
+          return;
+        }
+
+        // Role and channel selects
         let value: string | undefined;
         if (interaction.isRoleSelectMenu()) {
           value = interaction.values[0];
@@ -447,9 +598,9 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
       ),
   },
 
-  // 3. setup-continue — validate modRoleId, show confirmation
+  // 2. setup-next — validate current step and advance
   {
-    command: button("setup-continue"),
+    command: button("setup-next"),
     handler: (interaction) =>
       Effect.gen(function* () {
         const guildId = interaction.customId.split("|")[1];
@@ -465,10 +616,11 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
           return;
         }
 
-        if (!state.modRoleId) {
+        // Validate step 1 before advancing
+        if (state.step === 1 && !state.modRoleId) {
           yield* interactionUpdate(
             interaction,
-            buildSetupFormMessage(
+            buildStepMessage(
               guildId,
               state,
               "Please select a Moderator Role before continuing.",
@@ -477,32 +629,30 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
           return;
         }
 
-        yield* interactionUpdate(
-          interaction,
-          buildSetupConfirmMessage(guildId, state),
-        );
+        if (state.step < 3) {
+          state.step = (state.step + 1) as 2 | 3;
+        }
+
+        yield* interactionUpdate(interaction, buildStepMessage(guildId, state));
       }).pipe(
         Effect.catchAll((error) =>
           Effect.gen(function* () {
             const err =
               error instanceof Error ? error : new Error(String(error));
-            yield* logEffect(
-              "error",
-              "Commands",
-              "setup-continue handler failed",
-              { error: err },
-            );
+            yield* logEffect("error", "Commands", "setup-next handler failed", {
+              error: err,
+            });
             yield* interactionUpdate(interaction, {
               content: `Setup failed: ${err.message}`,
               components: [],
             }).pipe(Effect.catchAll(() => Effect.void));
           }),
         ),
-        Effect.withSpan("setupContinueHandler"),
+        Effect.withSpan("setupNextHandler"),
       ),
   },
 
-  // 4. setup-back — rebuild form with current state (pre-populated selects)
+  // 3. setup-back — go to previous step (or back from confirm)
   {
     command: button("setup-back"),
     handler: (interaction) =>
@@ -520,10 +670,11 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
           return;
         }
 
-        yield* interactionUpdate(
-          interaction,
-          buildSetupFormMessage(guildId, state),
-        );
+        if (state.step > 1) {
+          state.step = (state.step - 1) as 1 | 2;
+        }
+
+        yield* interactionUpdate(interaction, buildStepMessage(guildId, state));
       }).pipe(
         Effect.catchAll((error) =>
           Effect.gen(function* () {
@@ -538,7 +689,7 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
       ),
   },
 
-  // 5. setup-exec — defer, execute setupAll, show results
+  // 4. setup-exec — validate, show confirm, or execute
   {
     command: button("setup-exec"),
     handler: (interaction) =>
@@ -556,6 +707,19 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
           return;
         }
 
+        // Validate required fields
+        if (!state.modRoleId) {
+          yield* interactionUpdate(
+            interaction,
+            buildStepMessage(
+              guildId,
+              state,
+              "Please select a Moderator Role before confirming.",
+            ),
+          );
+          return;
+        }
+
         yield* interactionDeferUpdate(interaction);
 
         const result = yield* Effect.tryPromise(() =>
@@ -563,10 +727,19 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
             guildId,
             moderatorRoleId: state.modRoleId!,
             restrictedRoleId: state.restrictedRoleId,
+            quorum: state.quorum,
             modLogChannel: state.modLogChannel,
-            deletionLogChannel: state.deletionLogChannel ?? undefined,
-            honeypotChannel: state.honeypotChannel ?? undefined,
-            ticketChannel: state.ticketChannel ?? undefined,
+            // Only include step 2 options if user reached step 2
+            deletionLogChannel:
+              state.step >= 2
+                ? (state.deletionLogChannel ?? undefined)
+                : undefined,
+            honeypotChannel:
+              state.step >= 2
+                ? (state.honeypotChannel ?? undefined)
+                : undefined,
+            ticketChannel:
+              state.step >= 2 ? (state.ticketChannel ?? undefined) : undefined,
           }),
         );
 
@@ -582,30 +755,42 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
             userId: interaction.user.id,
             modRoleId: state.modRoleId,
             created: result.created,
+            step: state.step,
           },
         );
 
         commandStats.setupCompleted(interaction, {
-          moderator: state.modRoleId!,
+          moderator: state.modRoleId,
           modLog: result.modLogChannelId,
         });
 
         const statusLines = [
           `**Moderator Role:** <@&${state.modRoleId}>`,
           `**Mod Log:** <#${result.modLogChannelId}>${result.created.includes("mod-log") ? " (created)" : ""}`,
-          result.deletionLogChannelId
-            ? `**Deletion Log:** <#${result.deletionLogChannelId}>${result.created.includes("deletion-log") ? " (created)" : ""}`
-            : "**Deletion Log:** Disabled",
-          result.honeypotChannelId
-            ? `**Honeypot:** <#${result.honeypotChannelId}>${result.created.includes("honeypot") ? " (created)" : ""}`
-            : "**Honeypot:** Disabled",
-          result.ticketChannelId
-            ? `**Tickets:** <#${result.ticketChannelId}>${result.created.includes("contact-mods") ? " (created)" : ""}`
-            : "**Tickets:** Disabled",
-          ...(state.restrictedRoleId
-            ? [`**Restricted Role:** <@&${state.restrictedRoleId}>`]
-            : []),
         ];
+
+        if (state.step >= 2) {
+          statusLines.push(
+            result.deletionLogChannelId
+              ? `**Deletion Log:** <#${result.deletionLogChannelId}>${result.created.includes("deletion-log") ? " (created)" : ""}`
+              : "**Deletion Log:** Disabled",
+            result.honeypotChannelId
+              ? `**Honeypot:** <#${result.honeypotChannelId}>${result.created.includes("honeypot") ? " (created)" : ""}`
+              : "**Honeypot:** Disabled",
+            result.ticketChannelId
+              ? `**Tickets:** <#${result.ticketChannelId}>${result.created.includes("contact-mods") ? " (created)" : ""}`
+              : "**Tickets:** Disabled",
+          );
+        }
+
+        if (state.restrictedRoleId) {
+          statusLines.push(
+            `**Restricted Role:** <@&${state.restrictedRoleId}>`,
+          );
+        }
+        if (state.quorum !== undefined) {
+          statusLines.push(`**Escalation Quorum:** ${state.quorum} votes`);
+        }
 
         yield* interactionEditReply(
           interaction,

--- a/app/effects/errors.ts
+++ b/app/effects/errors.ts
@@ -36,12 +36,6 @@ export class ConfigError extends Data.TaggedError("ConfigError")<{
   message: string;
 }> {}
 
-export class DatabaseCorruptionError extends Data.TaggedError(
-  "DatabaseCorruptionError",
-)<{
-  readonly errors: string;
-}> {}
-
 // Escalation-specific errors
 export class AlreadyResolvedError extends Data.TaggedError(
   "AlreadyResolvedError",

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -26,6 +26,7 @@ export interface SetupAllOptions {
   guildId: string;
   moderatorRoleId: string;
   restrictedRoleId?: string;
+  quorum?: number;
   modLogChannel: string; // channel ID or CREATE_SENTINEL
   deletionLogChannel?: string; // channel ID, CREATE_SENTINEL, or undefined (disabled)
   honeypotChannel?: string; // channel ID, CREATE_SENTINEL, or undefined (disabled)
@@ -87,6 +88,7 @@ export async function setupAll(
     guildId,
     moderatorRoleId,
     restrictedRoleId,
+    quorum,
     modLogChannel,
     deletionLogChannel,
     honeypotChannel,
@@ -148,6 +150,7 @@ export async function setupAll(
     ...(deletionLogChannelId
       ? { [SETTINGS.deletionLog]: deletionLogChannelId }
       : {}),
+    ...(quorum !== undefined ? { [SETTINGS.quorum]: quorum } : {}),
   });
 
   // --- Honeypot channel (optional) ---

--- a/app/server.ts
+++ b/app/server.ts
@@ -34,7 +34,7 @@ import { startReactjiChanneler } from "#~/discord/reactjiChanneler";
 import { applicationKey } from "#~/helpers/env.server";
 
 import { runtime } from "./AppRuntime";
-import { checkpointWal, runIntegrityCheck } from "./Database";
+import { checkpointWal } from "./Database";
 import { DiscordApiError } from "./effects/errors";
 import { logEffect } from "./effects/observability";
 import { initializeGroups } from "./effects/posthog";
@@ -128,9 +128,6 @@ const startup = Effect.gen(function* () {
 
   // Initialize PostHog group analytics for guilds
   yield* initializeGroups(discordClient.guilds.cache);
-
-  yield* logEffect("debug", "Server", "scheduling integrity check");
-  runtime.runFork(runIntegrityCheck);
 
   // Graceful shutdown handler to checkpoint WAL and dispose the runtime
   // (tears down PostHog finalizer, feature flag interval, and SQLite connection)

--- a/cluster/uat/certificate.yaml
+++ b/cluster/uat/certificate.yaml
@@ -1,12 +1,12 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: wildcard-staging-cert
+  name: uat-staging-cert
   namespace: staging
 spec:
-  secretName: wildcard-staging-tls
+  secretName: uat-staging-tls
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer
   dnsNames:
-    - "*.euno-staging.reactiflux.com"
+    - "uat.euno-staging.reactiflux.com"

--- a/cluster/uat/deployment.yaml
+++ b/cluster/uat/deployment.yaml
@@ -104,4 +104,4 @@ spec:
   tls:
     - hosts:
         - uat.euno-staging.reactiflux.com
-      secretName: wildcard-staging-tls
+      secretName: uat-staging-tls

--- a/notes/2026-03-08_1_setup-wizard-redesign.md
+++ b/notes/2026-03-08_1_setup-wizard-redesign.md
@@ -1,0 +1,60 @@
+# Setup Wizard Redesign — 3-Step Flow
+
+## Steps
+
+### Step 1: Required
+- Moderator role (required, validated before next/confirm)
+- Mod log channel (defaults to CREATE_SENTINEL)
+- Buttons: [Next →] [Confirm ✓]
+
+### Step 2: Recommended
+- Deletion log (toggle + channel select)
+- Honeypot (toggle + channel select)
+- Ticket channel (toggle + channel select)
+- Buttons: [← Back] [Next →] [Confirm ✓]
+
+### Step 3: Continue Configuring
+- StringSelect dropdown of named features
+- When selected, shows that feature's config UI below the dropdown
+- Available features:
+  - Restricted Role — RoleSelect
+  - Quorum — StringSelect (2–7)
+- Buttons: [← Back] [Confirm ✓]
+
+## Behavior
+- **Confirm** at any step executes all accumulated state up to that point
+- **Next** advances to the next step (step 1 validates mod role first)
+- **Back** returns to previous step with state preserved
+- Step 3 dropdown controls which feature's UI is visible; multiple features
+  can be configured before confirming
+
+## custom_id scheme
+- `setup-sel|{guildId}|{field}` — select menus
+- `setup-sel|{guildId}|{field}|enable|disable` — toggle buttons
+- `setup-next|{guildId}` — advance step
+- `setup-back|{guildId}` — go back
+- `setup-exec|{guildId}` — confirm and execute
+
+## State
+```typescript
+interface PendingSetup {
+  step: 1 | 2 | 3;
+  // Step 1
+  modRoleId?: string;
+  modLogChannel: string;
+  // Step 2
+  deletionLogChannel: string | null;
+  honeypotChannel: string | null;
+  ticketChannel: string | null;
+  // Step 3
+  selectedFeature?: string;
+  restrictedRoleId?: string;
+  quorum?: number;
+  createdAt: number;
+}
+```
+
+## Files changed
+- `app/commands/setupHandlers.ts` — major rewrite (state, form builders, handlers)
+- `app/helpers/setupAll.server.ts` — add quorum to SetupAllOptions
+- `app/models/guilds.server.ts` — quorum already in SETTINGS, just needs to be written


### PR DESCRIPTION
## Summary
- **Remove periodic DB integrity check** that was causing healthcheck failures and reboot loops (closes #303)
- **Redesign `/setup` into a 3-step wizard:**
  1. **Required** — Moderator role + mod log channel
  2. **Recommended** — Deletion log, honeypot, tickets (with enable/disable toggles)
  3. **Continue configuring** — Dropdown menu of additional features (restricted role, escalation quorum)
- Each step has back/next/confirm buttons. Confirm at any step applies all accumulated config
- Moved restricted role from the main form to step 3's feature dropdown
- Added quorum configuration (2-7 votes) — previously hardcoded at 3 with no UI

## Test plan
- [ ] Run `/setup` and verify step 1 shows only moderator role + mod log
- [ ] Verify "Next" validates mod role is selected before advancing
- [ ] Verify step 2 shows deletion log, honeypot, tickets with toggles
- [ ] Verify step 3 dropdown shows restricted role and quorum options
- [ ] Confirm at step 1 — only required config applied
- [ ] Confirm at step 2 — required + recommended applied
- [ ] Confirm at step 3 — all config including quorum applied
- [ ] Back buttons navigate correctly between steps preserving state
- [ ] Verify bot no longer runs integrity check on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)