### PR TITLE
Fix duplicate auto-kick when spam messages flood concurrently

### DIFF
--- a/app/discord/automod.ts
+++ b/app/discord/automod.ts
@@ -3,11 +3,15 @@ import { Effect } from "effect";
 
 import { runEffect } from "#~/AppRuntime";
 import { SpamDetectionService } from "#~/features/spam/service.ts";
+import { kickedUsers } from "#~/features/spam/spamResponseHandler.ts";
 import { isStaff } from "#~/helpers/discord";
 
 export default async (bot: Client) => {
   bot.on(Events.MessageCreate, async (msg) => {
     if (msg.author.bot || msg.author.system || !msg.guild) return;
+
+    // Skip further spam processing for users already kicked this session
+    if (kickedUsers.has(`${msg.guild.id}:${msg.author.id}`)) return;
 
     const [member, message] = await Promise.all([
       msg.guild.members.fetch(msg.author.id).catch(() => undefined),

--- a/app/features/spam/spamResponseHandler.ts
+++ b/app/features/spam/spamResponseHandler.ts
@@ -20,6 +20,14 @@ import {
 
 import { AUTO_KICK_THRESHOLD, type SpamVerdict } from "./spamScorer.ts";
 
+/**
+ * Tracks users that have already been auto-kicked this session.
+ * Keyed by `${guildId}:${userId}`. Prevents duplicate kicks when multiple
+ * spam messages are processed concurrently before the first kick completes.
+ * Exported so the event listener can skip further processing for kicked users.
+ */
+export const kickedUsers = new Set<string>();
+
 /** Execute the graduated response for a spam verdict. */
 export const executeResponse = (
   verdict: SpamVerdict,
@@ -94,27 +102,34 @@ export const executeResponse = (
 
     // Check for auto-kick on high tier (spam reports only)
     if (verdict.tier === "high" && logResult) {
-      const { message: logMessage } = logResult;
-      const spamCount = yield* getSpamReportCount(userId, guildId);
-      if (spamCount >= AUTO_KICK_THRESHOLD) {
-        yield* Effect.tryPromise(() =>
-          member.kick("Autokicked for repeated spam"),
-        ).pipe(
-          Effect.catchAll((error) =>
-            logEffect("warn", "SpamResponse", "Failed to kick spammer", {
-              error: String(error),
+      const kickKey = `${guildId}:${userId}`;
+      // Guard against duplicate kicks when concurrent pipelines all reach this
+      // point before any single kick resolves. The Set check-and-set is
+      // synchronous, so it is atomic in Node's single-threaded event loop.
+      if (!kickedUsers.has(kickKey)) {
+        kickedUsers.add(kickKey);
+        const { message: logMessage } = logResult;
+        const spamCount = yield* getSpamReportCount(userId, guildId);
+        if (spamCount >= AUTO_KICK_THRESHOLD) {
+          yield* Effect.tryPromise(() =>
+            member.kick("Autokicked for repeated spam"),
+          ).pipe(
+            Effect.catchAll((error) =>
+              logEffect("warn", "SpamResponse", "Failed to kick spammer", {
+                error: String(error),
+              }),
+            ),
+          );
+
+          yield* Effect.tryPromise(() =>
+            logMessage.reply({
+              content: `Automatically kicked <@${userId}> for spam`,
+              allowedMentions: {},
             }),
-          ),
-        );
+          ).pipe(Effect.catchAll(() => Effect.void));
 
-        yield* Effect.tryPromise(() =>
-          logMessage.reply({
-            content: `Automatically kicked <@${userId}> for spam`,
-            allowedMentions: {},
-          }),
-        ).pipe(Effect.catchAll(() => Effect.void));
-
-        featureStats.spamKicked(guildId, userId, spamCount);
+          featureStats.spamKicked(guildId, userId, spamCount);
+        }
       }
     }
 


### PR DESCRIPTION
## Problem

When a spammer floods multiple messages in rapid succession, all concurrent
`MessageCreate` pipelines can each independently pass the auto-kick threshold
check before any single kick resolves. The race window:

1. Messages N, N+1, N+2 arrive before any kick completes
2. All three pipelines independently call `getSpamReportCount` and see the same DB count (e.g. 3)
3. All three call `member.kick()` — Discord throws on the 2nd and 3rd, but errors are swallowed
4. Multiple "Automatically kicked" replies appear in the mod thread

## Fix

**`spamResponseHandler.ts`** — add a module-level `kickedUsers` Set keyed by
`${guildId}:${userId}`. The check-and-set is synchronous (no `yield*` between
them), making it atomic in Node's single-threaded event loop. Only the first
pipeline to reach the kick block will execute it; all concurrent ones are
immediately skipped.

**`automod.ts`** — import and check `kickedUsers` at the very top of the
`MessageCreate` listener, before the expensive `members.fetch()` + `msg.fetch()`
calls. Subsequent messages from a kicked user are dropped at the entry point,
matching the issue's request to "stop processing messages from the kicked member".

## Notes

- The `kickedUsers` Set persists for the lifetime of the bot process. If a
  kicked user rejoins, the bot restarts and the Set is cleared, so they can be
  auto-kicked again in a new session.
- This pattern mirrors the `crossGuildTimeoutApplied` Set being introduced in
  PR #302 for the cross-guild timeout sweep.

Closes #193