### PR TITLE
feat: member applications — gated community onboarding

### DIFF
--- a/app/commands/checkRequirements.ts
+++ b/app/commands/checkRequirements.ts
@@ -1,4 +1,6 @@
+import { Routes } from "discord-api-types/v10";
 import {
+  ComponentType,
   MessageFlags,
   PermissionFlagsBits,
   SlashCommandBuilder,
@@ -6,6 +8,7 @@ import {
 import { Effect } from "effect";
 
 import { DatabaseService } from "#~/Database.ts";
+import { ssrDiscordSdk as rest } from "#~/discord/api";
 import {
   fetchChannel,
   interactionDeferReply,
@@ -20,6 +23,7 @@ import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
 export interface CheckResult {
   name: string;
   ok: boolean;
+  optional?: boolean;
   detail: string;
 }
 
@@ -170,7 +174,10 @@ export const Command = {
           ch?.id ?? null,
           "Not configured (optional but recommended)",
         );
-        if (result) results.push(result);
+        if (result) {
+          if (!result.ok) result.optional = true;
+          results.push(result);
+        }
       }
 
       // --- Restricted role (optional) ---
@@ -190,6 +197,7 @@ export const Command = {
         results.push({
           name: "Restricted Role",
           ok: false,
+          optional: true,
           detail: "Not configured (optional)",
         });
       }
@@ -250,8 +258,147 @@ export const Command = {
         });
       }
 
-      // --- Bot permissions ---
       const botMember = guild.members.me;
