### PR TITLE
fix: guild settings lost due to json_patch on null

### DIFF
--- a/app/models/guilds.server.ts
+++ b/app/models/guilds.server.ts
@@ -83,7 +83,10 @@ export const setSettings = async (
     db
       .updateTable("guilds")
       .set("settings", (eb) =>
-        eb.fn("json_patch", ["settings", eb.val(JSON.stringify(settings))]),
+        eb.fn("json_patch", [
+          eb.fn("coalesce", ["settings", eb.val("{}")]),
+          eb.val(JSON.stringify(settings)),
+        ]),
       )
       .where("id", "=", guildId),
   );

--- a/scripts/fixtures/seed-fixtures.ts
+++ b/scripts/fixtures/seed-fixtures.ts
@@ -50,7 +50,7 @@ export async function seedFixtures(): Promise<void> {
       .insertInto("guilds")
       .values({
         id: guild.id,
-        settings: null,
+        settings: JSON.stringify({}),
       })
       .onConflict((oc) => oc.doNothing())
       .execute();

--- a/scripts/seed-e2e.ts
+++ b/scripts/seed-e2e.ts
@@ -68,7 +68,7 @@ async function seed() {
   // Create free guild with subscription
   await db
     .insertInto("guilds")
-    .values({ id: TEST_GUILD_FREE_ID, settings: null })
+    .values({ id: TEST_GUILD_FREE_ID, settings: JSON.stringify({}) })
     .onConflict((oc) => oc.doNothing())
     .execute();
 
@@ -90,7 +90,7 @@ async function seed() {
   // Create paid guild with subscription
   await db
     .insertInto("guilds")
-    .values({ id: TEST_GUILD_PAID_ID, settings: null })
+    .values({ id: TEST_GUILD_PAID_ID, settings: JSON.stringify({}) })
     .onConflict((oc) => oc.doNothing())
     .execute();
 

--- a/tests/e2e/fixtures/db.ts
+++ b/tests/e2e/fixtures/db.ts
@@ -85,7 +85,7 @@ export class DbFixture {
       .insertInto("guilds")
       .values({
         id: guildId,
-        settings: null,
+        settings: JSON.stringify({}),
       })
       .execute();
 


### PR DESCRIPTION
setSettings used json_patch(settings, ...) which returns NULL when settings is NULL. Coalesce to '{}' so patches always apply. Also fix all fixture/seed scripts that inserted guilds with null settings — no production code path creates null settings, only test fixtures did.