### PR TITLE
fix(tickets): persist thread opener removal across server restarts (#220)

### DIFF
--- a/app/commands/setupTickets.ts
+++ b/app/commands/setupTickets.ts
@@ -341,10 +341,22 @@ export const Command = [
         const { user } = interaction.member;
         const interactionUserId = user.id;
 
+        const db = yield* DatabaseService;
+        const CLOSE_DELAY_MINUTES = 5;
+        const scheduledFor = new Date(
+          Date.now() + CLOSE_DELAY_MINUTES * 60 * 1000,
+        ).toISOString();
+
         yield* Effect.all([
-          Effect.tryPromise(() =>
-            rest.delete(Routes.threadMembers(threadId, ticketOpenerUserId)),
-          ),
+          // Schedule the opener removal in the DB so it survives restarts
+          db.insertInto("pending_ticket_closures").values({
+            id: crypto.randomUUID() as string,
+            thread_id: threadId,
+            opener_user_id: ticketOpenerUserId,
+            closed_by_user_id: interactionUserId,
+            guild_id: interaction.guild.id,
+            scheduled_for: scheduledFor,
+          }),
           Effect.tryPromise(() =>
             rest.post(Routes.channelMessages(modLog), {
               body: {
@@ -354,7 +366,7 @@ export const Command = [
             }),
           ),
           interactionReply(interaction, {
-            content: `The ticket was closed by <@${interactionUserId}>`,
+            content: `The ticket was closed by <@${interactionUserId}>. <@${ticketOpenerUserId}> will be removed from this thread in ${CLOSE_DELAY_MINUTES} minutes.`,
             allowedMentions: {},
           }),
         ]);

--- a/app/db.d.ts
+++ b/app/db.d.ts
@@ -104,6 +104,16 @@ export interface ModActions {
   user_id: string;
 }
 
+export interface PendingTicketClosures {
+  closed_by_user_id: string;
+  created_at: Generated<string>;
+  guild_id: string;
+  id: string;
+  opener_user_id: string;
+  scheduled_for: string;
+  thread_id: string;
+}
+
 export interface ReactjiChannelerConfig {
   channel_id: string;
   configured_by_id: string;
@@ -167,6 +177,7 @@ export interface DB {
   message_cache: MessageCache;
   message_stats: MessageStats;
   mod_actions: ModActions;
+  pending_ticket_closures: PendingTicketClosures;
   reactji_channeler_config: ReactjiChannelerConfig;
   reported_messages: ReportedMessages;
   sessions: Sessions;

--- a/app/discord/ticketClosureService.ts
+++ b/app/discord/ticketClosureService.ts
@@ -1,0 +1,138 @@
+import { Routes } from "discord-api-types/v10";
+import { Effect } from "effect";
+import type { Selectable } from "kysely";
+
+import { runEffectExit } from "#~/AppRuntime";
+import { DatabaseService } from "#~/Database.ts";
+import type { PendingTicketClosures } from "#~/db.d.ts";
+import { ssrDiscordSdk as rest } from "#~/discord/api";
+import { logEffect } from "#~/effects/observability";
+import { log } from "#~/helpers/observability";
+import { scheduleTask } from "#~/helpers/schedule";
+
+type PendingClosure = Selectable<PendingTicketClosures>;
+
+const ONE_MINUTE = 60 * 1000;
+
+/**
+ * Fetch all pending ticket closures whose scheduled_for time has passed.
+ */
+const getDueClosures = Effect.gen(function* () {
+  const db = yield* DatabaseService;
+  const now = new Date().toISOString();
+  return yield* db
+    .selectFrom("pending_ticket_closures")
+    .selectAll()
+    .where("scheduled_for", "<=", now);
+});
+
+/**
+ * Remove the opener from the ticket thread and delete the pending closure row.
+ */
+const processClosure = (closure: PendingClosure) =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
+
+    // Remove opener from thread. If they already left (or the thread is gone),
+    // the REST call will throw — catch and log so one bad record doesn't block others.
+    yield* Effect.tryPromise({
+      try: () =>
+        rest.delete(
+          Routes.threadMembers(closure.thread_id, closure.opener_user_id),
+        ),
+      catch: (cause) =>
+        new Error(
+          `Discord REST failed for closure ${closure.id}: ${String(cause)}`,
+        ),
+    }).pipe(
+      Effect.catchAll((error) =>
+        logEffect("warn", "TicketClosureService", "Failed to remove opener", {
+          closureId: closure.id,
+          threadId: closure.thread_id,
+          openerUserId: closure.opener_user_id,
+          error: String(error),
+        }),
+      ),
+    );
+
+    // Always delete the row so we don't retry indefinitely on permanent errors
+    yield* db
+      .deleteFrom("pending_ticket_closures")
+      .where("id", "=", closure.id);
+
+    yield* logEffect(
+      "info",
+      "TicketClosureService",
+      "Processed pending ticket closure",
+      {
+        closureId: closure.id,
+        threadId: closure.thread_id,
+        openerUserId: closure.opener_user_id,
+      },
+    );
+  }).pipe(
+    Effect.withSpan("ticketClosure.process", {
+      attributes: {
+        closureId: closure.id,
+        threadId: closure.thread_id,
+        guildId: closure.guild_id,
+      },
+    }),
+  );
+
+/**
+ * Check all due ticket closures and execute them.
+ */
+export const checkPendingTicketClosuresEffect = Effect.gen(function* () {
+  const due = yield* getDueClosures;
+
+  if (due.length === 0) {
+    return { processed: 0 };
+  }
+
+  yield* logEffect(
+    "debug",
+    "TicketClosureService",
+    "Processing pending ticket closures",
+    { count: due.length },
+  );
+
+  yield* Effect.forEach(due, (closure) =>
+    processClosure(closure).pipe(
+      Effect.catchAll((error) =>
+        logEffect(
+          "error",
+          "TicketClosureService",
+          "Unexpected error processing ticket closure",
+          { closureId: closure.id, error: String(error) },
+        ),
+      ),
+    ),
+  );
+
+  return { processed: due.length };
+}).pipe(Effect.withSpan("checkPendingTicketClosures"));
+
+/**
+ * Start the ticket closure scheduler.
+ * Runs every minute to process ticket closures whose scheduled_for time has passed.
+ * This ensures closures survive server restarts — on startup all overdue closures
+ * are processed immediately (within one minute).
+ */
+export function startTicketClosureService(): void {
+  log("info", "TicketClosureService", "Starting ticket closure scheduler", {});
+
+  scheduleTask("TicketClosureService", ONE_MINUTE, () => {
+    void (async () => {
+      const exit = await runEffectExit(checkPendingTicketClosuresEffect);
+      if (exit._tag === "Failure") {
+        log(
+          "error",
+          "TicketClosureService",
+          "Failed to check pending ticket closures",
+          { cause: String(exit.cause) },
+        );
+      }
+    })();
+  });
+}

--- a/app/server.ts
+++ b/app/server.ts
@@ -31,6 +31,7 @@ import { startEscalationResolver } from "#~/discord/escalationResolver";
 import { initDiscordBot } from "#~/discord/gateway";
 import onboardGuild from "#~/discord/onboardGuild";
 import { startReactjiChanneler } from "#~/discord/reactjiChanneler";
+import { startTicketClosureService } from "#~/discord/ticketClosureService";
 import { applicationKey } from "#~/helpers/env.server";
 
 import { runtime } from "./AppRuntime";
@@ -114,6 +115,9 @@ const startup = Effect.gen(function* () {
 
   // Start escalation resolver scheduler (must be after client is ready)
   startEscalationResolver(discordClient);
+
+  // Start ticket closure scheduler — processes pending closures every minute
+  startTicketClosureService();
 
   yield* logEffect("info", "Gateway", "Gateway initialization completed", {
     guildCount: discordClient.guilds.cache.size,

--- a/migrations/20260309000000_pending_ticket_closures.ts
+++ b/migrations/20260309000000_pending_ticket_closures.ts
@@ -1,0 +1,20 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable("pending_ticket_closures")
+    .addColumn("id", "text", (c) => c.primaryKey().notNull())
+    .addColumn("thread_id", "text", (c) => c.notNull())
+    .addColumn("opener_user_id", "text", (c) => c.notNull())
+    .addColumn("closed_by_user_id", "text", (c) => c.notNull())
+    .addColumn("guild_id", "text", (c) => c.notNull())
+    .addColumn("scheduled_for", "text", (c) => c.notNull())
+    .addColumn("created_at", "text", (c) =>
+      c.notNull().defaultTo("(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))"),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema.dropTable("pending_ticket_closures").execute();
+}


### PR DESCRIPTION
## Summary

When a ticket is closed, the thread opener is removed from the thread after a 5-minute grace period. This delay is stored in the database so it survives server restarts — if the server exits while a closure is pending, the opener is still removed within 60 seconds of the next restart.

## How it works

A \`pending_ticket_closures\` table acts as a durable queue. Closing a ticket inserts a row scheduled 5 minutes in the future. A polling service runs every 60 seconds, processes any overdue rows, removes the opener via Discord REST, and deletes the completed row.

## Behavior

| Scenario | Result |
|---|---|
| Normal flow (no restart) | ✅ opener removed after ~5 min |
| Server restarts mid-delay | ✅ processed within 60 s of restart |
| Multiple tickets pending simultaneously | ✅ all processed independently |
| Discord REST error (user left guild, etc.) | ✅ logged + row deleted, no retry loop |

## Changes

- \`migrations/20260309000000_pending_ticket_closures.ts\` — new table: \`id\`, \`thread_id\`, \`opener_user_id\`, \`closed_by_user_id\`, \`guild_id\`, \`scheduled_for\`, \`created_at\`
- \`app/db.d.ts\` — \`PendingTicketClosures\` interface registered in \`DB\`
- \`app/discord/ticketClosureService.ts\` *(new)* — polls DB every 60s, removes opener via REST, deletes processed row; errors caught per-closure so one bad record never blocks others
- \`app/commands/setupTickets.ts\` — \`close-ticket\` handler inserts a DB row (+5 min) and updates the reply to inform the opener they have 5 minutes to read
- \`app/server.ts\` — starts the closure scheduler after the bot is ready

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)