### PR TITLE
Prevent duplicate auto-kick from concurrent message flood (#193)

### DIFF
--- a/app/features/spam/spamResponseHandler.ts
+++ b/app/features/spam/spamResponseHandler.ts
@@ -20,6 +20,22 @@ import {
 
 import { AUTO_KICK_THRESHOLD, type SpamVerdict } from "./spamScorer.ts";
 
+/**
+ * In-flight deduplication guard for executeResponse.
+ *
+ * When a member sends a rapid flood of messages, multiple MessageCreate
+ * events fire concurrently — each independently reaching executeResponse
+ * before any action has been taken. Without a guard, all of them can read
+ * spamCount >= AUTO_KICK_THRESHOLD and attempt to kick the member.
+ *
+ * JavaScript is single-threaded, so a synchronous Set.has() + Set.add()
+ * before any yield* is race-free: no two concurrent executions can both
+ * pass the has() guard before either calls add().
+ *
+ * Keys are `${guildId}:${userId}`.
+ */
+const pendingExecutions = new Set<string>();
+
 /** Execute the graduated response for a spam verdict. */
 export const executeResponse = (
   verdict: SpamVerdict,
@@ -32,98 +48,124 @@ export const executeResponse = (
     const guildId = message.guild!.id;
     const userId = message.author.id;
 
-    yield* logEffect("info", "SpamResponse", `Spam verdict: ${verdict.tier}`, {
-      tier: verdict.tier,
-      score: verdict.totalScore,
-      userId,
-      guildId,
-      summary: verdict.summary,
-    });
-
-    // Honeypot: softban (ban + unban to clear 7 days of messages)
-    if (verdict.tier === "honeypot") {
-      yield* executeSoftban(message, member, verdict);
+    // Synchronous check-and-set — must happen before any yield* so no two
+    // concurrent executions can both pass the guard in the same event loop tick.
+    const executionKey = `${guildId}:${userId}`;
+    if (pendingExecutions.has(executionKey)) {
+      yield* logEffect(
+        "debug",
+        "SpamResponse",
+        "Duplicate response suppressed — execution already in-flight",
+        { userId, guildId },
+      );
       return;
     }
+    pendingExecutions.add(executionKey);
 
-    // Low tier: log only, no delete
-    if (verdict.tier === "low") {
-      yield* logSpamReport(message, verdict);
-      featureStats.spamFlaggedForReview(guildId, userId, message.channelId);
-      return;
-    }
+    yield* Effect.gen(function* () {
+      yield* logEffect(
+        "info",
+        "SpamResponse",
+        `Spam verdict: ${verdict.tier}`,
+        {
+          tier: verdict.tier,
+          score: verdict.totalScore,
+          userId,
+          guildId,
+          summary: verdict.summary,
+        },
+      );
 
-    // Medium and high: delete the message first
-    yield* deleteMessage(message).pipe(
-      Effect.tap(() => markMessageAsDeleted(message.id, guildId)),
-      Effect.catchTag("DiscordApiError", (e) =>
-        logEffect("warn", "SpamResponse", "Failed to delete spam message", {
-          error: String(e.cause),
-        }),
-      ),
-    );
+      // Honeypot: softban (ban + unban to clear 7 days of messages)
+      if (verdict.tier === "honeypot") {
+        yield* executeSoftban(message, member, verdict);
+        return;
+      }
 
-    if (verdict.tier === "medium") {
-      // Apply restricted role
-      yield* Effect.tryPromise(() => applyRestriction(member)).pipe(
-        Effect.catchAll((error) =>
-          logEffect("warn", "SpamResponse", "Failed to apply restriction", {
-            error: String(error),
+      // Low tier: log only, no delete
+      if (verdict.tier === "low") {
+        yield* logSpamReport(message, verdict);
+        featureStats.spamFlaggedForReview(guildId, userId, message.channelId);
+        return;
+      }
+
+      // Medium and high: delete the message first
+      yield* deleteMessage(message).pipe(
+        Effect.tap(() => markMessageAsDeleted(message.id, guildId)),
+        Effect.catchTag("DiscordApiError", (e) =>
+          logEffect("warn", "SpamResponse", "Failed to delete spam message", {
+            error: String(e.cause),
           }),
         ),
       );
-      featureStats.spamRestricted(guildId, userId, message.channelId);
-    }
 
-    if (verdict.tier === "high") {
-      // Timeout user
-      yield* Effect.tryPromise(() =>
-        timeout(member, "Automated spam detection"),
-      ).pipe(
-        Effect.catchAll((error) =>
-          logEffect("warn", "SpamResponse", "Failed to timeout user", {
-            error: String(error),
-          }),
-        ),
-      );
-      featureStats.spamTimedOut(guildId, userId, message.channelId);
-    }
-
-    // Log to mod thread for all medium/high tiers
-    const logResult = yield* logSpamReport(message, verdict);
-
-    // Check for auto-kick on high tier (spam reports only)
-    if (verdict.tier === "high" && logResult) {
-      const { message: logMessage } = logResult;
-      const spamCount = yield* getSpamReportCount(userId, guildId);
-      if (spamCount >= AUTO_KICK_THRESHOLD) {
-        yield* Effect.tryPromise(() =>
-          member.kick("Autokicked for repeated spam"),
-        ).pipe(
+      if (verdict.tier === "medium") {
+        // Apply restricted role
+        yield* Effect.tryPromise(() => applyRestriction(member)).pipe(
           Effect.catchAll((error) =>
-            logEffect("warn", "SpamResponse", "Failed to kick spammer", {
+            logEffect("warn", "SpamResponse", "Failed to apply restriction", {
               error: String(error),
             }),
           ),
         );
-
-        yield* Effect.tryPromise(() =>
-          logMessage.reply({
-            content: `Automatically kicked <@${userId}> for spam`,
-            allowedMentions: {},
-          }),
-        ).pipe(Effect.catchAll(() => Effect.void));
-
-        featureStats.spamKicked(guildId, userId, spamCount);
+        featureStats.spamRestricted(guildId, userId, message.channelId);
       }
-    }
 
-    featureStats.spamDetected(
-      guildId,
-      userId,
-      message.channelId,
-      verdict.tier,
-      verdict.totalScore,
+      if (verdict.tier === "high") {
+        // Timeout user
+        yield* Effect.tryPromise(() =>
+          timeout(member, "Automated spam detection"),
+        ).pipe(
+          Effect.catchAll((error) =>
+            logEffect("warn", "SpamResponse", "Failed to timeout user", {
+              error: String(error),
+            }),
+          ),
+        );
+        featureStats.spamTimedOut(guildId, userId, message.channelId);
+      }
+
+      // Log to mod thread for all medium/high tiers
+      const logResult = yield* logSpamReport(message, verdict);
+
+      // Check for auto-kick on high tier (spam reports only)
+      if (verdict.tier === "high" && logResult) {
+        const { message: logMessage } = logResult;
+        const spamCount = yield* getSpamReportCount(userId, guildId);
+        if (spamCount >= AUTO_KICK_THRESHOLD) {
+          yield* Effect.tryPromise(() =>
+            member.kick("Autokicked for repeated spam"),
+          ).pipe(
+            Effect.catchAll((error) =>
+              logEffect("warn", "SpamResponse", "Failed to kick spammer", {
+                error: String(error),
+              }),
+            ),
+          );
+
+          yield* Effect.tryPromise(() =>
+            logMessage.reply({
+              content: `Automatically kicked <@${userId}> for spam`,
+              allowedMentions: {},
+            }),
+          ).pipe(Effect.catchAll(() => Effect.void));
+
+          featureStats.spamKicked(guildId, userId, spamCount);
+        }
+      }
+
+      featureStats.spamDetected(
+        guildId,
+        userId,
+        message.channelId,
+        verdict.tier,
+        verdict.totalScore,
+      );
+    }).pipe(
+      // Always release the execution slot, even on unexpected errors
+      Effect.ensuring(
+        Effect.sync(() => pendingExecutions.delete(executionKey)),
+      ),
     );
   }).pipe(Effect.withSpan("SpamResponse.executeResponse"));
 


### PR DESCRIPTION
## Summary

- Adds a synchronous `pendingExecutions` Set guard to `executeResponse` in `spamResponseHandler.ts`
- Prevents multiple concurrent `MessageCreate` events from each independently reaching the kick path and firing duplicate `member.kick()` calls + duplicate "Automatically kicked @user" mod notifications
- Uses `Effect.ensuring` to guarantee the slot is always released, even on unexpected errors

## Root cause

When a member sends a rapid flood of messages, multiple `MessageCreate` events fire in quick succession. Each independently runs `checkMessage → executeResponse`. Without a guard, all can concurrently read `spamCount >= AUTO_KICK_THRESHOLD` before any kick has occurred, and each attempt to kick the member.

## Why this guard is race-free

JavaScript is single-threaded. The `Set.has()` + `Set.add()` both happen synchronously before any `yield*` in the outer generator, so no two concurrent Effect executions can both pass the check in the same event loop tick. This is the same synchronous-atomicity guarantee used for in-memory counters and caches throughout the codebase.

## What changed

| File | Change |
|------|--------|
| `app/features/spam/spamResponseHandler.ts` | Added `pendingExecutions` Set; wrap inner logic with `Effect.ensuring` cleanup |

Closes #193

## Test plan

- [x] All 100 existing tests pass
- [ ] Manual: flood a test server with rapid messages from a non-mod account above the kick threshold — verify only one kick notification appears in the mod thread

## Notes

The guard protects against concurrent in-flight duplicates. For sequential duplicates (where execution 1 completes before execution 2 starts), the `logUserMessage` DB-level duplicate detection and the Discord API error on `member.kick()` for an already-kicked member provide a secondary layer of protection. A session-lifetime `kickedUsers` Set could be added as a follow-up if sequential duplicates prove to be an issue in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)