### PR TITLE
RC fixes: setup persistence, permissions, applications, automod

### DIFF
--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -15,6 +15,7 @@ import { ssrDiscordSdk as rest } from "#~/discord/api";
 import { fetchChannel, interactionReply } from "#~/effects/discordSdk.ts";
 import { logEffect } from "#~/effects/observability.ts";
 import {
+  hasModRole,
   quoteMessageContent,
   type MessageComponentCommand,
   type ModalCommand,
@@ -403,6 +404,19 @@ export const Command = [
         const guildId = interaction.guild.id;
         const approverId = interaction.user.id;
 
+        // Verify the user has the moderator role
+        const { [SETTINGS.moderator]: modRoleId } = yield* fetchSettingsEffect(
+          guildId,
+          [SETTINGS.moderator],
+        );
+        if (!hasModRole(interaction, modRoleId)) {
+          yield* interactionReply(interaction, {
+            content: "Only moderators can approve applications.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
         const db = yield* DatabaseService;
         const configRows = yield* db
           .selectFrom("application_config")
@@ -523,6 +537,17 @@ export const Command = [
 
         const guildId = interaction.guild.id;
         const denierId = interaction.user.id;
+
+        // Verify the user has the moderator role
+        const { [SETTINGS.moderator]: denyModRoleId } =
+          yield* fetchSettingsEffect(guildId, [SETTINGS.moderator]);
+        if (!hasModRole(interaction, denyModRoleId)) {
+          yield* interactionReply(interaction, {
+            content: "Only moderators can deny applications.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
 
         const db = yield* DatabaseService;
 

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -469,7 +469,20 @@ export const Command = [
           allowedMentions: {},
         });
 
-        if (appRow?.thread_id) {
+        // Notify the applicant via DM, fall back to their application thread
+        const dmSent = yield* Effect.tryPromise(async () => {
+          const dmChannel = (await rest.post(Routes.userChannels(), {
+            body: { recipient_id: applicantUserId },
+          })) as { id: string };
+          await rest.post(Routes.channelMessages(dmChannel.id), {
+            body: {
+              content: `Your application to **${interaction.guild!.name}** has been approved! Welcome to the community!`,
+            },
+          });
+          return true;
+        }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+
+        if (!dmSent && appRow?.thread_id) {
           yield* Effect.tryPromise(() =>
             rest.post(Routes.channelMessages(appRow.thread_id), {
               body: {

--- a/app/commands/report/modActionLog.ts
+++ b/app/commands/report/modActionLog.ts
@@ -23,6 +23,7 @@ export type ModActionReport =
       executor: User | PartialUser | null;
       reason: string;
       duration: string;
+      isAutomod?: boolean;
     }
   | {
       guild: Guild;
@@ -78,11 +79,18 @@ export const logModAction = (report: ModActionReport) =>
       left: "left",
     };
     const actionLabel = actionLabels[actionType];
+    const isAutomod = "isAutomod" in report && report.isAutomod === true;
     const executorMention = executor
       ? ` by <@${executor.id}> (${executor.username})`
-      : " by unknown";
+      : isAutomod
+        ? " by AutoMod"
+        : " by unknown";
 
-    const reasonText = reason ? ` ${reason}` : " for no reason";
+    const reasonText = reason
+      ? ` ${reason}`
+      : isAutomod
+        ? ""
+        : " for no reason";
     const durationText =
       actionType === "timeout" ? ` for ${report.duration}` : "";
 

--- a/app/commands/report/modActionLogger.ts
+++ b/app/commands/report/modActionLogger.ts
@@ -263,7 +263,8 @@ const memberUpdateEffect = (
       },
     );
 
-    const entry = yield* fetchAuditLogEntry(
+    // Look for a manual timeout first (MemberUpdate audit log)
+    let entry = yield* fetchAuditLogEntry(
       guild,
       user.id,
       AuditLogEvent.MemberUpdate,
@@ -279,7 +280,29 @@ const memberUpdateEffect = (
         }),
     );
 
-    const executor = entry?.executor ?? null;
+    // Fall back to automod timeout if no manual entry found
+    let isAutomod = false;
+    if (!entry && isTimeoutApplied) {
+      const automodEntry = yield* fetchAuditLogEntry(
+        guild,
+        user.id,
+        AuditLogEvent.AutoModerationUserCommunicationDisabled,
+        (entries) =>
+          entries.find((e) => {
+            if (e.targetId !== user.id) return false;
+            if (Date.now() - e.createdTimestamp >= AUDIT_LOG_WINDOW_MS)
+              return false;
+            return true;
+          }),
+      );
+      if (automodEntry) {
+        isAutomod = true;
+        entry = automodEntry;
+      }
+    }
+
+    // For automod, the executor is the rule creator (misleading), so use null
+    const executor = isAutomod ? null : (entry?.executor ?? null);
     const reason = entry?.reason ?? "";
 
     // Skip if the bot performed this action (it's already logged elsewhere)
@@ -299,6 +322,7 @@ const memberUpdateEffect = (
         executor,
         reason,
         duration: duration!,
+        isAutomod,
       });
     } else {
       yield* logModAction({

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -18,6 +18,10 @@ import { logEffect } from "#~/effects/observability";
 import type { MessageComponentCommand } from "#~/helpers/discord";
 import { commandStats } from "#~/helpers/metrics";
 import { CREATE_SENTINEL, setupAll } from "#~/helpers/setupAll.server.ts";
+import {
+  checkSetupPermissions,
+  type SetupPermissionCheckResult,
+} from "#~/helpers/setupPermissionCheck";
 import { fetchGuild } from "#~/models/guilds.server";
 
 // --- State management ---
@@ -409,7 +413,42 @@ function roleValue(roleId: string | undefined): string {
   return roleId ? `<@&${roleId}>` : "None";
 }
 
-function buildSetupConfirmMessage(guildId: string, state: PendingSetup) {
+function buildPermWarnings(permCheck?: SetupPermissionCheckResult) {
+  if (!permCheck) return [];
+
+  const lines: string[] = [];
+
+  if (permCheck.missingGuildPerms.length > 0) {
+    lines.push(
+      `**Missing server permissions:** ${permCheck.missingGuildPerms.join(", ")}`,
+    );
+  }
+
+  for (const issue of permCheck.channelIssues) {
+    lines.push(`**${issue.label}:** missing ${issue.missing.join(", ")}`);
+  }
+
+  if (lines.length === 0) return [];
+
+  const icon = permCheck.hasHardBlock ? "⛔" : "⚠️";
+  const heading = permCheck.hasHardBlock
+    ? `### ${icon} Permission Issues (must fix before confirming)`
+    : `### ${icon} Permission Warnings`;
+
+  return [
+    { type: ComponentType.Separator },
+    {
+      type: ComponentType.TextDisplay,
+      content: `${heading}\n${lines.map((l) => `- ${l}`).join("\n")}`,
+    },
+  ];
+}
+
+function buildSetupConfirmMessage(
+  guildId: string,
+  state: PendingSetup,
+  permCheck?: SetupPermissionCheckResult,
+) {
   // --- Configuration summary table ---
   const configRows = [
     ["Moderator Role", roleValue(state.modRoleId)],
@@ -500,6 +539,7 @@ function buildSetupConfirmMessage(guildId: string, state: PendingSetup) {
                 },
               ]
             : []),
+          ...buildPermWarnings(permCheck),
           { type: ComponentType.Separator },
           {
             type: ComponentType.ActionRow,
@@ -515,6 +555,7 @@ function buildSetupConfirmMessage(guildId: string, state: PendingSetup) {
                 custom_id: `setup-exec|${guildId}`,
                 label: "Confirm ✓",
                 style: ButtonStyle.Primary,
+                ...(permCheck?.hasHardBlock ? { disabled: true } : {}),
               },
             ],
           },
@@ -629,9 +670,19 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
           return;
         }
 
+        const guild = interaction.guild;
+        const botMember = guild?.members.me;
+        let permCheck: SetupPermissionCheckResult | undefined;
+
+        if (guild && botMember) {
+          permCheck = yield* Effect.tryPromise(() =>
+            checkSetupPermissions(guild, botMember, state),
+          );
+        }
+
         yield* interactionUpdate(
           interaction,
-          buildSetupConfirmMessage(guildId, state),
+          buildSetupConfirmMessage(guildId, state, permCheck),
         );
       }).pipe(
         Effect.catchAll((error) =>

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -213,7 +213,8 @@ function buildSetupFormMessage(
           { type: ComponentType.Separator, spacing: 2 },
           {
             type: ComponentType.TextDisplay,
-            content: "**Moderator Role** *(required)*",
+            content:
+              "**Moderator Role** *(required)*\n**Mod Log** — Moderation actions and reports, visible only to mods",
           },
           {
             type: ComponentType.ActionRow,
@@ -227,12 +228,6 @@ function buildSetupFormMessage(
                   : {}),
               },
             ],
-          },
-          { type: ComponentType.Separator },
-          {
-            type: ComponentType.TextDisplay,
-            content:
-              "**Mod Log** — Moderation actions and reports. Visible only to moderators.",
           },
           {
             type: ComponentType.ActionRow,
@@ -250,10 +245,11 @@ function buildSetupFormMessage(
               },
             ],
           },
+          { type: ComponentType.Separator },
           {
             type: ComponentType.TextDisplay,
             content:
-              "**Deletion Log** — Captures deleted messages. Visible only to moderators.",
+              "**Deletion Log** — Captures deleted messages\n**Honeypot** — Trap channel; bots that post here are auto-banned\n**Ticket Channel** — Where members open private tickets\n**Restricted Role** *(optional)* — Assigned to muted/restricted members",
           },
           {
             type: ComponentType.ActionRow,
@@ -278,11 +274,6 @@ function buildSetupFormMessage(
             ],
           },
           {
-            type: ComponentType.TextDisplay,
-            content:
-              "**Honeypot** — Trap channel placed at top of channel list. Bots that post here are auto-banned.",
-          },
-          {
             type: ComponentType.ActionRow,
             components: [
               {
@@ -305,11 +296,6 @@ function buildSetupFormMessage(
             ],
           },
           {
-            type: ComponentType.TextDisplay,
-            content:
-              "**Ticket Channel** — Where members open private tickets with moderators.",
-          },
-          {
             type: ComponentType.ActionRow,
             components: [
               {
@@ -328,12 +314,6 @@ function buildSetupFormMessage(
                   : {}),
               },
             ],
-          },
-          { type: ComponentType.Separator },
-          {
-            type: ComponentType.TextDisplay,
-            content:
-              "**Restricted Role** *(optional)* — Role assigned to muted or restricted members.",
           },
           {
             type: ComponentType.ActionRow,
@@ -358,11 +338,28 @@ function buildSetupFormMessage(
           buildFeatureToggleRow(guildId, state),
           ...(state.applicationChannel !== null
             ? [
-                { type: ComponentType.Separator },
                 {
                   type: ComponentType.TextDisplay,
                   content:
-                    "**Member Role** — Role granted to approved applicants. All current members will receive this role.",
+                    "**Application Channel** — Where members submit applications\n**Member Role** — Granted to approved applicants; all current members will receive this role",
+                },
+                {
+                  type: ComponentType.ActionRow,
+                  components: [
+                    {
+                      type: ComponentType.ChannelSelect,
+                      custom_id: `setup-sel|${guildId}|applications`,
+                      placeholder: "Create new #apply-here (default)",
+                      channel_types: [ChannelType.GuildText],
+                      ...(channelDefaultValues(state.applicationChannel)
+                        ? {
+                            default_values: channelDefaultValues(
+                              state.applicationChannel,
+                            ),
+                          }
+                        : {}),
+                    },
+                  ],
                 },
                 {
                   type: ComponentType.ActionRow,

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -756,6 +756,7 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
           return;
         }
 
+        pendingSetups.delete(key);
         yield* interactionDeferUpdate(interaction);
 
         const result = yield* Effect.tryPromise(() =>
@@ -774,9 +775,6 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
                 : state.memberRoleId,
           }),
         );
-
-        // Clean up state
-        pendingSetups.delete(key);
 
         yield* logEffect(
           "info",

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -252,56 +252,77 @@ export async function setupAll(
         ),
     );
 
-    // Step 7: Bulk-assign @member to all current members (before changing @everyone)
-    let after = "0";
-    while (true) {
-      const members = (await ssrDiscordSdk.get(Routes.guildMembers(guildId), {
-        query: new URLSearchParams({ limit: "1000", after }),
-      })) as APIGuildMember[];
+    // Steps 7–9: Bulk-assign @member role then update permissions.
+    // This runs in the background so setup returns immediately.
+    const bulkRoleId = resolvedMemberRoleId;
+    log("info", "setupAll", "Starting background member-role assignment", {
+      guildId,
+    });
+    void (async () => {
+      try {
+        // Step 7: Bulk-assign @member to all current members (before changing @everyone)
+        let after = "0";
+        let assigned = 0;
+        while (true) {
+          const members = (await ssrDiscordSdk.get(
+            Routes.guildMembers(guildId),
+            {
+              query: new URLSearchParams({ limit: "1000", after }),
+            },
+          )) as APIGuildMember[];
 
-      if (members.length === 0) break;
+          if (members.length === 0) break;
 
-      for (const member of members) {
-        if (!member.user) continue; // skip partial member objects
-        if (member.user.bot) continue; // skip bots
-        try {
-          await ssrDiscordSdk.put(
-            Routes.guildMemberRole(
-              guildId,
-              member.user.id,
-              resolvedMemberRoleId,
-            ),
-          );
-        } catch {
-          // Member may have left or role hierarchy issue — log and continue
-          log("warn", "setupAll", "Failed to assign member role", {
-            guildId,
-            userId: member.user?.id,
-          });
+          for (const member of members) {
+            if (!member.user) continue; // skip partial member objects
+            if (member.user.bot) continue; // skip bots
+            try {
+              await ssrDiscordSdk.put(
+                Routes.guildMemberRole(guildId, member.user.id, bulkRoleId),
+              );
+              assigned++;
+            } catch {
+              // Member may have left or role hierarchy issue — log and continue
+              log("warn", "setupAll", "Failed to assign member role", {
+                guildId,
+                userId: member.user?.id,
+              });
+            }
+          }
+
+          after = members[members.length - 1].user.id;
+          if (members.length < 1000) break;
         }
+
+        // Step 8: Deny ViewChannel on @everyone
+        await ssrDiscordSdk.patch(Routes.guildRole(guildId, guildId), {
+          body: {
+            permissions: String(
+              everyonePerms &
+                ~PermissionFlagsBits.ViewChannel &
+                ~PermissionFlagsBits.MentionEveryone,
+            ),
+          },
+        });
+
+        // Step 9: Grant ViewChannel on @member role
+        await ssrDiscordSdk.patch(Routes.guildRole(guildId, bulkRoleId), {
+          body: {
+            permissions: String(memberPerms | PermissionFlagsBits.ViewChannel),
+          },
+        });
+
+        log("info", "setupAll", "Background member-role assignment complete", {
+          guildId,
+          assigned,
+        });
+      } catch (err) {
+        log("error", "setupAll", "Background member-role assignment failed", {
+          guildId,
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
-
-      after = members[members.length - 1].user.id;
-      if (members.length < 1000) break;
-    }
-
-    // Step 8: Deny ViewChannel on @everyone
-    await ssrDiscordSdk.patch(Routes.guildRole(guildId, guildId), {
-      body: {
-        permissions: String(
-          everyonePerms &
-            ~PermissionFlagsBits.ViewChannel &
-            ~PermissionFlagsBits.MentionEveryone,
-        ),
-      },
-    });
-
-    // Step 9: Grant ViewChannel on @member role
-    await ssrDiscordSdk.patch(Routes.guildRole(guildId, resolvedMemberRoleId), {
-      body: {
-        permissions: String(memberPerms | PermissionFlagsBits.ViewChannel),
-      },
-    });
+    })();
   }
 
   // --- Save guild settings ---

--- a/app/helpers/setupPermissionCheck.ts
+++ b/app/helpers/setupPermissionCheck.ts
@@ -1,0 +1,110 @@
+import { PermissionFlagsBits, type Guild, type GuildMember } from "discord.js";
+
+import { REQUIRED_PERMISSIONS } from "#~/helpers/botPermissions";
+import { CREATE_SENTINEL } from "#~/helpers/setupAll.server";
+
+export interface ChannelPermissionIssue {
+  channelId: string;
+  label: string;
+  missing: string[];
+  isHardBlock: boolean;
+}
+
+export interface SetupPermissionCheckResult {
+  missingGuildPerms: string[];
+  channelIssues: ChannelPermissionIssue[];
+  hasHardBlock: boolean;
+}
+
+interface SetupState {
+  modLogChannel: string;
+  deletionLogChannel: string | null;
+  honeypotChannel: string | null;
+  ticketChannel: string | null;
+  applicationChannel: string | null;
+}
+
+const CHANNEL_SLOTS: {
+  key: keyof SetupState;
+  label: string;
+}[] = [
+  { key: "modLogChannel", label: "Mod Log" },
+  { key: "deletionLogChannel", label: "Deletion Log" },
+  { key: "honeypotChannel", label: "Honeypot" },
+  { key: "ticketChannel", label: "Ticket Channel" },
+  { key: "applicationChannel", label: "Application Channel" },
+];
+
+export async function checkSetupPermissions(
+  guild: Guild,
+  botMember: GuildMember,
+  state: SetupState,
+): Promise<SetupPermissionCheckResult> {
+  try {
+    // Check guild-level permissions
+    const missingGuildPerms = REQUIRED_PERMISSIONS.filter(
+      ({ flag }) => !botMember.permissions.has(flag),
+    ).map(({ name }) => name);
+
+    const channelIssues: ChannelPermissionIssue[] = [];
+
+    // Check each channel slot
+    for (const { key, label } of CHANNEL_SLOTS) {
+      const value = state[key];
+      // Skip null (disabled) and CREATE_SENTINEL (bot creates it, so permissions are fine)
+      if (value === null || value === CREATE_SENTINEL) continue;
+
+      try {
+        const channel = await guild.channels.fetch(value);
+        if (!channel) {
+          channelIssues.push({
+            channelId: value,
+            label,
+            missing: ["Channel not found"],
+            isHardBlock: true,
+          });
+          continue;
+        }
+
+        if (!("permissionsFor" in channel)) continue;
+
+        const perms = channel.permissionsFor(botMember);
+        const missing: string[] = [];
+        let isHardBlock = false;
+
+        if (!perms.has(PermissionFlagsBits.ViewChannel)) {
+          missing.push("View Channels");
+          isHardBlock = true;
+        }
+        if (!perms.has(PermissionFlagsBits.SendMessages)) {
+          missing.push("Send Messages");
+          isHardBlock = true;
+        }
+
+        if (missing.length > 0) {
+          channelIssues.push({
+            channelId: value,
+            label,
+            missing,
+            isHardBlock,
+          });
+        }
+      } catch {
+        channelIssues.push({
+          channelId: value,
+          label,
+          missing: ["Channel not found"],
+          isHardBlock: true,
+        });
+      }
+    }
+
+    const hasHardBlock =
+      missingGuildPerms.length > 0 || channelIssues.some((i) => i.isHardBlock);
+
+    return { missingGuildPerms, channelIssues, hasHardBlock };
+  } catch {
+    // Never throw — return a clean pass on unexpected errors
+    return { missingGuildPerms: [], channelIssues: [], hasHardBlock: false };
+  }
+}

--- a/app/models/guilds.server.ts
+++ b/app/models/guilds.server.ts
@@ -83,7 +83,10 @@ export const setSettings = async (
     db
       .updateTable("guilds")
       .set("settings", (eb) =>
-        eb.fn("json_patch", ["settings", eb.val(JSON.stringify(settings))]),
+        eb.fn("json_patch", [
+          eb.fn("coalesce", ["settings", eb.val("{}")]),
+          eb.val(JSON.stringify(settings)),
+        ]),
       )
       .where("id", "=", guildId),
   );

--- a/scripts/fixtures/seed-fixtures.ts
+++ b/scripts/fixtures/seed-fixtures.ts
@@ -50,7 +50,7 @@ export async function seedFixtures(): Promise<void> {
       .insertInto("guilds")
       .values({
         id: guild.id,
-        settings: null,
+        settings: JSON.stringify({}),
       })
       .onConflict((oc) => oc.doNothing())
       .execute();

--- a/scripts/seed-e2e.ts
+++ b/scripts/seed-e2e.ts
@@ -68,7 +68,7 @@ async function seed() {
   // Create free guild with subscription
   await db
     .insertInto("guilds")
-    .values({ id: TEST_GUILD_FREE_ID, settings: null })
+    .values({ id: TEST_GUILD_FREE_ID, settings: JSON.stringify({}) })
     .onConflict((oc) => oc.doNothing())
     .execute();
 
@@ -90,7 +90,7 @@ async function seed() {
   // Create paid guild with subscription
   await db
     .insertInto("guilds")
-    .values({ id: TEST_GUILD_PAID_ID, settings: null })
+    .values({ id: TEST_GUILD_PAID_ID, settings: JSON.stringify({}) })
     .onConflict((oc) => oc.doNothing())
     .execute();
 

--- a/tests/e2e/fixtures/db.ts
+++ b/tests/e2e/fixtures/db.ts
@@ -85,7 +85,7 @@ export class DbFixture {
       .insertInto("guilds")
       .values({
         id: guildId,
-        settings: null,
+        settings: JSON.stringify({}),
       })
       .execute();
 


### PR DESCRIPTION
## Summary

Bug fixes and improvements found during acceptance testing of the v2026.11 RC.

- **fix: guild settings lost due to json_patch on null** — `setSettings` used `json_patch(NULL, ...)` which silently discards settings. Coalesce to `'{}'`. Also fix all fixture scripts that seeded guilds with null settings.
- **feat: pre-flight permission check on /setup confirmation** — Verify bot has ViewChannel + SendMessages in user-selected channels before confirming. Hard blocks disable the Confirm button.
- **feat: application channel selector in /setup** — Users can now pick an existing channel for applications instead of always creating #apply-here. Consolidated form layout to stay under Discord's 40-component limit.
- **fix: attribute automod timeouts** — Fall back to `AutoModerationUserCommunicationDisabled` audit log entries when `MemberUpdate` lookup fails, displaying "by AutoMod" instead of "by unknown for no reason".
- **fix: require moderator role for approve/deny** — Application approve and deny buttons were missing authorization checks.
- **fix: prevent double-execution of setup-exec** — Delete pending state immediately on confirm click so a second click gets the expired message.
- **perf: background bulk member-role assignment** — Move the bulk role assignment loop to fire-and-forget so setup returns immediately instead of blocking ~27 seconds.
- **fix: DM applicant on approval** — Attempt DM first, fall back to application thread (matching the deny handler pattern).

## Test plan

- [ ] `/setup` pre-populates with existing settings (including applicationChannel and memberRole)
- [ ] `/setup` confirmation shows permission warnings for inaccessible channels
- [ ] `/setup` with applications enabled shows channel picker
- [ ] `/setup` confirm button can't be double-clicked
- [ ] Setup completes quickly; role assignment finishes in background
- [ ] Application approve/deny requires moderator role
- [ ] Approved applicants receive a DM (or thread message if DMs closed)
- [ ] AutoMod timeouts show "by AutoMod" in mod log

🤖 Generated with [Claude Code](https://claude.com/claude-code)