### PR TITLE
Add Ban + Delete (7d) button to mod thread controls

### DIFF
--- a/app/commands/escalate/directActions.ts
+++ b/app/commands/escalate/directActions.ts
@@ -172,6 +172,73 @@ export const banUser = (interaction: MessageComponentInteraction) =>
     }),
   );
 
+const DELETE_MESSAGE_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+/**
+ * Ban a user from the guild and delete their recent messages (last 7 days).
+ * Requires moderator role.
+ */
+export const banUserAndDeleteMessages = (
+  interaction: MessageComponentInteraction,
+) =>
+  Effect.gen(function* () {
+    const reportedUserId = interaction.customId.split("|")[1];
+    const guildId = interaction.guildId!;
+
+    // Get settings and check permissions
+    const { moderator: modRoleId } = yield* fetchSettingsEffect(guildId, [
+      SETTINGS.moderator,
+    ]);
+
+    if (!hasModRole(interaction, modRoleId)) {
+      return yield* Effect.fail(
+        new NotAuthorizedError({
+          operation: "banUserAndDeleteMessages",
+          userId: interaction.user.id,
+          requiredRole: "moderator",
+        }),
+      );
+    }
+
+    // Fetch the reported member
+    const reportedMember = yield* fetchMember(
+      interaction.guild!,
+      reportedUserId,
+    );
+
+    // Execute ban with message deletion
+    yield* Effect.tryPromise({
+      try: () =>
+        ban(
+          reportedMember,
+          "single moderator decision",
+          DELETE_MESSAGE_SECONDS,
+        ),
+      catch: (error) => new DiscordApiError({ operation: "ban", cause: error }),
+    });
+
+    yield* logEffect(
+      "info",
+      "DirectActions",
+      "Banned user and deleted messages",
+      {
+        reportedUserId,
+        guildId,
+        actionBy: interaction.user.username,
+        deleteMessageSeconds: DELETE_MESSAGE_SECONDS,
+      },
+    );
+
+    return {
+      reportedUserId,
+      actionBy: interaction.user.username,
+    } satisfies ModActionResult;
+  }).pipe(
+    Effect.withSpan("banUserAndDeleteMessagesHandler", {
+      attributes: { userId: interaction.user.id, guildId: interaction.guildId },
+    }),
+  );
+
 /**
  * Apply restriction role to a user.
  * Requires moderator role.

--- a/app/commands/escalate/handlers.ts
+++ b/app/commands/escalate/handlers.ts
@@ -24,6 +24,7 @@ import {
 
 import {
   banUser,
+  banUserAndDeleteMessages,
   deleteMessages,
   kickUser,
   restrictUser,
@@ -338,6 +339,43 @@ export const EscalationHandlers = {
         }).pipe(() =>
           interactionReply(interaction, {
             content: "Failed to ban user",
+            flags: [MessageFlags.Ephemeral],
+          }).pipe(Effect.catchAll(() => Effect.void)),
+        ),
+      ),
+    ),
+  banAndDelete: (interaction: MessageComponentInteraction) =>
+    Effect.gen(function* () {
+      const reportedUserId = interaction.customId.split("|")[1];
+
+      const result = yield* banUserAndDeleteMessages(interaction);
+
+      yield* interactionReply(
+        interaction,
+        `<@${reportedUserId}> banned + messages deleted by ${result.actionBy}`,
+      );
+    }).pipe(
+      Effect.withSpan("escalation-banUserAndDeleteMessages", {
+        attributes: {
+          guildId: interaction.guildId,
+          userId: interaction.user.id,
+        },
+      }),
+      Effect.catchTag("NotAuthorizedError", () =>
+        interactionReply(interaction, {
+          content: "Insufficient permissions",
+          flags: [MessageFlags.Ephemeral],
+        }).pipe(Effect.catchAll(() => Effect.void)),
+      ),
+      Effect.catchAll((error) =>
+        logEffect(
+          "error",
+          "EscalationHandlers",
+          "Error banning user and deleting messages",
+          { error },
+        ).pipe(() =>
+          interactionReply(interaction, {
+            content: "Failed to ban user and delete messages",
             flags: [MessageFlags.Ephemeral],
           }).pipe(Effect.catchAll(() => Effect.void)),
         ),

--- a/app/commands/escalationControls.ts
+++ b/app/commands/escalationControls.ts
@@ -19,6 +19,7 @@ export const EscalationCommands: MessageComponentCommand[] = [
   { command: button("escalate-delete"), handler: h.delete },
   { command: button("escalate-kick"), handler: h.kick },
   { command: button("escalate-ban"), handler: h.ban },
+  { command: button("escalate-ban-delete"), handler: h.banAndDelete },
   { command: button("escalate-restrict"), handler: h.restrict },
   { command: button("escalate-timeout"), handler: h.timeout },
 

--- a/app/helpers/escalate.tsx
+++ b/app/helpers/escalate.tsx
@@ -33,6 +33,10 @@ export async function escalationControls(
           .setCustomId(`escalate-ban|${reportedUserId}`)
           .setLabel("Ban")
           .setStyle(ButtonStyle.Secondary),
+        new ButtonBuilder()
+          .setCustomId(`escalate-ban-delete|${reportedUserId}`)
+          .setLabel("Ban + Delete (7d)")
+          .setStyle(ButtonStyle.Danger),
       ),
     )
     .addActionRowComponents(

--- a/app/models/discord.server.ts
+++ b/app/models/discord.server.ts
@@ -85,12 +85,19 @@ export const kick = async (member: GuildMember | null, reason: string) => {
   return member.guild.members.kick(member, reason);
 };
 
-export const ban = async (member: GuildMember | null, reason: string) => {
+export const ban = async (
+  member: GuildMember | null,
+  reason: string,
+  deleteMessageSeconds?: number,
+) => {
   if (!member) {
     console.log("Tried to ban a null member");
     return;
   }
-  return member.guild.bans.create(member, { reason });
+  return member.guild.bans.create(member, {
+    reason,
+    ...(deleteMessageSeconds !== undefined && { deleteMessageSeconds }),
+  });
 };
 
 const OVERNIGHT = 1000 * 60 * 60 * 20;


### PR DESCRIPTION
Closes #242

## What

Adds a **"Ban + Delete (7d)"** button to the moderator controls in mod threads, sitting alongside the existing "Ban" button.

When a moderator clicks **Ban + Delete (7d)**, the bot:
1. Bans the user (same as the regular Ban button)
2. Passes `deleteMessageSeconds: 604800` to Discord's ban API, which wipes up to 7 days of that user's messages server-wide — instantly, with no extra steps

The existing **Ban** button is unchanged — mods can still ban without touching message history when appropriate.

## Why 7 days?

Discord's ban API supports up to 7 days (`deleteMessageSeconds` max is 604800). This is the same window the spam auto-ban already uses for honeypot violations. It covers the typical "bad actor joins and spams" window without being surprising.

## Changes

| File | Change |
|------|--------|
| `app/models/discord.server.ts` | `ban()` accepts optional `deleteMessageSeconds` |
| `app/commands/escalate/directActions.ts` | New `banUserAndDeleteMessages()` action (7-day window) |
| `app/commands/escalate/handlers.ts` | New `banAndDelete` handler wired to the above |
| `app/commands/escalationControls.ts` | Register `escalate-ban-delete` button route |
| `app/helpers/escalate.tsx` | "Ban + Delete (7d)" Danger button added to action row 1 |

## Test plan

- [ ] Click **Ban** in a mod thread → user banned, no messages deleted (unchanged behaviour)
- [ ] Click **Ban + Delete (7d)** → user banned, recent messages removed server-wide
- [ ] Non-moderator clicking either button → "Insufficient permissions" ephemeral reply
- [ ] CI passing ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)