### PR TITLE
fix(tickets): delay opener removal so they can read the closing message (#220)

### DIFF
--- a/app/commands/setupTickets.ts
+++ b/app/commands/setupTickets.ts
@@ -341,10 +341,9 @@ export const Command = [
         const { user } = interaction.member;
         const interactionUserId = user.id;
 
+        const CLOSE_DELAY_MINUTES = 5;
+
         yield* Effect.all([
-          Effect.tryPromise(() =>
-            rest.delete(Routes.threadMembers(threadId, ticketOpenerUserId)),
-          ),
           Effect.tryPromise(() =>
             rest.post(Routes.channelMessages(modLog), {
               body: {
@@ -354,10 +353,30 @@ export const Command = [
             }),
           ),
           interactionReply(interaction, {
-            content: `The ticket was closed by <@${interactionUserId}>`,
+            content: `The ticket was closed by <@${interactionUserId}>. <@${ticketOpenerUserId}> will be removed from this thread in ${CLOSE_DELAY_MINUTES} minutes.`,
             allowedMentions: {},
           }),
         ]);
+
+        // Remove the opener after a short delay so they have time to read the
+        // closing message before losing access to the thread (#220).
+        yield* Effect.fork(
+          Effect.gen(function* () {
+            yield* Effect.sleep(`${CLOSE_DELAY_MINUTES} minutes`);
+            yield* Effect.tryPromise(() =>
+              rest.delete(Routes.threadMembers(threadId, ticketOpenerUserId)),
+            );
+          }).pipe(
+            Effect.catchAll((error) =>
+              logEffect(
+                "error",
+                "TicketsClose",
+                "Error removing ticket opener after delay",
+                { error, threadId, ticketOpenerUserId },
+              ),
+            ),
+          ),
+        );
 
         featureStats.ticketClosed(
           interaction.guild.id,


### PR DESCRIPTION
## Problem

When a mod pressed "Close ticket", the ticket opener was immediately removed from the private thread — before they could read any closing message or context left by the moderators. The UX was: mod clicks Close → opener loses access → opener never sees what was said.

## Fix

Restructures the close-ticket handler so removal is deferred:

1. **Immediately** — mod-log is updated and the in-thread reply tells the opener they will be removed in 5 minutes
2. **After 5 minutes** — a background fiber (`Effect.fork`) wakes up and removes the opener via the thread-members REST endpoint

The opener now sees: _"The ticket was closed by @mod. @opener will be removed from this thread in 5 minutes."_ — giving them time to read the conversation and take any notes.

## Implementation notes

- The delay is controlled by `CLOSE_DELAY_MINUTES = 5` at the top of the handler — easy to tune
- Uses `Effect.fork` + `Effect.sleep("5 minutes")` — same pattern as `Effect.sleep("100 millis")` in `auditLog.ts`
- The forked fiber catches its own errors so a failed removal never surfaces back to the mod interaction
- A bot restart during the 5-minute window means the opener stays in the thread (harmless — they just stay accessible until the thread is archived or manually cleaned up)
- Mod-log format is unchanged; the immediate logging of "closed" still happens as the first step

## Considered alternatives

**DB-polling pattern** (like escalations): More resilient to restarts, but significantly more complex — new table, migration, new resolver, new scheduler registration. The failure mode for the simple approach (member stays in thread on restart) is harmless, making the complexity tradeoff not worth it for a 5-minute window.

Closes #220