### PR TITLE
fix(spam): back-fill prior duplicates and delete all messages on auto-kick

### DIFF
--- a/app/features/spam/service.ts
+++ b/app/features/spam/service.ts
@@ -24,7 +24,7 @@ import {
   type SpamSignal,
   type SpamVerdict,
 } from "./spamScorer.ts";
-import { analyzeVelocity } from "./velocityAnalyzer.ts";
+import { analyzeVelocity, getPriorDuplicates } from "./velocityAnalyzer.ts";
 
 export interface ISpamDetectionService {
   readonly checkMessage: (
@@ -194,7 +194,9 @@ export const SpamDetectionServiceLive = Layer.effect(
             message.embeds.some((e) => e.url != null);
 
           // Record in activity tracker
-          const attachmentIds = Array.from(message.attachments.keys()).sort().join(",");
+          const attachmentIds = Array.from(message.attachments.keys())
+            .sort()
+            .join(",");
           const baseContent = [content.toLowerCase().trim(), embedText]
             .filter(Boolean)
             .join(" ");
@@ -234,7 +236,29 @@ export const SpamDetectionServiceLive = Layer.effect(
             ...velocitySignals,
           ];
 
-          return computeVerdict(allSignals);
+          const verdict = computeVerdict(allSignals);
+
+          // When a duplicate velocity signal fires, the prior duplicate messages
+          // had tier=none when they were processed and were never logged.
+          // Attach them to the verdict so the response handler can back-fill
+          // them into reported_messages and clean them up on kick.
+          const hasDuplicateSignal = velocitySignals.some(
+            (s) =>
+              s.name === "duplicate_messages" ||
+              s.name === "cross_channel_spam",
+          );
+          if (hasDuplicateSignal) {
+            const priorDuplicates = getPriorDuplicates(
+              recentMessages,
+              message.id,
+              contentHash,
+            );
+            if (priorDuplicates.length > 0) {
+              return { ...verdict, priorDuplicates };
+            }
+          }
+
+          return verdict;
         }).pipe(
           Effect.catchAll((error) =>
             Effect.gen(function* () {

--- a/app/features/spam/spamResponseHandler.ts
+++ b/app/features/spam/spamResponseHandler.ts
@@ -13,9 +13,11 @@ import { logEffect } from "#~/effects/observability.ts";
 import { featureStats } from "#~/helpers/metrics.ts";
 import { applyRestriction, timeout } from "#~/models/discord.server.ts";
 import {
+  deleteAllReportedForUser,
   getSpamReportCount,
   getSpamReportGuildCount,
   markMessageAsDeleted,
+  recordReport,
   ReportReasons,
 } from "#~/models/reportedMessages.ts";
 
@@ -119,6 +121,19 @@ export const executeResponse = (
             logEffect("warn", "SpamResponse", "Failed to kick spammer", {
               error: String(error),
             }),
+          ),
+        );
+
+        // Clean up all reported messages for the kicked user — including any
+        // back-filled prior duplicates — so nothing is left behind on Discord.
+        yield* deleteAllReportedForUser(userId, guildId).pipe(
+          Effect.catchAll((error) =>
+            logEffect(
+              "warn",
+              "SpamResponse",
+              "Failed to delete reported messages after autokick",
+              { error: String(error), userId, guildId },
+            ),
           ),
         );
 
@@ -242,6 +257,52 @@ const logSpamReport = (message: Message, verdict: SpamVerdict) =>
         }),
       ),
     );
+
+    // Back-fill any prior duplicate messages that were not logged when they
+    // were first processed (because at that point they looked like tier=none).
+    // We record them against the same mod-log thread post as the trigger message
+    // so mods can see the full duplicate sequence, and so deleteAllReportedForUser
+    // can clean them all up on kick.
+    if (
+      result &&
+      verdict.priorDuplicates &&
+      verdict.priorDuplicates.length > 0
+    ) {
+      const guildId = message.guild!.id;
+      const userId = message.author.id;
+      const logMessageId = result.message.id;
+      const logChannelId = result.thread.id;
+      const backfillExtra = `Back-filled prior duplicate. ${extra}`;
+
+      for (const prior of verdict.priorDuplicates) {
+        yield* recordReport({
+          reportedMessageId: prior.messageId,
+          reportedChannelId: prior.channelId,
+          reportedUserId: userId,
+          guildId,
+          logMessageId,
+          logChannelId,
+          reason: ReportReasons.spam,
+          extra: backfillExtra,
+        }).pipe(
+          Effect.catchAll((error) =>
+            logEffect(
+              "warn",
+              "SpamResponse",
+              "Failed to back-fill prior duplicate into reported_messages",
+              { messageId: prior.messageId, error: String(error) },
+            ),
+          ),
+        );
+      }
+
+      yield* logEffect(
+        "info",
+        "SpamResponse",
+        `Back-filled ${verdict.priorDuplicates.length} prior duplicate(s)`,
+        { userId, guildId },
+      );
+    }
 
     return result;
   }).pipe(Effect.withSpan("SpamResponse.logSpamReport"));

