### PR TITLE
fix(analytics): add category_id to channel_info for durable category joins

### DIFF
--- a/app/db.d.ts
+++ b/app/db.d.ts
@@ -12,6 +12,7 @@ export type Generated<T> =
 
 export interface ChannelInfo {
   category: string | null;
+  category_id: string | null;
   id: string | null;
   name: string | null;
 }

--- a/app/discord/utils.ts
+++ b/app/discord/utils.ts
@@ -25,22 +25,18 @@ export async function getOrFetchChannel(msg: Message) {
   const data = (await msg.channel.fetch()) as TextChannel;
   const values = {
     id: msg.channelId,
-    category: data.parent?.name,
+    category: data.parent?.name ?? null,
+    category_id: data.parent?.id ?? null,
     name: data.name,
   };
 
-  await run(
-    db.insertInto("channel_info").values({
-      id: msg.channelId,
-      name: data.name,
-      category: data.parent?.name ?? null,
-    }),
-  );
+  await run(db.insertInto("channel_info").values(values));
 
   log("debug", "ActivityTracker", "Channel info added to cache", {
     channelId: msg.channelId,
     channelName: data.name,
     category: data.parent?.name,
+    categoryId: data.parent?.id,
   });
 
   return values;

--- a/migrations/20260313000000_channel_info_category_id.ts
+++ b/migrations/20260313000000_channel_info_category_id.ts
@@ -1,0 +1,23 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Add category_id to channel_info.
+ *
+ * Previously only the category *name* was stored, making it silently stale
+ * whenever a Discord category channel is renamed. Storing the category channel
+ * snowflake ID alongside the name gives us a stable reference for joins and
+ * for the Starhunter config-channels display layer.
+ */
+export async function up(db: Kysely<any>) {
+  return db.schema
+    .alterTable("channel_info")
+    .addColumn("category_id", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<any>) {
+  return db.schema
+    .alterTable("channel_info")
+    .dropColumn("category_id")
+    .execute();
+}


### PR DESCRIPTION
## Summary

- `channel_info` previously stored only the category channel *name* (`data.parent?.name`), making the stored reference silently stale whenever a Discord category is renamed
- This adds a `category_id TEXT` column (the stable Discord channel snowflake) to `channel_info` and populates it alongside the existing `category` name in `getOrFetchChannel()`
- The category *name* column is kept intact for backward compatibility and human-readable display; the ID is an addition, not a replacement
- Establishes the join layer (#97) needed by Starhunter's `starhunter_config_channels` display logic: resolving channel names from IDs stored in config

## Changes

- `migrations/20260313000000_channel_info_category_id.ts`: add `category_id TEXT` column to `channel_info`
- `app/discord/utils.ts`: populate `category_id` from `data.parent?.id` when writing a new `channel_info` row; log it in debug output
- `app/db.d.ts`: add `category_id: string | null` to `ChannelInfo` interface (manual update — the field will appear when codegen is next run)

## What this does NOT change (yet)

- The `ALLOWED_CATEGORIES` filter in `activity.server.ts` still uses name strings; switching it to ID-based filtering is a follow-up once category IDs are known at runtime (tracked in #185)
- Existing `channel_info` rows will have `category_id = NULL` until they are evicted and re-populated from Discord

## Test plan

- [x] 100 existing unit tests pass
- [ ] After deploy, spot-check a few `channel_info` rows — newly inserted records should have a non-null `category_id` for channels in categories
- [ ] Verify `getOrFetchChannel` logs include `categoryId` field

Closes #185 (Sub-task 2)
Part of #325 (Starhunter implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)