+
+      // --- Member applications ---
+      const appConfigRows = yield* db
+        .selectFrom("application_config")
+        .selectAll()
+        .where("guild_id", "=", guildId);
+      const appConfig = appConfigRows[0];
+
+      if (appConfig) {
+        // Check channel exists and has correct permissions
+        const appCh = yield* fetchChannel(guild, appConfig.channel_id).pipe(
+          Effect.catchAll(() => Effect.succeed(null)),
+        );
+
+        if (!appCh) {
+          results.push({
+            name: "Application Channel",
+            ok: false,
+            detail: `Channel \`${appConfig.channel_id}\` not found`,
+          });
+        } else {
+          const channelIssues: string[] = [];
+
+          // Check @everyone can view the channel
+          const everyoneOverwrite =
+            appCh.isTextBased() && "permissionOverwrites" in appCh
+              ? appCh.permissionOverwrites.cache.get(guildId)
+              : undefined;
+          if (!everyoneOverwrite?.allow.has(PermissionFlagsBits.ViewChannel)) {
+            channelIssues.push(
+              "@everyone missing ViewChannel allow on channel",
+            );
+          }
+
+          // Check @member is denied view
+          const memberOverwrite =
+            appCh.isTextBased() && "permissionOverwrites" in appCh
+              ? appCh.permissionOverwrites.cache.get(appConfig.role_id)
+              : undefined;
+          if (!memberOverwrite?.deny.has(PermissionFlagsBits.ViewChannel)) {
+            channelIssues.push(
+              "Member role missing ViewChannel deny on channel",
+            );
+          }
+
+          // Check bot has required permissions on channel
+          if (botMember && "permissionsFor" in appCh) {
+            const botPerms = appCh.permissionsFor(botMember);
+            const needed = [
+              { flag: PermissionFlagsBits.ViewChannel, name: "ViewChannel" },
+              { flag: PermissionFlagsBits.SendMessages, name: "SendMessages" },
+              {
+                flag: PermissionFlagsBits.CreatePrivateThreads,
+                name: "CreatePrivateThreads",
+              },
+              {
+                flag: PermissionFlagsBits.ManageThreads,
+                name: "ManageThreads",
+              },
+            ];
+            const missingPerms = needed.filter(
+              ({ flag }) => !botPerms.has(flag),
+            );
+            if (missingPerms.length > 0) {
+              channelIssues.push(
+                `Bot missing: ${missingPerms.map((p) => p.name).join(", ")}`,
+              );
+            }
+          }
+
+          results.push({
+            name: "Application Channel",
+            ok: channelIssues.length === 0,
+            detail:
+              channelIssues.length === 0
+                ? `<#${appCh.id}>`
+                : `<#${appCh.id}> — ${channelIssues.join("; ")}`,
+          });
+        }
+
+        // Check button message still exists
+        const buttonMsg = yield* Effect.tryPromise(() =>
+          rest.get(
+            Routes.channelMessage(appConfig.channel_id, appConfig.message_id),
+          ),
+        ).pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+        results.push({
+          name: "Apply Button",
+          ok: !!buttonMsg,
+          detail: buttonMsg
+            ? "Button message present"
+            : "Button message not found — run `/setup` to recreate",
+        });
+
+        // Check @everyone has ViewChannel denied server-wide
+        const everyoneRole = yield* Effect.tryPromise(() =>
+          guild.roles.fetch(guildId),
+        ).pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+        if (everyoneRole) {
+          const hasViewDenied = !everyoneRole.permissions.has(
+            PermissionFlagsBits.ViewChannel,
+          );
+          results.push({
+            name: "Channel Gating",
+            ok: hasViewDenied,
+            detail: hasViewDenied
+              ? "@everyone denied ViewChannel (server-wide)"
+              : "@everyone still has ViewChannel — channels are not gated",
+          });
+        }
+
+        // Check member role exists and bot can manage it
+        const memberRole = yield* Effect.tryPromise(() =>
+          guild.roles.fetch(appConfig.role_id),
+        ).pipe(Effect.catchAll(() => Effect.succeed(null)));
+
+        if (!memberRole) {
+          results.push({
+            name: "Member Role",
+            ok: false,
+            detail: `Role \`${appConfig.role_id}\` not found`,
+          });
+        } else {
+          const botHighest = botMember?.roles.highest;
+          const canManage =
+            botHighest && botHighest.position > memberRole.position;
+
+          results.push({
+            name: "Member Role",
+            ok: !!canManage,
+            detail: canManage
+              ? `<@&${memberRole.id}>`
+              : `<@&${memberRole.id}> — bot's role must be above this role to assign it`,
+          });
+        }
+      }
+
+      // --- Bot permissions ---
       if (botMember) {
         const missing = REQUIRED_PERMISSIONS.filter(
           ({ flag }) => !botMember.permissions.has(flag),
@@ -274,37 +421,44 @@ export const Command = {
       }
 
       // --- Build result ---
-      const allOk = results.every((r) => r.ok);
-      const requiredFailing = results
-        .filter(
-          (r) =>
-            !r.ok &&
-            !r.name.includes("Restricted") &&
-            !r.name.includes("Deletion"),
-        )
-        .map((r) => r.name);
+      const hasRequiredFailure = results.some((r) => !r.ok && !r.optional);
+
+      function icon(r: CheckResult): string {
+        if (r.ok) return "🟢";
+        if (r.optional) return "🔵";
+        return "🔴";
+      }
+
+      const lines = results.map((r) => `${icon(r)} ${r.name}: ${r.detail}`);
 
       yield* interactionEditReply(interaction, {
-        embeds: [
+        flags: MessageFlags.IsComponentsV2 | MessageFlags.Ephemeral,
+        components: [
           {
-            title: "Euno Configuration Check",
-            color: requiredFailing.length === 0 ? 0x00cc00 : 0xcc0000,
-            fields: results.map((r) => ({
-              name: `${r.ok ? "\u2713" : "\u2717"} ${r.name}`,
-              value: r.detail,
-              inline: true,
-            })),
-            footer: {
-              text:
-                requiredFailing.length === 0
-                  ? allOk
-                    ? "All checks passed"
-                    : "Core features configured. Optional features noted above."
-                  : "Run /setup to fix configuration",
-            },
+            type: ComponentType.Container,
+            accent_color: hasRequiredFailure ? 0xcc0000 : 0x00cc00,
+            components: [
+              {
+                type: ComponentType.TextDisplay,
+                content: "## Euno Configuration Check",
+              },
+              { type: ComponentType.Separator },
+              {
+                type: ComponentType.TextDisplay,
+                content: lines.join("\n"),
+              },
+              { type: ComponentType.Separator },
+              {
+                type: ComponentType.TextDisplay,
+                content: hasRequiredFailure
+                  ? "Run `/setup` to fix configuration"
+                  : "All required checks passed",
+              },
+            ],
           },
         ],
-      });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Components V2 types not fully supported by discord.js
+      } as any);
 
       commandStats.commandExecuted(interaction, "check-requirements", true);
     }).pipe(

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -24,6 +24,7 @@ import {
   type ModalCommand,
 } from "#~/helpers/discord";
 import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { getOrCreateUserThread } from "#~/models/userThreads";
 
 export const Command = [
   {
@@ -144,21 +145,28 @@ export const Command = [
           }),
         );
 
+        // Post application content to the applicant's private thread
         yield* sendMessage(
           thread,
-          `**Application from ${user.displayName} (<@${user.id}>)**\n\n` +
+          `<@${user.id}>, your application has been received. A moderator will review it shortly.\n\n` +
             `**Tell us about yourself**\n${about}\n\n` +
             `**How did you find this server?**\n${referral}\n\n` +
             `**What do you hope to get from this community?**\n${goals}`,
         );
 
-        const { [SETTINGS.moderator]: modRole } = yield* fetchSettingsEffect(
-          interaction.guild.id,
-          [SETTINGS.moderator],
-        );
+        // Post review message with approve/deny buttons to the mod-log user thread
+        const modThread = yield* getOrCreateUserThread(interaction.guild, user);
 
-        yield* sendMessage(thread, {
-          content: `<@&${modRole}> — a new application is ready for review.`,
+        const applicationContent =
+          `**Application from ${user.displayName} (<@${user.id}>)**\n\n` +
+          `**Tell us about yourself**\n${about}\n\n` +
+          `**How did you find this server?**\n${referral}\n\n` +
+          `**What do you hope to get from this community?**\n${goals}`;
+
+        yield* sendMessage(modThread, applicationContent);
+
+        yield* sendMessage(modThread, {
+          content: "Review this application:",
           components: [
             // @ts-expect-error Types for this are super busted
             new ActionRowBuilder().addComponents(

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -1,0 +1,365 @@
+import { Routes, TextInputStyle } from "discord-api-types/v10";
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ChannelType,
+  InteractionType,
+  MessageFlags,
+  ModalBuilder,
+  TextInputBuilder,
+} from "discord.js";
+import { Effect } from "effect";
+
+import { DatabaseService } from "#~/Database.ts";
+import { ssrDiscordSdk as rest } from "#~/discord/api";
+import {
+  fetchChannel,
+  interactionReply,
+  sendMessage,
+} from "#~/effects/discordSdk.ts";
+import { logEffect } from "#~/effects/observability.ts";
+import {
+  type MessageComponentCommand,
+  type ModalCommand,
+} from "#~/helpers/discord";
+import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+
+export const Command = [
+  {
+    command: {
+      type: InteractionType.MessageComponent,
+      name: "apply-to-join",
+    },
+    handler: (interaction) =>
+      Effect.gen(function* () {
+        const modal = new ModalBuilder()
+          .setCustomId("modal-apply-to-join")
+          .setTitle("Apply to join this community");
+
+        const aboutRow = new ActionRowBuilder().addComponents(
+          new TextInputBuilder()
+            .setLabel("Tell us about yourself")
+            .setCustomId("about")
+            .setMinLength(20)
+            .setMaxLength(500)
+            .setRequired(true)
+            .setStyle(TextInputStyle.Paragraph),
+        );
+        const referralRow = new ActionRowBuilder().addComponents(
+          new TextInputBuilder()
+            .setLabel("How did you find this server?")
+            .setCustomId("referral")
+            .setMaxLength(200)
+            .setRequired(true)
+            .setStyle(TextInputStyle.Short),
+        );
+        const goalsRow = new ActionRowBuilder().addComponents(
+          new TextInputBuilder()
+            .setLabel("What do you hope to get from this community?")
+            .setCustomId("goals")
+            .setMaxLength(300)
+            .setRequired(true)
+            .setStyle(TextInputStyle.Paragraph),
+        );
+
+        // @ts-expect-error busted types
+        modal.addComponents(aboutRow, referralRow, goalsRow);
+
+        yield* Effect.tryPromise(() => interaction.showModal(modal));
+      }).pipe(
+        Effect.catchAll(() => Effect.void),
+        Effect.withSpan("applyToJoinModal", {
+          attributes: {
+            guildId: interaction.guildId,
+            userId: interaction.user.id,
+          },
+        }),
+      ),
+  } satisfies MessageComponentCommand,
+
+  {
+    command: {
+      type: InteractionType.ModalSubmit,
+      name: "modal-apply-to-join",
+    },
+    handler: (interaction) =>
+      Effect.gen(function* () {
+        if (
+          !interaction.channel ||
+          !interaction.guild ||
+          !interaction.message
+        ) {
+          yield* interactionReply(interaction, {
+            content: "Something went wrong while submitting your application",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        const { fields, user } = interaction;
+        const about = fields.getTextInputValue("about");
+        const referral = fields.getTextInputValue("referral");
+        const goals = fields.getTextInputValue("goals");
+
+        const db = yield* DatabaseService;
+        const configRows = yield* db
+          .selectFrom("application_config")
+          .selectAll()
+          .where("guild_id", "=", interaction.guild.id);
+        const config = configRows[0];
+
+        if (!config) {
+          yield* interactionReply(interaction, {
+            content:
+              "Applications are not configured for this server. Please contact an administrator.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        const applyChannel = yield* fetchChannel(
+          interaction.guild,
+          config.channel_id,
+        );
+
+        if (
+          !applyChannel?.isTextBased() ||
+          applyChannel.type !== ChannelType.GuildText
+        ) {
+          yield* interactionReply(interaction, {
+            content:
+              "The application channel is misconfigured. Please contact an administrator.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        const thread = yield* Effect.tryPromise(() =>
+          applyChannel.threads.create({
+            name: `Application: ${user.username}`,
+            autoArchiveDuration: 60 * 24 * 7,
+            type: ChannelType.PrivateThread,
+            invitable: false,
+          }),
+        );
+
+        yield* sendMessage(
+          thread,
+          `**Application from ${user.displayName} (<@${user.id}>)**\n\n` +
+            `**Tell us about yourself**\n${about}\n\n` +
+            `**How did you find this server?**\n${referral}\n\n` +
+            `**What do you hope to get from this community?**\n${goals}`,
+        );
+
+        const { [SETTINGS.moderator]: modRole } = yield* fetchSettingsEffect(
+          interaction.guild.id,
+          [SETTINGS.moderator],
+        );
+
+        yield* sendMessage(thread, {
+          content: `<@&${modRole}> — a new application is ready for review.`,
+          components: [
+            // @ts-expect-error Types for this are super busted
+            new ActionRowBuilder().addComponents(
+              new ButtonBuilder()
+                .setCustomId(`app-approve||${user.id}`)
+                .setLabel("Approve")
+                .setStyle(ButtonStyle.Success),
+              new ButtonBuilder()
+                .setCustomId(`app-deny||${user.id}`)
+                .setLabel("Deny")
+                .setStyle(ButtonStyle.Danger),
+            ),
+          ],
+        });
+
+        yield* interactionReply(interaction, {
+          content:
+            "Your application has been submitted! A moderator will review it shortly.",
+          flags: MessageFlags.Ephemeral,
+        });
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.gen(function* () {
+            yield* logEffect(
+              "error",
+              "MemberApplication",
+              "Error submitting application",
+              { error },
+            );
+
+            yield* interactionReply(interaction, {
+              content: "Something went wrong while submitting your application",
+              flags: MessageFlags.Ephemeral,
+            }).pipe(Effect.catchAll(() => Effect.void));
+          }),
+        ),
+        Effect.withSpan("modalApplyToJoin", {
+          attributes: {
+            guildId: interaction.guildId,
+            userId: interaction.user.id,
+          },
+        }),
+      ),
+  } satisfies ModalCommand,
+
+  {
+    command: {
+      type: InteractionType.MessageComponent,
+      name: "app-approve",
+    },
+    handler: (interaction) =>
+      Effect.gen(function* () {
+        const [, applicantUserId] = interaction.customId.split("||");
+
+        if (!interaction.guild || !interaction.member) {
+          yield* interactionReply(interaction, {
+            content: "Something went wrong",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        const guildId = interaction.guild.id;
+        const approverId = interaction.user.id;
+
+        const db = yield* DatabaseService;
+        const configRows = yield* db
+          .selectFrom("application_config")
+          .selectAll()
+          .where("guild_id", "=", guildId);
+        const config = configRows[0];
+
+        if (!config) {
+          yield* interactionReply(interaction, {
+            content: "Application config not found for this server.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        yield* Effect.tryPromise(() =>
+          rest.put(
+            Routes.guildMemberRole(guildId, applicantUserId, config.role_id),
+          ),
+        );
+
+        yield* interactionReply(interaction, {
+          content: `<@${applicantUserId}>'s application has been approved by <@${approverId}>. Welcome to the community!`,
+          allowedMentions: {},
+        });
+
+        const { [SETTINGS.modLog]: modLog } = yield* fetchSettingsEffect(
+          guildId,
+          [SETTINGS.modLog],
+        );
+
+        yield* Effect.tryPromise(() =>
+          rest.post(Routes.channelMessages(modLog), {
+            body: {
+              content: `<@${applicantUserId}>'s application approved by <@${approverId}> in <#${interaction.channelId}>`,
+              allowedMentions: {},
+            },
+          }),
+        );
+
+        yield* Effect.tryPromise(() =>
+          rest.patch(Routes.channel(interaction.channelId), {
+            body: { archived: true, locked: true },
+          }),
+        );
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.gen(function* () {
+            yield* logEffect(
+              "error",
+              "MemberApplication",
+              "Error approving application",
+              { error },
+            );
+
+            yield* interactionReply(interaction, {
+              content: "Something went wrong while approving the application",
+              flags: MessageFlags.Ephemeral,
+            }).pipe(Effect.catchAll(() => Effect.void));
+          }),
+        ),
+        Effect.withSpan("appApprove", {
+          attributes: {
+            guildId: interaction.guildId,
+            userId: interaction.user.id,
+          },
+        }),
+      ),
+  } satisfies MessageComponentCommand,
+
+  {
+    command: {
+      type: InteractionType.MessageComponent,
+      name: "app-deny",
+    },
+    handler: (interaction) =>
+      Effect.gen(function* () {
+        const [, applicantUserId] = interaction.customId.split("||");
+
+        if (!interaction.guild || !interaction.member) {
+          yield* interactionReply(interaction, {
+            content: "Something went wrong",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        const guildId = interaction.guild.id;
+        const denierId = interaction.user.id;
+
+        yield* interactionReply(interaction, {
+          content: `<@${applicantUserId}>'s application has been denied by <@${denierId}>.`,
+          allowedMentions: {},
+        });
+
+        const { [SETTINGS.modLog]: modLog } = yield* fetchSettingsEffect(
+          guildId,
+          [SETTINGS.modLog],
+        );
+
+        yield* Effect.tryPromise(() =>
+          rest.post(Routes.channelMessages(modLog), {
+            body: {
+              content: `<@${applicantUserId}>'s application denied by <@${denierId}> in <#${interaction.channelId}>`,
+              allowedMentions: {},
+            },
+          }),
+        );
+
+        yield* Effect.tryPromise(() =>
+          rest.patch(Routes.channel(interaction.channelId), {
+            body: { archived: true, locked: true },
+          }),
+        );
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.gen(function* () {
+            yield* logEffect(
+              "error",
+              "MemberApplication",
+              "Error denying application",
+              { error },
+            );
+
+            yield* interactionReply(interaction, {
+              content: "Something went wrong while denying the application",
+              flags: MessageFlags.Ephemeral,
+            }).pipe(Effect.catchAll(() => Effect.void));
+          }),
+        ),
+        Effect.withSpan("appDeny", {
+          attributes: {
+            guildId: interaction.guildId,
+            userId: interaction.user.id,
+          },
+        }),
+      ),
+  } satisfies MessageComponentCommand,
+];

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -418,11 +418,22 @@ export const Command = [
           return;
         }
 
-        yield* Effect.tryPromise(() =>
-          rest.put(
-            Routes.guildMemberRole(guildId, applicantUserId, config.role_id),
-          ),
-        );
+        // Verify a pending application exists before taking action
+        const [appRow] = yield* db
+          .selectFrom("applications")
+          .selectAll()
+          .where("guild_id", "=", guildId)
+          .where("user_id", "=", applicantUserId)
+          .where("status", "=", "pending");
+
+        if (!appRow) {
+          yield* interactionReply(interaction, {
+            content:
+              "No pending application found — it may have already been resolved or retracted.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
 
         yield* db
           .updateTable("applications")
@@ -431,22 +442,18 @@ export const Command = [
             reviewed_by: approverId,
             resolved_at: new Date().toISOString(),
           })
-          .where("guild_id", "=", guildId)
-          .where("user_id", "=", applicantUserId)
-          .where("status", "=", "pending");
+          .where("id", "=", appRow.id);
+
+        yield* Effect.tryPromise(() =>
+          rest.put(
+            Routes.guildMemberRole(guildId, applicantUserId, config.role_id),
+          ),
+        );
 
         yield* interactionReply(interaction, {
           content: `<@${applicantUserId}>'s application has been approved by <@${approverId}>.`,
           allowedMentions: {},
         });
-
-        // Notify the applicant in their thread
-        const [appRow] = yield* db
-          .selectFrom("applications")
-          .select("thread_id")
-          .where("guild_id", "=", guildId)
-          .where("user_id", "=", applicantUserId)
-          .orderBy("created_at", "desc");
 
         if (appRow?.thread_id) {
           yield* Effect.tryPromise(() =>
@@ -519,6 +526,23 @@ export const Command = [
 
         const db = yield* DatabaseService;
 
+        // Verify a pending application exists before taking action
+        const [denyAppRow] = yield* db
+          .selectFrom("applications")
+          .selectAll()
+          .where("guild_id", "=", guildId)
+          .where("user_id", "=", applicantUserId)
+          .where("status", "=", "pending");
+
+        if (!denyAppRow) {
+          yield* interactionReply(interaction, {
+            content:
+              "No pending application found — it may have already been resolved or retracted.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
         // Notify the applicant via DM before kicking, fall back to thread
         const dmSent = yield* Effect.tryPromise(async () => {
           const dmChannel = (await rest.post(Routes.userChannels(), {
@@ -532,23 +556,14 @@ export const Command = [
           return true;
         }).pipe(Effect.catchAll(() => Effect.succeed(false)));
 
-        if (!dmSent) {
-          const [denyAppRow] = yield* db
-            .selectFrom("applications")
-            .select("thread_id")
-            .where("guild_id", "=", guildId)
-            .where("user_id", "=", applicantUserId)
-            .where("status", "=", "pending");
-
-          if (denyAppRow?.thread_id) {
-            yield* Effect.tryPromise(() =>
-              rest.post(Routes.channelMessages(denyAppRow.thread_id), {
-                body: {
-                  content: `<@${applicantUserId}>, your application has been denied.`,
-                },
-              }),
-            ).pipe(Effect.catchAll(() => Effect.void));
-          }
+        if (!dmSent && denyAppRow.thread_id) {
+          yield* Effect.tryPromise(() =>
+            rest.post(Routes.channelMessages(denyAppRow.thread_id), {
+              body: {
+                content: `<@${applicantUserId}>, your application has been denied.`,
+              },
+            }),
+          ).pipe(Effect.catchAll(() => Effect.void));
         }
 
         yield* db
@@ -558,9 +573,7 @@ export const Command = [
             reviewed_by: denierId,
             resolved_at: new Date().toISOString(),
           })
-          .where("guild_id", "=", guildId)
-          .where("user_id", "=", applicantUserId)
-          .where("status", "=", "pending");
+          .where("id", "=", denyAppRow.id);
 
         // Kick the applicant
         yield* Effect.tryPromise(() =>

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -343,7 +343,10 @@ export const Command = [
         // Store the log message ID so we can update it on resolution
         yield* db
           .updateTable("applications")
-          .set({ log_message_id: logMsg.id })
+          .set({
+            log_message_id: logMsg.id,
+            review_message_id: reviewMsg.id,
+          })
           .where("guild_id", "=", interaction.guild.id)
           .where("user_id", "=", user.id)
           .where("status", "=", "pending");
@@ -649,6 +652,97 @@ export const Command = [
           .where("guild_id", "=", guildId)
           .where("user_id", "=", applicantUserId)
           .where("status", "=", "pending");
+
+        // Disable approve/deny buttons on the mod thread review message
+        const [retractAppRow] = yield* db
+          .selectFrom("applications")
+          .select(["review_message_id"])
+          .where("guild_id", "=", guildId)
+          .where("user_id", "=", applicantUserId)
+          .orderBy("created_at", "desc");
+
+        const [modThreadRow] = yield* db
+          .selectFrom("user_threads")
+          .select("thread_id")
+          .where("guild_id", "=", guildId)
+          .where("user_id", "=", applicantUserId);
+
+        if (retractAppRow?.review_message_id && modThreadRow?.thread_id) {
+          // Fetch the existing message to preserve application content
+          const existingMsg = (yield* Effect.tryPromise(() =>
+            rest.get(
+              Routes.channelMessage(
+                modThreadRow.thread_id,
+                retractAppRow.review_message_id!,
+              ),
+            ),
+          ).pipe(Effect.catchAll(() => Effect.succeed(null)))) as {
+            components?: { components?: unknown[] }[];
+          } | null;
+
+          if (existingMsg?.components?.[0]) {
+            const container = existingMsg.components[0] as {
+              components: unknown[];
+            };
+            // Replace the header and swap buttons for disabled ones
+            const updatedComponents = container.components.map(
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Components V2 types not fully supported
+              (c: any) => {
+                if (
+                  c.type === ComponentType.TextDisplay &&
+                  c.content?.startsWith("## Application from")
+                ) {
+                  return {
+                    ...c,
+                    content: `## Application from <@${applicantUserId}>\n*Retracted by applicant*`,
+                  };
+                }
+                if (c.type === ComponentType.ActionRow) {
+                  return {
+                    type: ComponentType.ActionRow,
+                    components: [
+                      {
+                        type: ComponentType.Button,
+                        custom_id: `app-approve||${applicantUserId}`,
+                        label: "Approve",
+                        style: ButtonStyle.Success,
+                        disabled: true,
+                      },
+                      {
+                        type: ComponentType.Button,
+                        custom_id: `app-deny||${applicantUserId}`,
+                        label: "Deny",
+                        style: ButtonStyle.Danger,
+                        disabled: true,
+                      },
+                    ],
+                  };
+                }
+                return c;
+              },
+            );
+
+            yield* Effect.tryPromise(() =>
+              rest.patch(
+                Routes.channelMessage(
+                  modThreadRow.thread_id,
+                  retractAppRow.review_message_id!,
+                ),
+                {
+                  body: {
+                    flags: MessageFlags.IsComponentsV2,
+                    components: [
+                      {
+                        ...existingMsg.components![0],
+                        components: updatedComponents,
+                      },
+                    ],
+                  },
+                },
+              ),
+            ).pipe(Effect.catchAll(() => Effect.void));
+          }
+        }
 
         yield* interactionReply(interaction, {
           content:

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -1,9 +1,8 @@
-import { Routes, TextInputStyle } from "discord-api-types/v10";
+import { ButtonStyle, Routes, TextInputStyle } from "discord-api-types/v10";
 import {
   ActionRowBuilder,
-  ButtonBuilder,
-  ButtonStyle,
   ChannelType,
+  ComponentType,
   InteractionType,
   MessageFlags,
   ModalBuilder,
@@ -13,13 +12,10 @@ import { Effect } from "effect";
 
 import { DatabaseService } from "#~/Database.ts";
 import { ssrDiscordSdk as rest } from "#~/discord/api";
-import {
-  fetchChannel,
-  interactionReply,
-  sendMessage,
-} from "#~/effects/discordSdk.ts";
+import { fetchChannel, interactionReply } from "#~/effects/discordSdk.ts";
 import { logEffect } from "#~/effects/observability.ts";
 import {
+  quoteMessageContent,
   type MessageComponentCommand,
   type ModalCommand,
 } from "#~/helpers/discord";
@@ -145,42 +141,84 @@ export const Command = [
           }),
         );
 
-        // Post application content to the applicant's private thread
-        yield* sendMessage(
-          thread,
-          `<@${user.id}>, your application has been received. A moderator will review it shortly.\n\n` +
-            `**Tell us about yourself**\n${about}\n\n` +
-            `**How did you find this server?**\n${referral}\n\n` +
-            `**What do you hope to get from this community?**\n${goals}`,
+        const applicationComponents = [
+          {
+            type: ComponentType.TextDisplay,
+            content: `Tell us about yourself\n${quoteMessageContent(about)}`,
+          },
+          {
+            type: ComponentType.TextDisplay,
+            content: `How did you find this server?\n${quoteMessageContent(referral)}`,
+          },
+          {
+            type: ComponentType.TextDisplay,
+            content: `What do you hope to get from this community?\n${quoteMessageContent(goals)}`,
+          },
+        ];
+
+        // Post application receipt to the applicant's private thread
+        yield* Effect.tryPromise(() =>
+          rest.post(Routes.channelMessages(thread.id), {
+            body: {
+              flags: MessageFlags.IsComponentsV2,
+              components: [
+                {
+                  type: ComponentType.Container,
+                  components: [
+                    {
+                      type: ComponentType.TextDisplay,
+                      content: `<@${user.id}>, your application has been received. A moderator will review it shortly.`,
+                    },
+                    { type: ComponentType.Separator },
+                    ...applicationComponents,
+                  ],
+                },
+              ],
+            },
+          }),
         );
 
         // Post review message with approve/deny buttons to the mod-log user thread
         const modThread = yield* getOrCreateUserThread(interaction.guild, user);
 
-        const applicationContent =
-          `**Application from ${user.displayName} (<@${user.id}>)**\n\n` +
-          `**Tell us about yourself**\n${about}\n\n` +
-          `**How did you find this server?**\n${referral}\n\n` +
-          `**What do you hope to get from this community?**\n${goals}`;
-
-        yield* sendMessage(modThread, applicationContent);
-
-        yield* sendMessage(modThread, {
-          content: "Review this application:",
-          components: [
-            // @ts-expect-error Types for this are super busted
-            new ActionRowBuilder().addComponents(
-              new ButtonBuilder()
-                .setCustomId(`app-approve||${user.id}`)
-                .setLabel("Approve")
-                .setStyle(ButtonStyle.Success),
-              new ButtonBuilder()
-                .setCustomId(`app-deny||${user.id}`)
-                .setLabel("Deny")
-                .setStyle(ButtonStyle.Danger),
-            ),
-          ],
-        });
+        yield* Effect.tryPromise(() =>
+          rest.post(Routes.channelMessages(modThread.id), {
+            body: {
+              flags: MessageFlags.IsComponentsV2,
+              components: [
+                {
+                  type: ComponentType.Container,
+                  components: [
+                    {
+                      type: ComponentType.TextDisplay,
+                      content: `## Application from ${user.displayName}\nApplicant thread: <#${thread.id}>`,
+                    },
+                    { type: ComponentType.Separator },
+                    ...applicationComponents,
+                    { type: ComponentType.Separator },
+                    {
+                      type: ComponentType.ActionRow,
+                      components: [
+                        {
+                          type: ComponentType.Button,
+                          custom_id: `app-approve||${user.id}`,
+                          label: "Approve",
+                          style: ButtonStyle.Success,
+                        },
+                        {
+                          type: ComponentType.Button,
+                          custom_id: `app-deny||${user.id}`,
+                          label: "Deny",
+                          style: ButtonStyle.Danger,
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+        );
 
         yield* interactionReply(interaction, {
           content:

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -22,6 +22,40 @@ import {
 import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
 import { getOrCreateUserThread } from "#~/models/userThreads";
 
+function pendingLabel(count: number): string {
+  if (count === 0) return "apply-here";
+  return `apply-here⎸${count}-pending`;
+}
+
+/** Update the #apply-here channel name to reflect the current pending count. */
+const syncChannelName = (guildId: string) =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
+    const [row] = yield* db
+      .selectFrom("applications")
+      .select((eb) => eb.fn.count("id").as("count"))
+      .where("guild_id", "=", guildId)
+      .where("status", "=", "pending");
+
+    const count = Number(row?.count ?? 0);
+
+    const [config] = yield* db
+      .selectFrom("application_config")
+      .select("channel_id")
+      .where("guild_id", "=", guildId);
+
+    if (!config) return;
+
+    yield* Effect.tryPromise(() =>
+      rest.patch(Routes.channel(config.channel_id), {
+        body: { name: pendingLabel(count) },
+      }),
+    );
+  }).pipe(
+    // Channel rename is cosmetic — don't fail the main operation
+    Effect.catchAll(() => Effect.void),
+  );
+
 export const Command = [
   {
     command: {
@@ -30,6 +64,24 @@ export const Command = [
     },
     handler: (interaction) =>
       Effect.gen(function* () {
+        // Block duplicate applications before showing the modal
+        const db = yield* DatabaseService;
+        const existingApp = yield* db
+          .selectFrom("applications")
+          .selectAll()
+          .where("guild_id", "=", interaction.guildId!)
+          .where("user_id", "=", interaction.user.id)
+          .where("status", "=", "pending");
+
+        if (existingApp[0]) {
+          yield* interactionReply(interaction, {
+            content:
+              "You already have a pending application. Please wait for a moderator to review it.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
         const modal = new ModalBuilder()
           .setCustomId("modal-apply-to-join")
           .setTitle("Apply to join this community");
@@ -141,6 +193,16 @@ export const Command = [
           }),
         );
 
+        // Record the application in the database
+        yield* db.insertInto("applications").values({
+          id: crypto.randomUUID(),
+          guild_id: interaction.guild.id,
+          user_id: user.id,
+          thread_id: thread.id,
+          status: "pending",
+          created_at: new Date().toISOString(),
+        });
+
         const applicationComponents = [
           {
             type: ComponentType.TextDisplay,
@@ -225,6 +287,8 @@ export const Command = [
             "Your application has been submitted! A moderator will review it shortly.",
           flags: MessageFlags.Ephemeral,
         });
+
+        yield* syncChannelName(interaction.guild.id);
       }).pipe(
         Effect.catchAll((error) =>
           Effect.gen(function* () {
@@ -291,6 +355,17 @@ export const Command = [
           ),
         );
 
+        yield* db
+          .updateTable("applications")
+          .set({
+            status: "approved",
+            reviewed_by: approverId,
+            resolved_at: new Date().toISOString(),
+          })
+          .where("guild_id", "=", guildId)
+          .where("user_id", "=", applicantUserId)
+          .where("status", "=", "pending");
+
         yield* interactionReply(interaction, {
           content: `<@${applicantUserId}>'s application has been approved by <@${approverId}>. Welcome to the community!`,
           allowedMentions: {},
@@ -315,6 +390,8 @@ export const Command = [
             body: { archived: true, locked: true },
           }),
         );
+
+        yield* syncChannelName(guildId);
       }).pipe(
         Effect.catchAll((error) =>
           Effect.gen(function* () {
@@ -360,6 +437,18 @@ export const Command = [
         const guildId = interaction.guild.id;
         const denierId = interaction.user.id;
 
+        const db = yield* DatabaseService;
+        yield* db
+          .updateTable("applications")
+          .set({
+            status: "denied",
+            reviewed_by: denierId,
+            resolved_at: new Date().toISOString(),
+          })
+          .where("guild_id", "=", guildId)
+          .where("user_id", "=", applicantUserId)
+          .where("status", "=", "pending");
+
         yield* interactionReply(interaction, {
           content: `<@${applicantUserId}>'s application has been denied by <@${denierId}>.`,
           allowedMentions: {},
@@ -384,6 +473,8 @@ export const Command = [
             body: { archived: true, locked: true },
           }),
         );
+
+        yield* syncChannelName(guildId);
       }).pipe(
         Effect.catchAll((error) =>
           Effect.gen(function* () {

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -56,6 +56,37 @@ const syncChannelName = (guildId: string) =>
     Effect.catchAll(() => Effect.void),
   );
 
+/** Update the mod-log summary message with resolution details. */
+const resolveLogMessage = (
+  guildId: string,
+  applicantUserId: string,
+  content: string,
+) =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
+    const { [SETTINGS.modLog]: modLog } = yield* fetchSettingsEffect(guildId, [
+      SETTINGS.modLog,
+    ]);
+
+    const [app] = yield* db
+      .selectFrom("applications")
+      .select("log_message_id")
+      .where("guild_id", "=", guildId)
+      .where("user_id", "=", applicantUserId)
+      .orderBy("created_at", "desc");
+
+    if (!app?.log_message_id) return;
+
+    yield* Effect.tryPromise(() =>
+      rest.patch(Routes.channelMessage(modLog, app.log_message_id!), {
+        body: {
+          content,
+          allowedMentions: {},
+        },
+      }),
+    );
+  }).pipe(Effect.catchAll(() => Effect.void));
+
 export const Command = [
   {
     command: {
@@ -255,7 +286,7 @@ export const Command = [
         // Post review message with approve/deny buttons to the mod-log user thread
         const modThread = yield* getOrCreateUserThread(interaction.guild, user);
 
-        yield* Effect.tryPromise(() =>
+        const reviewMsg = (yield* Effect.tryPromise(() =>
           rest.post(Routes.channelMessages(modThread.id), {
             body: {
               flags: MessageFlags.IsComponentsV2,
@@ -292,7 +323,30 @@ export const Command = [
               ],
             },
           }),
+        )) as { id: string };
+
+        // Post summary to mod-log channel with link to the review message
+        const { [SETTINGS.modLog]: modLog } = yield* fetchSettingsEffect(
+          interaction.guild.id,
+          [SETTINGS.modLog],
         );
+        const reviewLink = `https://discord.com/channels/${interaction.guild.id}/${modThread.id}/${reviewMsg.id}`;
+        const logMsg = (yield* Effect.tryPromise(() =>
+          rest.post(Routes.channelMessages(modLog), {
+            body: {
+              content: `<@${user.id}> applied to join — [review application](${reviewLink})`,
+              allowedMentions: {},
+            },
+          }),
+        )) as { id: string };
+
+        // Store the log message ID so we can update it on resolution
+        yield* db
+          .updateTable("applications")
+          .set({ log_message_id: logMsg.id })
+          .where("guild_id", "=", interaction.guild.id)
+          .where("user_id", "=", user.id)
+          .where("status", "=", "pending");
 
         yield* interactionReply(interaction, {
           content:
@@ -383,20 +437,11 @@ export const Command = [
           allowedMentions: {},
         });
 
-        const { [SETTINGS.modLog]: modLog } = yield* fetchSettingsEffect(
-          guildId,
-          [SETTINGS.modLog],
-        );
-
         const appMsgLink = `https://discord.com/channels/${guildId}/${interaction.channelId}/${interaction.message?.id}`;
-
-        yield* Effect.tryPromise(() =>
-          rest.post(Routes.channelMessages(modLog), {
-            body: {
-              content: `<@${applicantUserId}>'s [application](${appMsgLink}) approved by <@${approverId}>`,
-              allowedMentions: {},
-            },
-          }),
+        yield* resolveLogMessage(
+          guildId,
+          applicantUserId,
+          `<@${applicantUserId}>'s [application](${appMsgLink}) approved by <@${approverId}>`,
         );
 
         yield* Effect.tryPromise(() =>
@@ -463,25 +508,23 @@ export const Command = [
           .where("user_id", "=", applicantUserId)
           .where("status", "=", "pending");
 
+        // Kick the applicant
+        yield* Effect.tryPromise(() =>
+          rest.delete(Routes.guildMember(guildId, applicantUserId), {
+            reason: `Application denied by ${denierId}`,
+          }),
+        );
+
         yield* interactionReply(interaction, {
-          content: `<@${applicantUserId}>'s application has been denied by <@${denierId}>.`,
+          content: `<@${applicantUserId}>'s application has been denied by <@${denierId}>. They have been kicked from the server.`,
           allowedMentions: {},
         });
 
-        const { [SETTINGS.modLog]: modLog } = yield* fetchSettingsEffect(
-          guildId,
-          [SETTINGS.modLog],
-        );
-
         const appMsgLink = `https://discord.com/channels/${guildId}/${interaction.channelId}/${interaction.message?.id}`;
-
-        yield* Effect.tryPromise(() =>
-          rest.post(Routes.channelMessages(modLog), {
-            body: {
-              content: `<@${applicantUserId}>'s [application](${appMsgLink}) denied by <@${denierId}>`,
-              allowedMentions: {},
-            },
-          }),
+        yield* resolveLogMessage(
+          guildId,
+          applicantUserId,
+          `<@${applicantUserId}>'s [application](${appMsgLink}) denied by <@${denierId}> (kicked)`,
         );
 
         yield* Effect.tryPromise(() =>
@@ -561,18 +604,10 @@ export const Command = [
             "Your application has been retracted. You can apply again at any time.",
         });
 
-        const { [SETTINGS.modLog]: modLog } = yield* fetchSettingsEffect(
+        yield* resolveLogMessage(
           guildId,
-          [SETTINGS.modLog],
-        );
-
-        yield* Effect.tryPromise(() =>
-          rest.post(Routes.channelMessages(modLog), {
-            body: {
-              content: `<@${applicantUserId}> retracted their application`,
-              allowedMentions: {},
-            },
-          }),
+          applicantUserId,
+          `<@${applicantUserId}> retracted their application`,
         );
 
         yield* Effect.tryPromise(() =>

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -233,6 +233,18 @@ export const Command = [
                     },
                     { type: ComponentType.Separator },
                     ...applicationComponents,
+                    { type: ComponentType.Separator },
+                    {
+                      type: ComponentType.ActionRow,
+                      components: [
+                        {
+                          type: ComponentType.Button,
+                          custom_id: `app-retract||${user.id}`,
+                          label: "Retract Application",
+                          style: ButtonStyle.Secondary,
+                        },
+                      ],
+                    },
                   ],
                 },
               ],
@@ -376,10 +388,12 @@ export const Command = [
           [SETTINGS.modLog],
         );
 
+        const appMsgLink = `https://discord.com/channels/${guildId}/${interaction.channelId}/${interaction.message?.id}`;
+
         yield* Effect.tryPromise(() =>
           rest.post(Routes.channelMessages(modLog), {
             body: {
-              content: `<@${applicantUserId}>'s application approved by <@${approverId}> in <#${interaction.channelId}>`,
+              content: `<@${applicantUserId}>'s [application](${appMsgLink}) approved by <@${approverId}>`,
               allowedMentions: {},
             },
           }),
@@ -459,10 +473,12 @@ export const Command = [
           [SETTINGS.modLog],
         );
 
+        const appMsgLink = `https://discord.com/channels/${guildId}/${interaction.channelId}/${interaction.message?.id}`;
+
         yield* Effect.tryPromise(() =>
           rest.post(Routes.channelMessages(modLog), {
             body: {
-              content: `<@${applicantUserId}>'s application denied by <@${denierId}> in <#${interaction.channelId}>`,
+              content: `<@${applicantUserId}>'s [application](${appMsgLink}) denied by <@${denierId}>`,
               allowedMentions: {},
             },
           }),
@@ -492,6 +508,97 @@ export const Command = [
           }),
         ),
         Effect.withSpan("appDeny", {
+          attributes: {
+            guildId: interaction.guildId,
+            userId: interaction.user.id,
+          },
+        }),
+      ),
+  } satisfies MessageComponentCommand,
+
+  {
+    command: {
+      type: InteractionType.MessageComponent,
+      name: "app-retract",
+    },
+    handler: (interaction) =>
+      Effect.gen(function* () {
+        const [, applicantUserId] = interaction.customId.split("||");
+
+        if (!interaction.guild) {
+          yield* interactionReply(interaction, {
+            content: "Something went wrong",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        // Only the applicant can retract their own application
+        if (interaction.user.id !== applicantUserId) {
+          yield* interactionReply(interaction, {
+            content: "Only the applicant can retract their application.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        const guildId = interaction.guild.id;
+
+        const db = yield* DatabaseService;
+        yield* db
+          .updateTable("applications")
+          .set({
+            status: "retracted",
+            reviewed_by: applicantUserId,
+            resolved_at: new Date().toISOString(),
+          })
+          .where("guild_id", "=", guildId)
+          .where("user_id", "=", applicantUserId)
+          .where("status", "=", "pending");
+
+        yield* interactionReply(interaction, {
+          content:
+            "Your application has been retracted. You can apply again at any time.",
+        });
+
+        const { [SETTINGS.modLog]: modLog } = yield* fetchSettingsEffect(
+          guildId,
+          [SETTINGS.modLog],
+        );
+
+        yield* Effect.tryPromise(() =>
+          rest.post(Routes.channelMessages(modLog), {
+            body: {
+              content: `<@${applicantUserId}> retracted their application`,
+              allowedMentions: {},
+            },
+          }),
+        );
+
+        yield* Effect.tryPromise(() =>
+          rest.patch(Routes.channel(interaction.channelId), {
+            body: { archived: true, locked: true },
+          }),
+        );
+
+        yield* syncChannelName(guildId);
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.gen(function* () {
+            yield* logEffect(
+              "error",
+              "MemberApplication",
+              "Error retracting application",
+              { error },
+            );
+
+            yield* interactionReply(interaction, {
+              content: "Something went wrong while retracting the application",
+              flags: MessageFlags.Ephemeral,
+            }).pipe(Effect.catchAll(() => Effect.void));
+          }),
+        ),
+        Effect.withSpan("appRetract", {
           attributes: {
             guildId: interaction.guildId,
             userId: interaction.user.id,

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -433,9 +433,27 @@ export const Command = [
           .where("status", "=", "pending");
 
         yield* interactionReply(interaction, {
-          content: `<@${applicantUserId}>'s application has been approved by <@${approverId}>. Welcome to the community!`,
+          content: `<@${applicantUserId}>'s application has been approved by <@${approverId}>.`,
           allowedMentions: {},
         });
+
+        // Notify the applicant in their thread
+        const [appRow] = yield* db
+          .selectFrom("applications")
+          .select("thread_id")
+          .where("guild_id", "=", guildId)
+          .where("user_id", "=", applicantUserId)
+          .orderBy("created_at", "desc");
+
+        if (appRow?.thread_id) {
+          yield* Effect.tryPromise(() =>
+            rest.post(Routes.channelMessages(appRow.thread_id), {
+              body: {
+                content: `<@${applicantUserId}>, your application has been approved! Welcome to the community!`,
+              },
+            }),
+          ).pipe(Effect.catchAll(() => Effect.void));
+        }
 
         const appMsgLink = `https://discord.com/channels/${guildId}/${interaction.channelId}/${interaction.message?.id}`;
         yield* resolveLogMessage(
@@ -497,6 +515,39 @@ export const Command = [
         const denierId = interaction.user.id;
 
         const db = yield* DatabaseService;
+
+        // Notify the applicant via DM before kicking, fall back to thread
+        const dmSent = yield* Effect.tryPromise(async () => {
+          const dmChannel = (await rest.post(Routes.userChannels(), {
+            body: { recipient_id: applicantUserId },
+          })) as { id: string };
+          await rest.post(Routes.channelMessages(dmChannel.id), {
+            body: {
+              content: `Your application to **${interaction.guild!.name}** has been denied.`,
+            },
+          });
+          return true;
+        }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+
+        if (!dmSent) {
+          const [denyAppRow] = yield* db
+            .selectFrom("applications")
+            .select("thread_id")
+            .where("guild_id", "=", guildId)
+            .where("user_id", "=", applicantUserId)
+            .where("status", "=", "pending");
+
+          if (denyAppRow?.thread_id) {
+            yield* Effect.tryPromise(() =>
+              rest.post(Routes.channelMessages(denyAppRow.thread_id), {
+                body: {
+                  content: `<@${applicantUserId}>, your application has been denied.`,
+                },
+              }),
+            ).pipe(Effect.catchAll(() => Effect.void));
+          }
+        }
+
         yield* db
           .updateTable("applications")
           .set({

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -28,7 +28,9 @@ interface PendingSetup {
   deletionLogChannel: string | null; // channel ID, CREATE_SENTINEL, or null (disabled)
   honeypotChannel: string | null; // channel ID, CREATE_SENTINEL, or null (disabled)
   ticketChannel: string | null; // channel ID, CREATE_SENTINEL, or null (disabled)
+  applicationChannel: string | null; // channel ID, CREATE_SENTINEL, or null (disabled)
   restrictedRoleId?: string; // undefined = skip
+  memberRoleId?: string; // role ID or undefined
   createdAt: number;
 }
 
@@ -55,7 +57,9 @@ function defaultSetup(): Omit<PendingSetup, "createdAt"> {
     deletionLogChannel: CREATE_SENTINEL,
     honeypotChannel: CREATE_SENTINEL,
     ticketChannel: CREATE_SENTINEL,
+    applicationChannel: null, // disabled by default
     restrictedRoleId: undefined,
+    memberRoleId: undefined,
   };
 }
 
@@ -65,7 +69,9 @@ const FIELD_MAP = {
   deletionLog: "deletionLogChannel",
   honeypot: "honeypotChannel",
   tickets: "ticketChannel",
+  applications: "applicationChannel",
   restrictedRole: "restrictedRoleId",
+  memberRole: "memberRoleId",
 } as const;
 
 type FieldKey = keyof typeof FIELD_MAP;
@@ -82,6 +88,7 @@ const OPTIONAL_CHANNELS = [
   { field: "deletionLog", label: "Deletion Log" },
   { field: "honeypot", label: "Honeypot" },
   { field: "tickets", label: "Tickets" },
+  { field: "applications", label: "Member Applications" },
 ] as const;
 
 function buildFeatureToggleRow(guildId: string, state: PendingSetup) {
@@ -199,14 +206,6 @@ function buildSetupFormMessage(
             content:
               "Select your channels and roles below. Channels left on 'Create new' will be auto-created with sensible defaults.",
           },
-          ...(errorText
-            ? [
-                {
-                  type: ComponentType.TextDisplay,
-                  content: `⚠ ${errorText}`,
-                },
-              ]
-            : []),
           { type: ComponentType.Separator, spacing: 2 },
           {
             type: ComponentType.TextDisplay,
@@ -353,7 +352,42 @@ function buildSetupFormMessage(
             content: "**Enabled features**",
           },
           buildFeatureToggleRow(guildId, state),
+          ...(state.applicationChannel !== null
+            ? [
+                { type: ComponentType.Separator },
+                {
+                  type: ComponentType.TextDisplay,
+                  content:
+                    "**Member Role** — Role granted to approved applicants. All current members will receive this role.",
+                },
+                {
+                  type: ComponentType.ActionRow,
+                  components: [
+                    {
+                      type: ComponentType.RoleSelect,
+                      custom_id: `setup-sel|${guildId}|memberRole`,
+                      placeholder: "Create new @Member role (default)",
+                      ...(state.memberRoleId
+                        ? {
+                            default_values: roleDefaultValues(
+                              state.memberRoleId,
+                            ),
+                          }
+                        : {}),
+                    },
+                  ],
+                },
+              ]
+            : []),
           { type: ComponentType.Separator },
+          ...(errorText
+            ? [
+                {
+                  type: ComponentType.TextDisplay,
+                  content: `⛔ ${errorText}`,
+                },
+              ]
+            : []),
           {
             type: ComponentType.ActionRow,
             components: [
@@ -371,15 +405,71 @@ function buildSetupFormMessage(
   });
 }
 
+function roleValue(roleId: string | undefined): string {
+  return roleId ? `<@&${roleId}>` : "None";
+}
+
 function buildSetupConfirmMessage(guildId: string, state: PendingSetup) {
-  const summaryLines = [
-    `**Moderator Role:** <@&${state.modRoleId}>`,
-    `**Mod Log:** ${channelValue(state.modLogChannel, "mod-log")}`,
-    `**Deletion Log:** ${channelValue(state.deletionLogChannel, "deletion-log")}`,
-    `**Honeypot:** ${channelValue(state.honeypotChannel, "honeypot")}`,
-    `**Ticket Channel:** ${channelValue(state.ticketChannel, "contact-mods")}`,
-    `**Restricted Role:** ${state.restrictedRoleId ? `<@&${state.restrictedRoleId}>` : "None"}`,
+  // --- Configuration summary table ---
+  const configRows = [
+    ["Moderator Role", roleValue(state.modRoleId)],
+    ["Mod Log", channelValue(state.modLogChannel, "mod-log")],
+    ["Deletion Log", channelValue(state.deletionLogChannel, "deletion-log")],
+    ["Honeypot", channelValue(state.honeypotChannel, "honeypot")],
+    ["Tickets", channelValue(state.ticketChannel, "contact-mods")],
+    [
+      "Member Applications",
+      state.applicationChannel !== null
+        ? channelValue(state.applicationChannel, "apply-here")
+        : "Disabled",
+    ],
+    ...(state.applicationChannel !== null
+      ? [
+          [
+            "Member Role",
+            state.memberRoleId
+              ? roleValue(state.memberRoleId)
+              : "Create new @Member",
+          ],
+        ]
+      : []),
+    ["Restricted Role", roleValue(state.restrictedRoleId)],
   ];
+
+  const configList = configRows.map(([k, v]) => `- ${k}: ${v}`).join("\n");
+
+  // --- Delta: what Euno will change on the server ---
+  const adds: string[] = [];
+  const modifies: string[] = [];
+
+  if (state.modLogChannel === CREATE_SENTINEL) adds.push("#mod-log channel");
+  if (state.deletionLogChannel === CREATE_SENTINEL)
+    adds.push("#deletion-log channel");
+  if (state.honeypotChannel === CREATE_SENTINEL) adds.push("#honeypot channel");
+  if (state.ticketChannel === CREATE_SENTINEL)
+    adds.push("#contact-mods channel");
+  if (
+    state.modLogChannel === CREATE_SENTINEL ||
+    state.deletionLogChannel === CREATE_SENTINEL
+  )
+    adds.push("Euno Logs category");
+
+  if (state.applicationChannel !== null) {
+    if (state.applicationChannel === CREATE_SENTINEL)
+      adds.push("#apply-here channel");
+    if (!state.memberRoleId) adds.push("@Member role");
+    modifies.push("@everyone — deny View Channels (server-wide)");
+    modifies.push(
+      `${state.memberRoleId ? roleValue(state.memberRoleId) : "@Member"} — grant View Channels`,
+    );
+    modifies.push("All current members — grant Member role");
+  }
+
+  const deltaLines: string[] = [];
+  if (adds.length > 0)
+    deltaLines.push(`Create:\n${adds.map((a) => `+ ${a}`).join("\n")}`);
+  if (modifies.length > 0)
+    deltaLines.push(`Modify:\n${modifies.map((m) => `~ ${m}`).join("\n")}`);
 
   return v2Update({
     flags: MessageFlags.IsComponentsV2,
@@ -394,13 +484,22 @@ function buildSetupConfirmMessage(guildId: string, state: PendingSetup) {
           {
             type: ComponentType.TextDisplay,
             content:
-              "Review your configuration. Click **Confirm** to apply, or go back to make changes.",
+              "Review your configuration. Click Confirm to apply, or go back to make changes.",
           },
           { type: ComponentType.Separator, spacing: 2 },
           {
             type: ComponentType.TextDisplay,
-            content: summaryLines.join("\n"),
+            content: configList,
           },
+          ...(deltaLines.length > 0
+            ? [
+                { type: ComponentType.Separator },
+                {
+                  type: ComponentType.TextDisplay,
+                  content: `### Changes Euno will make\n${deltaLines.join("\n\n")}`,
+                },
+              ]
+            : []),
           { type: ComponentType.Separator },
           {
             type: ComponentType.ActionRow,
@@ -620,6 +719,11 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
             deletionLogChannel: state.deletionLogChannel ?? undefined,
             honeypotChannel: state.honeypotChannel ?? undefined,
             ticketChannel: state.ticketChannel ?? undefined,
+            applicationChannel: state.applicationChannel ?? undefined,
+            memberRoleId:
+              state.applicationChannel !== null && !state.memberRoleId
+                ? CREATE_SENTINEL
+                : state.memberRoleId,
           }),
         );
 
@@ -655,6 +759,9 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
           result.ticketChannelId
             ? `**Tickets:** <#${result.ticketChannelId}>${result.created.includes("contact-mods") ? " (created)" : ""}`
             : "**Tickets:** Disabled",
+          result.applicationChannelId
+            ? `**Applications:** <#${result.applicationChannelId}>${result.created.includes("apply-here") ? " (created)" : ""}`
+            : "**Applications:** Disabled",
           ...(state.restrictedRoleId
             ? [`**Restricted Role:** <@&${state.restrictedRoleId}>`]
             : []),

--- a/app/db.d.ts
+++ b/app/db.d.ts
@@ -17,6 +17,17 @@ export interface ApplicationConfig {
   role_id: string;
 }
 
+export interface Applications {
+  created_at: string;
+  guild_id: string;
+  id: string;
+  resolved_at: string | null;
+  reviewed_by: string | null;
+  status: Generated<string>;
+  thread_id: string;
+  user_id: string;
+}
+
 export interface ChannelInfo {
   category: string | null;
   category_id: string | null;
@@ -166,6 +177,7 @@ export interface UserThreads {
 
 export interface DB {
   application_config: ApplicationConfig;
+  applications: Applications;
   channel_info: ChannelInfo;
   deletion_log_threads: DeletionLogThreads;
   escalation_records: EscalationRecords;

--- a/app/db.d.ts
+++ b/app/db.d.ts
@@ -21,6 +21,7 @@ export interface Applications {
   created_at: string;
   guild_id: string;
   id: string;
+  log_message_id: string | null;
   resolved_at: string | null;
   reviewed_by: string | null;
   status: Generated<string>;

--- a/app/db.d.ts
+++ b/app/db.d.ts
@@ -23,6 +23,7 @@ export interface Applications {
   id: string;
   log_message_id: string | null;
   resolved_at: string | null;
+  review_message_id: string | null;
   reviewed_by: string | null;
   status: Generated<string>;
   thread_id: string;

--- a/app/db.d.ts
+++ b/app/db.d.ts
@@ -10,6 +10,13 @@ export type Generated<T> =
     ? ColumnType<S, I | undefined, U>
     : ColumnType<T, T | undefined, T>;
 
+export interface ApplicationConfig {
+  channel_id: string;
+  guild_id: string;
+  message_id: string;
+  role_id: string;
+}
+
 export interface ChannelInfo {
   category: string | null;
   category_id: string | null;
@@ -158,6 +165,7 @@ export interface UserThreads {
 }
 
 export interface DB {
+  application_config: ApplicationConfig;
   channel_info: ChannelInfo;
   deletion_log_threads: DeletionLogThreads;
   escalation_records: EscalationRecords;

--- a/app/discord/deployCommands.server.ts
+++ b/app/discord/deployCommands.server.ts
@@ -35,7 +35,7 @@ export const deployCommands = async (client: Client) => {
 
   await (isProd()
     ? deployProdCommands(client, localCommands)
-    : deployTestCommands(client, localCommands));
+    : deployTestCommands(client));
 };
 
 type ChangedCommands = ReturnType<typeof calculateChangedCommands>;
@@ -128,10 +128,7 @@ Global commands ${
   );
 };
 
-export const deployTestCommands = async (
-  client: Client,
-  localCommands: (ContextMenuCommandBuilder | SlashCommandBuilder)[],
-) => {
+export const deployTestCommands = async (client: Client) => {
   // Delete all global commands
   // This shouldn't happen, but ensures a consistent state esp in development
   const globalCommands = (await ssrDiscordSdk.get(
@@ -147,34 +144,43 @@ export const deployTestCommands = async (
   // Deploy directly to all connected guilds
   const guilds = await client.guilds.fetch();
   console.log(`Deploying test commands to ${guilds.size} guilds…`);
-  await Promise.all(
-    guilds.map(async (guild) => {
-      const guildCommands = (await ssrDiscordSdk.get(
-        Routes.applicationGuildCommands(applicationId, guild.id),
-      )) as APIApplicationCommand[];
+  await Promise.all(guilds.map((guild) => deployToGuild(guild.id, guild.name)));
+};
 
-      const changes = calculateChangedCommands(localCommands, guildCommands);
-      console.log(
-        `${guild.name} (${localCommands.length} local): ${
-          changes.didCommandsChange
-            ? `Upserting ${localCommands.length} commands.`
-            : "No command updates."
-        } ${
-          changes.toDelete.length > 0
-            ? `Deleting ${changes.toDelete.join(", ")}`
-            : ""
-        }`,
-      );
-      await applyCommandChanges(
-        localCommands,
-        changes.toDelete,
-        changes.didCommandsChange,
-        guildCommands.length,
-        () => Routes.applicationGuildCommands(applicationId, guild.id),
-        (commandId: string) =>
-          Routes.applicationGuildCommand(applicationId, guild.id, commandId),
-      );
-    }),
+export const deployToGuild = async (guildId: string, guildName?: string) => {
+  const localCommands = [...commands.values()]
+    .filter(
+      (c) =>
+        isSlashCommand(c) ||
+        isUserContextCommand(c) ||
+        isMessageContextCommand(c),
+    )
+    .map(({ command }) => command);
+
+  const guildCommands = (await ssrDiscordSdk.get(
+    Routes.applicationGuildCommands(applicationId, guildId),
+  )) as APIApplicationCommand[];
+
+  const changes = calculateChangedCommands(localCommands, guildCommands);
+  console.log(
+    `${guildName ?? guildId} (${localCommands.length} local): ${
+      changes.didCommandsChange
+        ? `Upserting ${localCommands.length} commands.`
+        : "No command updates."
+    } ${
+      changes.toDelete.length > 0
+        ? `Deleting ${changes.toDelete.join(", ")}`
+        : ""
+    }`,
+  );
+  await applyCommandChanges(
+    localCommands,
+    changes.toDelete,
+    changes.didCommandsChange,
+    guildCommands.length,
+    () => Routes.applicationGuildCommands(applicationId, guildId),
+    (commandId: string) =>
+      Routes.applicationGuildCommand(applicationId, guildId, commandId),
   );
 };
 

--- a/app/discord/onboardGuild.ts
+++ b/app/discord/onboardGuild.ts
@@ -4,8 +4,7 @@ import { botStats } from "#~/helpers/metrics";
 import { retry } from "#~/helpers/misc";
 import { fetchGuild } from "#~/models/guilds.server";
 
-import { client } from "./client.server";
-import { deployCommands } from "./deployCommands.server";
+import { deployToGuild } from "./deployCommands.server";
 
 export default async (bot: Client) => {
   // This is called any time the bot comes online, when a server becomes
@@ -16,7 +15,7 @@ export default async (bot: Client) => {
     if (appGuild) return;
 
     // New installation - deploy commands and send welcome message
-    await deployCommands(client);
+    await deployToGuild(guild.id, guild.name);
 
     const welcomeMessage = `Euno is here! Run \`/setup\` to get started.`;
 

--- a/app/helpers/botPermissions.ts
+++ b/app/helpers/botPermissions.ts
@@ -22,6 +22,7 @@ export const REQUIRED_PERMISSIONS = [
     flag: PermissionFlagsBits.CreatePrivateThreads,
     name: "Create Private Threads",
   },
+  { flag: PermissionFlagsBits.ManageThreads, name: "Manage Threads" },
   { flag: PermissionFlagsBits.ViewAuditLog, name: "View Audit Log" },
 ] as const;
 

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -6,7 +6,9 @@ import {
   PermissionFlagsBits,
   Routes,
   type APIChannel,
+  type APIGuildMember,
   type APIMessage,
+  type APIRole,
   type RESTPostAPIGuildChannelJSONBody,
 } from "discord-api-types/v10";
 
@@ -30,6 +32,8 @@ export interface SetupAllOptions {
   deletionLogChannel?: string; // channel ID, CREATE_SENTINEL, or undefined (disabled)
   honeypotChannel?: string; // channel ID, CREATE_SENTINEL, or undefined (disabled)
   ticketChannel?: string; // channel ID, CREATE_SENTINEL, or undefined (disabled)
+  applicationChannel?: string; // channel ID, CREATE_SENTINEL, or undefined (disabled)
+  memberRoleId?: string; // role ID or undefined
 }
 
 export interface SetupAllResult {
@@ -37,6 +41,8 @@ export interface SetupAllResult {
   deletionLogChannelId: string | undefined;
   honeypotChannelId: string | undefined;
   ticketChannelId: string | undefined;
+  applicationChannelId: string | undefined;
+  memberRoleId: string | undefined;
   created: string[]; // names of channels that were created
 }
 
@@ -91,6 +97,8 @@ export async function setupAll(
     deletionLogChannel,
     honeypotChannel,
     ticketChannel,
+    applicationChannel,
+    memberRoleId,
   } = options;
 
   const created: string[] = [];
@@ -140,6 +148,158 @@ export async function setupAll(
     deletionLogChannelId = deletionLogChannel;
   }
 
+  // --- Member application channel (optional) ---
+  let applicationChannelId: string | undefined;
+  let resolvedMemberRoleId: string | undefined;
+
+  if (applicationChannel !== undefined && memberRoleId !== undefined) {
+    // Step 1: Resolve @member role
+    if (memberRoleId === CREATE_SENTINEL) {
+      const role = (await ssrDiscordSdk.post(Routes.guildRoles(guildId), {
+        body: { name: "Member", permissions: "0" },
+      })) as APIRole;
+      resolvedMemberRoleId = role.id;
+      created.push("Member role");
+    } else {
+      resolvedMemberRoleId = memberRoleId;
+    }
+
+    // Step 2: Fetch current @everyone role permissions
+    const roles = (await ssrDiscordSdk.get(
+      Routes.guildRoles(guildId),
+    )) as APIRole[];
+    const everyoneRole = roles.find((r) => r.id === guildId);
+    const everyonePerms = BigInt(everyoneRole?.permissions ?? "0");
+
+    // Step 3: Fetch current @member role permissions
+    const memberRole = roles.find((r) => r.id === resolvedMemberRoleId);
+    const memberPerms = BigInt(memberRole?.permissions ?? "0");
+
+    // Step 4: Create #apply-here channel (before permission changes so bot still has access)
+    if (applicationChannel === CREATE_SENTINEL) {
+      const botUserId = applicationId;
+      const ch = await createGuildChannel(guildId, {
+        name: "apply-here",
+        type: ChannelType.GuildText,
+        permission_overwrites: [
+          {
+            id: guildId,
+            type: OverwriteType.Role,
+            allow: String(
+              PermissionFlagsBits.ViewChannel |
+                PermissionFlagsBits.ReadMessageHistory,
+            ),
+            deny: String(PermissionFlagsBits.SendMessages),
+          },
+          {
+            id: resolvedMemberRoleId,
+            type: OverwriteType.Role,
+            deny: String(PermissionFlagsBits.ViewChannel),
+          },
+          {
+            id: botUserId,
+            type: OverwriteType.Member,
+            allow: String(
+              PermissionFlagsBits.ViewChannel |
+                PermissionFlagsBits.SendMessages |
+                PermissionFlagsBits.CreatePrivateThreads |
+                PermissionFlagsBits.ManageThreads,
+            ),
+          },
+        ],
+      });
+      applicationChannelId = ch.id;
+      created.push("apply-here");
+    } else {
+      applicationChannelId = applicationChannel;
+    }
+
+    // Step 5: Post "Apply to Join" button
+    const appMessage = await sendChannelMessage(applicationChannelId, {
+      content:
+        "Welcome! To gain access to this server, please submit an application. A moderator will review it shortly.",
+      components: [
+        {
+          type: ComponentType.ActionRow,
+          components: [
+            {
+              type: ComponentType.Button,
+              label: "Apply to Join",
+              style: ButtonStyle.Primary,
+              custom_id: "apply-to-join",
+            },
+          ],
+        },
+      ],
+    });
+
+    // Step 6: Insert into application_config (upsert on re-setup)
+    await run(
+      db
+        .insertInto("application_config")
+        .values({
+          guild_id: guildId,
+          channel_id: applicationChannelId,
+          role_id: resolvedMemberRoleId,
+          message_id: appMessage.id,
+        })
+        .onConflict((c) =>
+          c.column("guild_id").doUpdateSet({
+            channel_id: applicationChannelId,
+            role_id: resolvedMemberRoleId,
+            message_id: appMessage.id,
+          }),
+        ),
+    );
+
+    // Step 7: Bulk-assign @member to all current members (before changing @everyone)
+    let after = "0";
+    while (true) {
+      const members = (await ssrDiscordSdk.get(Routes.guildMembers(guildId), {
+        query: new URLSearchParams({ limit: "1000", after }),
+      })) as APIGuildMember[];
+
+      if (members.length === 0) break;
+
+      for (const member of members) {
+        if (!member.user) continue; // skip partial member objects
+        if (member.user.bot) continue; // skip bots
+        try {
+          await ssrDiscordSdk.put(
+            Routes.guildMemberRole(
+              guildId,
+              member.user.id,
+              resolvedMemberRoleId,
+            ),
+          );
+        } catch {
+          // Member may have left or role hierarchy issue — log and continue
+          log("warn", "setupAll", "Failed to assign member role", {
+            guildId,
+            userId: member.user?.id,
+          });
+        }
+      }
+
+      after = members[members.length - 1].user.id;
+      if (members.length < 1000) break;
+    }
+
+    // Step 8: Deny ViewChannel on @everyone
+    await ssrDiscordSdk.patch(Routes.guildRole(guildId, guildId), {
+      body: {
+        permissions: String(everyonePerms & ~PermissionFlagsBits.ViewChannel),
+      },
+    });
+
+    // Step 9: Grant ViewChannel on @member role
+    await ssrDiscordSdk.patch(Routes.guildRole(guildId, resolvedMemberRoleId), {
+      body: {
+        permissions: String(memberPerms | PermissionFlagsBits.ViewChannel),
+      },
+    });
+  }
+
   // --- Save guild settings ---
   await setSettings(guildId, {
     [SETTINGS.modLog]: modLogChannelId,
@@ -147,6 +307,12 @@ export async function setupAll(
     [SETTINGS.restricted]: restrictedRoleId,
     ...(deletionLogChannelId
       ? { [SETTINGS.deletionLog]: deletionLogChannelId }
+      : {}),
+    ...(resolvedMemberRoleId
+      ? { [SETTINGS.memberRole]: resolvedMemberRoleId }
+      : {}),
+    ...(applicationChannelId
+      ? { [SETTINGS.applicationChannel]: applicationChannelId }
       : {}),
   });
 
@@ -233,6 +399,8 @@ export async function setupAll(
     deletionLogChannelId,
     honeypotChannelId,
     ticketChannelId,
+    applicationChannelId,
+    memberRoleId: resolvedMemberRoleId,
     created,
   };
 }

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -299,11 +299,7 @@ export async function setupAll(
     // Step 9: Grant ViewChannel on @member role
     await ssrDiscordSdk.patch(Routes.guildRole(guildId, resolvedMemberRoleId), {
       body: {
-        permissions: String(
-          memberPerms |
-            PermissionFlagsBits.ViewChannel |
-            PermissionFlagsBits.MentionEveryone,
-        ),
+        permissions: String(memberPerms | PermissionFlagsBits.ViewChannel),
       },
     });
   }

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -288,14 +288,22 @@ export async function setupAll(
     // Step 8: Deny ViewChannel on @everyone
     await ssrDiscordSdk.patch(Routes.guildRole(guildId, guildId), {
       body: {
-        permissions: String(everyonePerms & ~PermissionFlagsBits.ViewChannel),
+        permissions: String(
+          everyonePerms &
+            ~PermissionFlagsBits.ViewChannel &
+            ~PermissionFlagsBits.MentionEveryone,
+        ),
       },
     });
 
     // Step 9: Grant ViewChannel on @member role
     await ssrDiscordSdk.patch(Routes.guildRole(guildId, resolvedMemberRoleId), {
       body: {
-        permissions: String(memberPerms | PermissionFlagsBits.ViewChannel),
+        permissions: String(
+          memberPerms |
+            PermissionFlagsBits.ViewChannel |
+            PermissionFlagsBits.MentionEveryone,
+        ),
       },
     });
   }

--- a/app/models/guilds.server.ts
+++ b/app/models/guilds.server.ts
@@ -13,6 +13,8 @@ export const SETTINGS = {
   restricted: "restricted",
   quorum: "quorum",
   deletionLog: "deletionLog",
+  memberRole: "memberRole",
+  applicationChannel: "applicationChannel",
 } as const;
 
 export const DEFAULT_QUORUM = 3;
@@ -25,6 +27,8 @@ interface SettingsRecord {
   [SETTINGS.restricted]?: string;
   [SETTINGS.quorum]?: number;
   [SETTINGS.deletionLog]?: string;
+  [SETTINGS.memberRole]?: string;
+  [SETTINGS.applicationChannel]?: string;
 }
 
 export const fetchGuild = async (guildId: string) => {

--- a/app/server.ts
+++ b/app/server.ts
@@ -11,6 +11,7 @@ import { createRequestHandler } from "@react-router/express";
 import { Command as checkRequirements } from "#~/commands/checkRequirements";
 import { EscalationCommands } from "#~/commands/escalationControls";
 import { Command as forceBan } from "#~/commands/force-ban";
+import { Command as memberApplications } from "#~/commands/memberApplications";
 import { Command as modreport } from "#~/commands/modreport";
 import { Command as report } from "#~/commands/report";
 import modActionLogger from "#~/commands/report/modActionLogger";
@@ -93,6 +94,7 @@ const startup = Effect.gen(function* () {
     registerCommand(SetupComponentCommands),
     registerCommand(checkRequirements),
     registerCommand(modreport),
+    registerCommand(memberApplications),
   ]);
 
   yield* logEffect("debug", "Server", "initializing Discord bot");

--- a/migrations/20260319000000_application_config.ts
+++ b/migrations/20260319000000_application_config.ts
@@ -1,0 +1,15 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  return db.schema
+    .createTable("application_config")
+    .addColumn("guild_id", "text", (c) => c.primaryKey().notNull())
+    .addColumn("channel_id", "text", (c) => c.notNull())
+    .addColumn("role_id", "text", (c) => c.notNull())
+    .addColumn("message_id", "text", (c) => c.notNull())
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  return db.schema.dropTable("application_config").execute();
+}

--- a/migrations/20260320000000_applications.ts
+++ b/migrations/20260320000000_applications.ts
@@ -1,0 +1,25 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .createTable("applications")
+    .addColumn("id", "text", (c) => c.primaryKey().notNull())
+    .addColumn("guild_id", "text", (c) => c.notNull())
+    .addColumn("user_id", "text", (c) => c.notNull())
+    .addColumn("thread_id", "text", (c) => c.notNull())
+    .addColumn("status", "text", (c) => c.notNull().defaultTo("pending"))
+    .addColumn("reviewed_by", "text")
+    .addColumn("created_at", "text", (c) => c.notNull())
+    .addColumn("resolved_at", "text")
+    .execute();
+
+  await db.schema
+    .createIndex("idx_applications_guild_user_status")
+    .on("applications")
+    .columns(["guild_id", "user_id", "status"])
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  return db.schema.dropTable("applications").execute();
+}

--- a/migrations/20260320100000_applications_log_message.ts
+++ b/migrations/20260320100000_applications_log_message.ts
@@ -1,0 +1,15 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable("applications")
+    .addColumn("log_message_id", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable("applications")
+    .dropColumn("log_message_id")
+    .execute();
+}

--- a/migrations/20260320200000_applications_review_message.ts
+++ b/migrations/20260320200000_applications_review_message.ts
@@ -1,0 +1,15 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable("applications")
+    .addColumn("review_message_id", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await db.schema
+    .alterTable("applications")
+    .dropColumn("review_message_id")
+    .execute();
+}


### PR DESCRIPTION
## Summary

Closes #329. Adds an optional "member applications" mode that gates server access behind a moderator-reviewed application process.

- **Setup integration**: New "Member Applications" toggle in `/setup` wizard. Creates `@Member` role, `#apply-here` channel, denies `@everyone` ViewChannel + MentionEveryone server-wide, bulk-assigns `@Member` to existing members
- **Application flow**: Button in `#apply-here` → modal with 3 questions → private thread for applicant, Components V2 review message with approve/deny buttons in per-user mod-log thread
- **Approve**: Grants `@Member` role, notifies applicant in their thread, updates mod-log summary
- **Deny**: DMs the applicant (falls back to thread), kicks from server, updates mod-log
- **Retract**: Applicant can retract their own application, disables mod buttons while preserving application content
- **Tracking**: `applications` table tracks each submission with status, reviewer, timestamps. Blocks duplicate pending applications. Channel name syncs pending count (e.g. `#apply-here⎸3-pending`)
- **Single mod-log message**: Each application gets one evolving message — "applied to join" on submit, edited to show resolution with link to review thread
- **Deep `/check-requirements`**: Rewritten as Components V2 with 🟢🔵🔴 icons. Verifies channel permissions, button message, @everyone gating, role hierarchy
- **Bot permissions**: Added ManageThreads to required permissions

## Test plan

- [ ] Run `/setup`, enable Member Applications, confirm — verify channel/role/permissions created correctly
- [ ] As a non-member, verify only `#apply-here` is visible
- [ ] Click "Apply to Join", fill modal, submit — verify threads created in both `#apply-here` and mod-log
- [ ] Submit again — verify blocked with "already have a pending application"
- [ ] Click Approve — verify role granted, applicant notified, mod-log updated, thread archived
- [ ] Test Deny flow — verify DM sent, applicant kicked, mod-log updated
- [ ] Test Retract — verify buttons disabled in mod thread, mod-log updated, can re-apply
- [ ] Run `/check-requirements` — verify all application checks pass
- [ ] Verify channel name updates with pending count

🤖 Generated with [Claude Code](https://claude.com/claude-code)