### PR TITLE
fix(analytics): correct code_stats JSON parsing in cohort analysis

### DIFF
--- a/app/helpers/cohortAnalysis.ts
+++ b/app/helpers/cohortAnalysis.ts
@@ -272,7 +272,7 @@ export async function getCohortMetrics(
       eb.fn.count<number>("author_id").as("message_count"),
       eb.fn.sum<number>("word_count").as("word_count"),
       eb.fn.sum<number>("react_count").as("reaction_count"),
-      eb.fn("group_concat", ["code_stats"]).as("code_stats_json"),
+      eb.fn("group_concat", ["code_stats", eb.lit("|||")]).as("code_stats_json"),
       eb
         .fn("date", [eb("sent_at", "/", eb.lit(1000)), sql.lit("unixepoch")])
         .as("date"),
@@ -318,7 +318,7 @@ export async function getCohortMetrics(
 
   return userStats.map((user) => {
     const codeStatsArray = user.code_stats_json
-      ? JSON.stringify(user.code_stats_json).split(",").filter(Boolean)
+      ? user.code_stats_json.split("|||").filter(Boolean)
       : [];
 
     const userDailyActivity = fillDateGaps(


### PR DESCRIPTION
## Summary

- `getCohortMetrics()` uses `group_concat("code_stats")` to aggregate per-message code stats across a date range, then splits the result back into individual JSON strings for parsing
- The default comma separator causes `split(",")` to break on commas *within* each JSON array element (e.g. `{"lang":"js","chars":100}` contains commas), producing garbled fragments
- Additionally the original code applied `JSON.stringify()` before splitting, wrapping the concatenated string in quotes and making it doubly wrong
- Fix: use `"|||"` as the `group_concat` separator (a string that will never appear in serialized JSON), then `split("|||")` on the result

## Changes

- `app/helpers/cohortAnalysis.ts`: use custom `|||` separator in `group_concat` query; remove incorrect `JSON.stringify()` before splitting

## Test plan

- [x] 105 existing unit tests pass
- [ ] Manually verify that `getCohortMetrics()` returns non-zero `codeStats.totalChars` for users who have sent code blocks during the period

Closes #185 (Sub-task 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)