--- a/app/features/spam/spamScorer.ts
+++ b/app/features/spam/spamScorer.ts
@@ -20,6 +20,14 @@ export interface SpamVerdict {
   signals: SpamSignal[];
   /** Short summary for mod log display */
   summary: string;
+  /**
+   * Prior duplicate messages identified in the activity tracker.
+   * Populated by the service layer when a duplicate_messages or
+   * cross_channel_spam velocity signal fires, so the response handler can
+   * back-fill these earlier messages into reported_messages and ensure
+   * they are cleaned up on kick.
+   */
+  priorDuplicates?: readonly { messageId: string; channelId: string }[];
 }
 
 /** Score thresholds for each response tier */

--- a/app/features/spam/velocityAnalyzer.test.ts
+++ b/app/features/spam/velocityAnalyzer.test.ts
@@ -1,5 +1,5 @@
 import type { RecentMessage } from "./recentActivityTracker";
-import { analyzeVelocity } from "./velocityAnalyzer";
+import { analyzeVelocity, getPriorDuplicates } from "./velocityAnalyzer";
 
 const makeMessage = (
   overrides: Partial<RecentMessage> = {},
@@ -147,4 +147,112 @@ test("does not flag cross-channel spam if content differs", () => {
 
   const signals = analyzeVelocity(messages, "new content");
   expect(signals.find((s) => s.name === "cross_channel_spam")).toBeUndefined();
+});
+
+// ── getPriorDuplicates tests ──
+
+test("getPriorDuplicates returns earlier messages with the same hash", () => {
+  const now = Date.now();
+  const hash = "spam content";
+  const currentId = "msg-current";
+  const messages = [
+    makeMessage({
+      messageId: "msg-1",
+      contentHash: hash,
+      timestamp: now - 60000,
+    }),
+    makeMessage({
+      messageId: "msg-2",
+      contentHash: hash,
+      timestamp: now - 30000,
+    }),
+    makeMessage({ messageId: currentId, contentHash: hash, timestamp: now }),
+  ];
+
+  const priors = getPriorDuplicates(messages, currentId, hash);
+  expect(priors).toHaveLength(2);
+  expect(priors.map((m) => m.messageId)).toEqual(
+    expect.arrayContaining(["msg-1", "msg-2"]),
+  );
+  // Should not include the current message
+  expect(priors.find((m) => m.messageId === currentId)).toBeUndefined();
+});
+
+test("getPriorDuplicates excludes messages with a different hash", () => {
+  const now = Date.now();
+  const hash = "spam content";
+  const currentId = "msg-current";
+  const messages = [
+    makeMessage({
+      messageId: "msg-unrelated",
+      contentHash: "other content",
+      timestamp: now - 10000,
+    }),
+    makeMessage({ messageId: currentId, contentHash: hash, timestamp: now }),
+  ];
+
+  const priors = getPriorDuplicates(messages, currentId, hash);
+  expect(priors).toHaveLength(0);
+});
+
+test("getPriorDuplicates excludes messages outside the time window", () => {
+  const now = Date.now();
+  const hash = "spam content";
+  const currentId = "msg-current";
+  const FIVE_MIN = 5 * 60 * 1000;
+  const messages = [
+    // Just outside the window
+    makeMessage({
+      messageId: "msg-old",
+      contentHash: hash,
+      timestamp: now - FIVE_MIN - 1000,
+    }),
+    // Inside the window
+    makeMessage({
+      messageId: "msg-recent",
+      contentHash: hash,
+      timestamp: now - FIVE_MIN + 1000,
+    }),
+    makeMessage({ messageId: currentId, contentHash: hash, timestamp: now }),
+  ];
+
+  const priors = getPriorDuplicates(messages, currentId, hash);
+  expect(priors).toHaveLength(1);
+  expect(priors[0].messageId).toBe("msg-recent");
+});
+
+test("getPriorDuplicates returns empty array when no prior duplicates exist", () => {
+  const now = Date.now();
+  const hash = "unique content";
+  const currentId = "msg-current";
+  const messages = [
+    makeMessage({ messageId: currentId, contentHash: hash, timestamp: now }),
+  ];
+
+  const priors = getPriorDuplicates(messages, currentId, hash);
+  expect(priors).toHaveLength(0);
+});
+
+test("getPriorDuplicates respects a custom window", () => {
+  const now = Date.now();
+  const hash = "spam content";
+  const currentId = "msg-current";
+  const messages = [
+    makeMessage({
+      messageId: "msg-1",
+      contentHash: hash,
+      timestamp: now - 90000,
+    }), // 90s ago
+    makeMessage({
+      messageId: "msg-2",
+      contentHash: hash,
+      timestamp: now - 30000,
+    }), // 30s ago
+    makeMessage({ messageId: currentId, contentHash: hash, timestamp: now }),
+  ];
+
+  // 60-second window: only msg-2 should be included
+  const priors = getPriorDuplicates(messages, currentId, hash, 60000);
+  expect(priors).toHaveLength(1);
+  expect(priors[0].messageId).toBe("msg-2");
 });

--- a/app/features/spam/velocityAnalyzer.ts
+++ b/app/features/spam/velocityAnalyzer.ts
@@ -150,3 +150,29 @@ export function analyzeVelocity(
 
   return signals;
 }
+
+/**
+ * Collect prior messages in the tracker that have the same content hash as the
+ * current message, excluding the current message itself.
+ *
+ * These are the messages that were sent *before* the duplicate signal fired —
+ * they were processed when no duplicate was yet detected (verdict: 'none') and
+ * so were never recorded in reported_messages. The response handler uses this
+ * list to back-fill them so they are tracked and cleaned up on kick.
+ *
+ * Pure function — no side effects.
+ */
+export function getPriorDuplicates(
+  recentMessages: RecentMessage[],
+  currentMessageId: string,
+  contentHash: string,
+  windowMs: number = FIVE_MINUTES_MS,
+): RecentMessage[] {
+  const cutoff = Date.now() - windowMs;
+  return recentMessages.filter(
+    (m) =>
+      m.contentHash === contentHash &&
+      m.messageId !== currentMessageId &&
+      m.timestamp > cutoff,
+  );
+}


### PR DESCRIPTION
## Problem

Fixes #322 — spam duplicate detection leaves one message behind on Discord.

**Root cause:** When a user sends a duplicate spam message, only the *trigger* message (the one that causes the duplicate signal to fire) gets logged to `reported_messages`. The first copy of the message was processed earlier when no duplicate was yet detected — its verdict was `none`, so it was never recorded.

When a user is then auto-kicked and `deleteAllReportedForUser` runs, it can only delete messages that are in `reported_messages`. The first untracked duplicate stays on Discord.

## Fix

Two complementary changes:

### 1. Back-fill prior duplicate messages (`spamResponseHandler.ts`)

When a spam report is logged and the verdict carries `priorDuplicates`, we call `recordReport` for each earlier duplicate, using the same mod-log thread post as the trigger message. This ensures every duplicate is tracked in `reported_messages`.

### 2. Wire `deleteAllReportedForUser` into the auto-kick path (`spamResponseHandler.ts`)

After every auto-kick, we now call `deleteAllReportedForUser(userId, guildId)` to delete *all* of the user's reported messages from Discord — including the newly back-filled prior duplicates. Previously only the trigger message was marked as deleted.

## Implementation details

- **`SpamVerdict.priorDuplicates`** (new optional field) — carries the prior duplicate `{ messageId, channelId }` pairs from the service layer to the response handler, keeping the pure scorer free of tracker knowledge.
- **`getPriorDuplicates()`** (new pure function in `velocityAnalyzer.ts`) — filters the in-memory tracker's recent messages to find prior duplicates within the detection window, excluding the current message. Pure, no side effects.
- **`service.ts`** — populates `priorDuplicates` on the verdict when `duplicate_messages` or `cross_channel_spam` velocity signals fire.

## Tests

Added 5 unit tests for `getPriorDuplicates` covering:
- Returns prior messages with matching hash
- Excludes current message
- Excludes messages with a different hash
- Excludes messages outside the time window
- Respects a custom window size

All 118 existing tests continue to pass.