### PR TITLE
Manual membership gate activation with progress tracking

### DIFF
--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -1,4 +1,9 @@
-import { ButtonStyle, Routes, TextInputStyle } from "discord-api-types/v10";
+import {
+  ButtonStyle,
+  Routes,
+  TextInputStyle,
+  type APIRole,
+} from "discord-api-types/v10";
 import {
   ActionRowBuilder,
   ChannelType,
@@ -6,13 +11,19 @@ import {
   InteractionType,
   MessageFlags,
   ModalBuilder,
+  PermissionFlagsBits,
   TextInputBuilder,
 } from "discord.js";
 import { Effect } from "effect";
 
 import { DatabaseService } from "#~/Database.ts";
 import { ssrDiscordSdk as rest } from "#~/discord/api";
-import { fetchChannel, interactionReply } from "#~/effects/discordSdk.ts";
+import {
+  fetchChannel,
+  interactionReply,
+  interactionUpdate,
+} from "#~/effects/discordSdk.ts";
+import { DiscordApiError } from "#~/effects/errors.ts";
 import { logEffect } from "#~/effects/observability.ts";
 import {
   hasModRole,
@@ -20,6 +31,7 @@ import {
   type MessageComponentCommand,
   type ModalCommand,
 } from "#~/helpers/discord";
+import { activateMembershipGateEffect } from "#~/jobs/bulkRoleAssignment";
 import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
 import { getOrCreateUserThread } from "#~/models/userThreads";
 
@@ -799,6 +811,143 @@ export const Command = [
           }),
         ),
         Effect.withSpan("appRetract", {
+          attributes: {
+            guildId: interaction.guildId,
+            userId: interaction.user.id,
+          },
+        }),
+      ),
+  } satisfies MessageComponentCommand,
+
+  {
+    command: {
+      type: InteractionType.MessageComponent,
+      name: "activate-gate",
+    },
+    handler: (interaction) =>
+      Effect.gen(function* () {
+        const [, guildId] = interaction.customId.split("|");
+
+        if (!interaction.guild || !interaction.member) {
+          yield* interactionReply(interaction, {
+            content: "Something went wrong",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        // Verify the user has the moderator role
+        const { [SETTINGS.moderator]: modRoleId } = yield* fetchSettingsEffect(
+          guildId,
+          [SETTINGS.moderator],
+        );
+        if (!hasModRole(interaction, modRoleId)) {
+          yield* interactionReply(interaction, {
+            content: "Only moderators can activate the membership gate.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        // Load application_config to get role_id
+        const db = yield* DatabaseService;
+        const [config] = yield* db
+          .selectFrom("application_config")
+          .selectAll()
+          .where("guild_id", "=", guildId);
+
+        if (!config) {
+          yield* interactionReply(interaction, {
+            content:
+              "Application config not found. Re-run `/setup` to configure.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        // Fetch current role permissions from Discord API
+        const roles = (yield* Effect.tryPromise({
+          try: () => rest.get(Routes.guildRoles(guildId)),
+          catch: (error) =>
+            new DiscordApiError({ operation: "fetchGuildRoles", cause: error }),
+        })) as APIRole[];
+
+        const everyoneRole = roles.find((r) => r.id === guildId);
+        const memberRole = roles.find((r) => r.id === config.role_id);
+
+        if (!everyoneRole || !memberRole) {
+          yield* interactionReply(interaction, {
+            content:
+              "Could not find required roles. Re-run `/setup` to configure.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
+        // Idempotency check: if @everyone already has ViewChannel denied, gate is active
+        const everyonePerms = BigInt(everyoneRole.permissions);
+        if ((everyonePerms & PermissionFlagsBits.ViewChannel) === 0n) {
+          yield* interactionUpdate(interaction, {
+            flags: MessageFlags.IsComponentsV2,
+            components: [
+              {
+                type: ComponentType.Container,
+                accent_color: 0x57f287, // green
+                components: [
+                  {
+                    type: ComponentType.TextDisplay,
+                    content: `## Membership gate is active\n\nThe membership gate was already activated.`,
+                  },
+                ],
+              },
+            ],
+          });
+          return;
+        }
+
+        // Run the gate activation
+        yield* activateMembershipGateEffect({
+          guildId,
+          roleId: config.role_id,
+          everyonePermissions: everyoneRole.permissions,
+          memberPermissions: memberRole.permissions,
+        });
+
+        // On success: replace the message with confirmation
+        yield* interactionUpdate(interaction, {
+          flags: MessageFlags.IsComponentsV2,
+          components: [
+            {
+              type: ComponentType.Container,
+              accent_color: 0x57f287, // green
+              components: [
+                {
+                  type: ComponentType.TextDisplay,
+                  content: `## Membership gate activated\n\nThe membership gate has been activated by <@${interaction.user.id}>. New members will only see the application channel until approved.`,
+                },
+              ],
+            },
+          ],
+        });
+      }).pipe(
+        Effect.catchAll((error) =>
+          Effect.gen(function* () {
+            yield* logEffect(
+              "error",
+              "MembershipGate",
+              "Failed to activate gate",
+              {
+                guildId: interaction.guildId,
+                error: String(error),
+              },
+            );
+            yield* interactionReply(interaction, {
+              content: `Gate activation failed: ${String(error)}\n\nThe button is still active — you can try again.`,
+              flags: MessageFlags.Ephemeral,
+            }).pipe(Effect.catchAll(() => Effect.void));
+          }),
+        ),
+        Effect.withSpan("activateGate", {
           attributes: {
             guildId: interaction.guildId,
             userId: interaction.user.id,

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -1,5 +1,7 @@
 import {
   ButtonStyle,
+  OverwriteType,
+  PermissionFlagsBits,
   Routes,
   TextInputStyle,
   type APIRole,
@@ -11,7 +13,6 @@ import {
   InteractionType,
   MessageFlags,
   ModalBuilder,
-  PermissionFlagsBits,
   TextInputBuilder,
 } from "discord.js";
 import { Effect } from "effect";
@@ -913,6 +914,30 @@ export const Command = [
           memberPermissions: memberRole.permissions,
         });
 
+        // Reveal #apply-here to @everyone now that the gate is active
+        yield* Effect.tryPromise({
+          try: () =>
+            rest.put(Routes.channelPermission(config.channel_id, guildId), {
+              body: {
+                type: OverwriteType.Role,
+                allow: String(
+                  PermissionFlagsBits.ViewChannel |
+                    PermissionFlagsBits.ReadMessageHistory,
+                ),
+                deny: String(
+                  PermissionFlagsBits.SendMessages |
+                    PermissionFlagsBits.CreatePublicThreads |
+                    PermissionFlagsBits.CreatePrivateThreads,
+                ),
+              },
+            }),
+          catch: (error) =>
+            new DiscordApiError({
+              operation: "revealApplyHere",
+              cause: error,
+            }),
+        });
+
         // On success: replace the message with confirmation
         yield* interactionUpdate(interaction, {
           flags: MessageFlags.IsComponentsV2,
@@ -942,7 +967,8 @@ export const Command = [
               },
             );
             yield* interactionReply(interaction, {
-              content: `Gate activation failed: ${String(error)}\n\nThe button is still active — you can try again.`,
+              content:
+                "Gate activation failed. The button is still active — you can try again.",
               flags: MessageFlags.Ephemeral,
             }).pipe(Effect.catchAll(() => Effect.void));
           }),

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -854,7 +854,12 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
                   {
                     type: ComponentType.TextDisplay,
                     content: isAsyncSetup
-                      ? `Created channels and roles. Now assigning the Member role to all existing members — this can take several hours for large servers.\n\nYou'll be notified in <#${result.modLogChannelId}> when the role assignment is complete. From there, you can activate the membership gate.`
+                      ? `Created channels and roles. The following will happen automatically:\n\n` +
+                        `1. The **Member** role is being assigned to all existing members. This can take several hours for large servers.\n` +
+                        `2. Progress updates will be posted to <#${result.modLogChannelId}> every 30 minutes.\n` +
+                        `3. When complete, a button will appear in <#${result.modLogChannelId}> to activate the membership gate.\n` +
+                        `4. The **#apply-here** channel is hidden until you activate the gate.\n\n` +
+                        `Until the gate is activated, the server will continue to work normally.`
                       : "All channels and features have been configured. Run `/check-requirements` to verify everything is working.",
                   },
                   { type: ComponentType.Separator },

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -834,6 +834,8 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
             : []),
         ];
 
+        const isAsyncSetup = !!result.applicationChannelId;
+
         yield* interactionEditReply(
           interaction,
           v2Update({
@@ -841,16 +843,19 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
             components: [
               {
                 type: ComponentType.Container,
-                accent_color: 0x00cc00,
+                accent_color: isAsyncSetup ? 0x5865f2 : 0x00cc00,
                 components: [
                   {
                     type: ComponentType.TextDisplay,
-                    content: "## Setup Complete ✓",
+                    content: isAsyncSetup
+                      ? "## Setup in Progress"
+                      : "## Setup Complete ✓",
                   },
                   {
                     type: ComponentType.TextDisplay,
-                    content:
-                      "All channels and features have been configured. Run `/check-requirements` to verify everything is working.",
+                    content: isAsyncSetup
+                      ? `Created channels and roles. Now assigning the Member role to all existing members — this can take several hours for large servers.\n\nYou'll be notified in <#${result.modLogChannelId}> when the role assignment is complete. From there, you can activate the membership gate.`
+                      : "All channels and features have been configured. Run `/check-requirements` to verify everything is working.",
                   },
                   { type: ComponentType.Separator },
                   {

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -565,10 +565,20 @@ export function buildSetupConfirmMessage(
   });
 }
 
-const EXPIRED_MESSAGE = {
-  content: "Setup session expired. Please run `/setup` again.",
-  components: [],
-};
+const EXPIRED_MESSAGE = v2Update({
+  flags: MessageFlags.IsComponentsV2,
+  components: [
+    {
+      type: ComponentType.Container,
+      components: [
+        {
+          type: ComponentType.TextDisplay,
+          content: "Setup session expired. Please run `/setup` again.",
+        },
+      ],
+    },
+  ],
+});
 
 const button = (name: string) => ({
   type: InteractionType.MessageComponent as const,
@@ -629,10 +639,8 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
       }).pipe(
         Effect.catchAll((error) =>
           Effect.gen(function* () {
-            const err =
-              error instanceof Error ? error : new Error(String(error));
             yield* logEffect("error", "Commands", "setup-sel handler failed", {
-              error: err,
+              error: String(error),
             });
           }),
         ),
@@ -687,18 +695,30 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
       }).pipe(
         Effect.catchAll((error) =>
           Effect.gen(function* () {
-            const err =
-              error instanceof Error ? error : new Error(String(error));
             yield* logEffect(
               "error",
               "Commands",
               "setup-continue handler failed",
-              { error: err },
+              { error },
             );
-            yield* interactionUpdate(interaction, {
-              content: `Setup failed: ${err.message}`,
-              components: [],
-            }).pipe(Effect.catchAll(() => Effect.void));
+            yield* interactionUpdate(
+              interaction,
+              v2Update({
+                flags: MessageFlags.IsComponentsV2,
+                components: [
+                  {
+                    type: ComponentType.Container,
+                    accent_color: 0xed4245,
+                    components: [
+                      {
+                        type: ComponentType.TextDisplay,
+                        content: `Setup failed. Please try again or contact an admin.`,
+                      },
+                    ],
+                  },
+                ],
+              }),
+            ).pipe(Effect.catchAll(() => Effect.void));
           }),
         ),
         Effect.withSpan("setupContinueHandler"),
@@ -730,10 +750,8 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
       }).pipe(
         Effect.catchAll((error) =>
           Effect.gen(function* () {
-            const err =
-              error instanceof Error ? error : new Error(String(error));
             yield* logEffect("error", "Commands", "setup-back handler failed", {
-              error: err,
+              error,
             });
           }),
         ),
@@ -847,13 +865,10 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
       }).pipe(
         Effect.catchAll((error) =>
           Effect.gen(function* () {
-            const err =
-              error instanceof Error ? error : new Error(String(error));
-
             yield* logEffect("error", "Commands", "setup-exec handler failed", {
               guildId: interaction.guildId,
               userId: interaction.user.id,
-              error: err,
+              error,
             });
 
             yield* interactionEditReply(
@@ -867,7 +882,7 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
                     components: [
                       {
                         type: ComponentType.TextDisplay,
-                        content: `Setup failed. Run \`/check-requirements\` to see what was configured.\n\`\`\`\n${err.toString()}\n\`\`\``,
+                        content: `Setup failed. Run \`/check-requirements\` to see what was configured.`,
                       },
                     ],
                   },

--- a/app/commands/setupTickets.ts
+++ b/app/commands/setupTickets.ts
@@ -194,6 +194,19 @@ export const Command = [
           !interaction.guild ||
           !interaction.message
         ) {
+          yield* logEffect(
+            "error",
+            "TicketsModal",
+            "Guard failed in modal-open-ticket",
+            {
+              hasChannel: !!interaction.channel,
+              channelType: interaction.channel?.type,
+              hasGuild: !!interaction.guild,
+              hasMessage: !!interaction.message,
+              interactionId: interaction.id,
+              customId: interaction.customId,
+            },
+          );
           yield* interactionReply(interaction, {
             content: "Something went wrong while creating a ticket",
             flags: MessageFlags.Ephemeral,

--- a/app/commands/setupTickets.ts
+++ b/app/commands/setupTickets.ts
@@ -136,6 +136,12 @@ export const Command = [
               "Error setting up tickets",
               { error },
             );
+
+            yield* interactionReply(interaction, {
+              content:
+                "Failed to set up tickets. Check bot permissions and try again.",
+              flags: MessageFlags.Ephemeral,
+            }).pipe(Effect.catchAll(() => Effect.void));
           }),
         ),
         Effect.withSpan("ticketsChannelCommand", {

--- a/app/discord/automod.ts
+++ b/app/discord/automod.ts
@@ -1,4 +1,4 @@
-import { Events, type Client } from "discord.js";
+import { Events, MessageType, type Client } from "discord.js";
 import { Effect } from "effect";
 
 import { runEffect } from "#~/AppRuntime";
@@ -8,6 +8,9 @@ import { isStaff } from "#~/helpers/discord";
 export default async (bot: Client) => {
   bot.on(Events.MessageCreate, async (msg) => {
     if (msg.author.bot || msg.author.system || !msg.guild) return;
+    // Skip system messages (join notifications, boosts, etc.) — only scan user-authored content
+    if (msg.type !== MessageType.Default && msg.type !== MessageType.Reply)
+      return;
 
     const [member, message] = await Promise.all([
       msg.guild.members.fetch(msg.author.id).catch(() => undefined),

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -269,7 +269,7 @@ export async function setupAll(
         everyonePermissions: String(everyonePerms),
         memberPermissions: String(memberPerms),
       },
-      totalPhases: 2,
+      totalPhases: 1,
       notifyChannelId: modLogChannelId,
     });
 

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -185,14 +185,19 @@ export async function setupAll(
           {
             id: guildId,
             type: OverwriteType.Role,
+            deny: String(
+              PermissionFlagsBits.ViewChannel |
+                PermissionFlagsBits.SendMessages |
+                PermissionFlagsBits.CreatePublicThreads |
+                PermissionFlagsBits.CreatePrivateThreads,
+            ),
+          },
+          {
+            id: moderatorRoleId,
+            type: OverwriteType.Role,
             allow: String(
               PermissionFlagsBits.ViewChannel |
                 PermissionFlagsBits.ReadMessageHistory,
-            ),
-            deny: String(
-              PermissionFlagsBits.SendMessages |
-                PermissionFlagsBits.CreatePublicThreads |
-                PermissionFlagsBits.CreatePrivateThreads,
             ),
           },
           {

--- a/app/helpers/setupPermissionCheck.test.ts
+++ b/app/helpers/setupPermissionCheck.test.ts
@@ -1,8 +1,21 @@
 import { PermissionFlagsBits, type Guild, type GuildMember } from "discord.js";
+import { vi } from "vitest";
 
 import { CREATE_SENTINEL } from "#~/helpers/setupAll.server";
 
 import { checkSetupPermissions } from "./setupPermissionCheck";
+
+// Mock the job runner to prevent side-effects from bulkRoleAssignment's
+// top-level registerNotificationBuilder call during import.
+vi.mock("#~/jobs/jobRunner", () => ({
+  registerJobHandler: () => {
+    /* noop for test */
+  },
+  registerNotificationBuilder: () => {
+    /* noop for test */
+  },
+  createJob: vi.fn(),
+}));
 
 // ---------------------------------------------------------------------------
 // Helpers to build lightweight fakes

--- a/app/jobs/bulkRoleAssignment.test.ts
+++ b/app/jobs/bulkRoleAssignment.test.ts
@@ -19,10 +19,10 @@ import { DatabaseService } from "#~/Database";
 import type { DB } from "#~/db";
 
 import {
+  activateMembershipGateEffect,
   executeJobEffect,
   processBatchEffect,
   scanFinalCursorEffect,
-  updatePermissionsEffect,
 } from "./bulkRoleAssignment";
 import type { Job } from "./jobRunner";
 
@@ -50,14 +50,12 @@ vi.mock("#~/helpers/observability", () => ({
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyEffectFn = (...args: any[]) => Effect.Effect<void>;
 const mockCheckpointJob = vi.fn<AnyEffectFn>(() => Effect.void);
-const mockAdvancePhase = vi.fn<AnyEffectFn>(() => Effect.void);
 const mockCompleteJob = vi.fn<AnyEffectFn>(() => Effect.void);
 const mockFailJob = vi.fn<AnyEffectFn>(() => Effect.void);
 const mockRecordJobError = vi.fn<AnyEffectFn>(() => Effect.void);
 
 vi.mock("./jobRunner", () => ({
   checkpointJobEffect: (...args: unknown[]) => mockCheckpointJob(...args),
-  advancePhaseEffect: (...args: unknown[]) => mockAdvancePhase(...args),
   completeJobEffect: (...args: unknown[]) => mockCompleteJob(...args),
   failJobEffect: (...args: unknown[]) => mockFailJob(...args),
   recordJobErrorEffect: (...args: unknown[]) => mockRecordJobError(...args),
@@ -273,13 +271,13 @@ describe("scanFinalCursorEffect", () => {
   });
 });
 
-describe("updatePermissionsEffect", () => {
+describe("activateMembershipGateEffect", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("grants member role ViewChannel then denies @everyone", async () => {
     mockPatch.mockResolvedValue(undefined);
     await Effect.runPromise(
-      updatePermissionsEffect({
+      activateMembershipGateEffect({
         guildId: "guild-1",
         roleId: "role-1",
         everyonePermissions: String(
@@ -302,7 +300,7 @@ describe("updatePermissionsEffect", () => {
     mockPatch.mockRejectedValueOnce(new Error("role hierarchy"));
     await expect(
       Effect.runPromise(
-        updatePermissionsEffect({
+        activateMembershipGateEffect({
           guildId: "guild-1",
           roleId: "role-1",
           everyonePermissions: String(PermissionFlagsBits.ViewChannel),
@@ -321,7 +319,7 @@ describe("updatePermissionsEffect", () => {
 
     await expect(
       Effect.runPromise(
-        updatePermissionsEffect({
+        activateMembershipGateEffect({
           guildId: "guild-1",
           roleId: "role-1",
           everyonePermissions: String(PermissionFlagsBits.ViewChannel),
@@ -348,7 +346,7 @@ function makeJob(overrides: Partial<Record<string, unknown>> = {}) {
     cursor: null,
     final_cursor: null,
     phase: 1,
-    total_phases: 2,
+    total_phases: 1,
     progress_count: 0,
     error_count: 0,
     last_error: null,
@@ -379,7 +377,6 @@ describe("executeJobEffect", () => {
 
     expect(mockPut).toHaveBeenCalledTimes(2); // 2 members assigned
     expect(mockCheckpointJob).toHaveBeenCalled();
-    expect(mockAdvancePhase).toHaveBeenCalled();
     expect(mockCompleteJob).toHaveBeenCalled();
   });
 
@@ -398,7 +395,6 @@ describe("executeJobEffect", () => {
     await runTest(executeJobEffect(makeJob() as unknown as Job));
 
     expect(mockFailJob).toHaveBeenCalled();
-    expect(mockAdvancePhase).not.toHaveBeenCalled();
   });
 
   it("phase 1: resumes from existing cursor and final_cursor", async () => {
@@ -422,22 +418,5 @@ describe("executeJobEffect", () => {
     // Should NOT scan — final_cursor already set, so first GET is the batch
     expect(mockGet).toHaveBeenCalledTimes(1);
     expect(mockPut).toHaveBeenCalledTimes(1);
-  });
-
-  it("phase 2: calls updatePermissions and completes", async () => {
-    mockPatch.mockResolvedValue(undefined);
-
-    await runTest(executeJobEffect(makeJob({ phase: 2 }) as unknown as Job));
-
-    expect(mockPatch).toHaveBeenCalledTimes(2); // grant + deny
-    expect(mockCompleteJob).toHaveBeenCalled();
-  });
-
-  it("phase 2: fails job if updatePermissions throws", async () => {
-    mockPatch.mockRejectedValue(new Error("role hierarchy"));
-
-    await runTest(executeJobEffect(makeJob({ phase: 2 }) as unknown as Job));
-
-    expect(mockFailJob).toHaveBeenCalled();
   });
 });

--- a/app/jobs/bulkRoleAssignment.test.ts
+++ b/app/jobs/bulkRoleAssignment.test.ts
@@ -59,6 +59,12 @@ vi.mock("./jobRunner", () => ({
   completeJobEffect: (...args: unknown[]) => mockCompleteJob(...args),
   failJobEffect: (...args: unknown[]) => mockFailJob(...args),
   recordJobErrorEffect: (...args: unknown[]) => mockRecordJobError(...args),
+  registerJobHandler: () => {
+    /* noop for test */
+  },
+  registerNotificationBuilder: () => {
+    /* noop for test */
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -130,7 +136,7 @@ describe("processBatchEffect", () => {
         guildId: "guild-1",
         roleId: "role-1",
         cursor: { after: "0" },
-        finalCursor: { lastMemberId: "9999999999999999999" },
+        finalCursor: { lastMemberId: "9999999999999999999", memberCount: 3 },
         batchSize: 1000,
       }),
     );
@@ -155,7 +161,7 @@ describe("processBatchEffect", () => {
         guildId: "guild-1",
         roleId: "role-1",
         cursor: { after: "0" },
-        finalCursor: { lastMemberId: "1099511627778" },
+        finalCursor: { lastMemberId: "1099511627778", memberCount: 2 },
         batchSize: 1000,
       }),
     );
@@ -176,7 +182,7 @@ describe("processBatchEffect", () => {
         guildId: "guild-1",
         roleId: "role-1",
         cursor: { after: "0" },
-        finalCursor: { lastMemberId: "9999999999999999999" },
+        finalCursor: { lastMemberId: "9999999999999999999", memberCount: 3 },
         batchSize: 1000,
       }),
     );
@@ -199,7 +205,7 @@ describe("processBatchEffect", () => {
         guildId: "guild-1",
         roleId: "role-1",
         cursor: { after: "0" },
-        finalCursor: { lastMemberId: "9999999999999999999" },
+        finalCursor: { lastMemberId: "9999999999999999999", memberCount: 3 },
         batchSize: 1000,
       }),
     );
@@ -220,7 +226,7 @@ describe("processBatchEffect", () => {
         guildId: "guild-1",
         roleId: "role-1",
         cursor: { after: "0" },
-        finalCursor: { lastMemberId: "9999999999999999999" },
+        finalCursor: { lastMemberId: "9999999999999999999", memberCount: 3 },
         batchSize: 1000,
       }),
     );
@@ -237,7 +243,7 @@ describe("processBatchEffect", () => {
         guildId: "guild-1",
         roleId: "role-1",
         cursor: { after: "0" },
-        finalCursor: { lastMemberId: "9999999999999999999" },
+        finalCursor: { lastMemberId: "9999999999999999999", memberCount: 3 },
         batchSize: 1000,
       }),
     );
@@ -261,6 +267,7 @@ describe("scanFinalCursorEffect", () => {
 
     const result = await Effect.runPromise(scanFinalCursorEffect("guild-1"));
     expect(result.lastMemberId).toBe("1099511628800");
+    expect(result.memberCount).toBe(1001);
     expect(mockGet).toHaveBeenCalledTimes(2);
   });
 
@@ -268,6 +275,7 @@ describe("scanFinalCursorEffect", () => {
     mockGet.mockResolvedValue([]);
     const result = await Effect.runPromise(scanFinalCursorEffect("guild-1"));
     expect(result.lastMemberId).toBe("0");
+    expect(result.memberCount).toBe(0);
   });
 });
 
@@ -409,7 +417,10 @@ describe("executeJobEffect", () => {
       executeJobEffect(
         makeJob({
           cursor: JSON.stringify({ after: "1099511627777" }),
-          final_cursor: JSON.stringify({ lastMemberId: "1099511627778" }),
+          final_cursor: JSON.stringify({
+            lastMemberId: "1099511627778",
+            memberCount: 2,
+          }),
           progress_count: 500,
         }) as unknown as Job,
       ),

--- a/app/jobs/bulkRoleAssignment.ts
+++ b/app/jobs/bulkRoleAssignment.ts
@@ -11,7 +11,6 @@ import { DiscordApiError } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 
 import {
-  advancePhaseEffect,
   checkpointJobEffect,
   completeJobEffect,
   failJobEffect,
@@ -170,7 +169,9 @@ interface UpdatePermissionsOptions {
  * Order: grant ViewChannel on @member FIRST, then deny on @everyone.
  * Rolls back if the deny fails after grant succeeds.
  */
-export const updatePermissionsEffect = (options: UpdatePermissionsOptions) =>
+export const activateMembershipGateEffect = (
+  options: UpdatePermissionsOptions,
+) =>
   Effect.gen(function* () {
     const { guildId, roleId, everyonePermissions, memberPermissions } = options;
     const memberPerms = BigInt(memberPermissions);
@@ -268,8 +269,6 @@ export const executeJobEffect = (job: Job) =>
 
     if (job.phase === 1) {
       yield* executePhase1Effect(job, payload);
-    } else if (job.phase === 2) {
-      yield* executePhase2Effect(job, payload);
     }
   }).pipe(Effect.withSpan("executeJob", { attributes: { jobId: job.id } }));
 
@@ -352,37 +351,8 @@ const executePhase1Effect = (job: Job, payload: BulkRoleAssignmentPayload) =>
     yield* logEffect(
       "info",
       "BulkRoleAssignment",
-      "Phase 1 complete, advancing to phase 2",
+      "Phase 1 complete, role assignment finished",
       { jobId: job.id, assigned: totalAssigned },
     );
-    yield* advancePhaseEffect(job.id, 2);
-    yield* executePhase2Effect(job, payload);
+    yield* completeJobEffect(job.id);
   }).pipe(Effect.withSpan("executePhase1"));
-
-const executePhase2Effect = (job: Job, payload: BulkRoleAssignmentPayload) =>
-  Effect.gen(function* () {
-    const exit = yield* updatePermissionsEffect({
-      guildId: job.guild_id,
-      roleId: payload.roleId,
-      everyonePermissions: payload.everyonePermissions,
-      memberPermissions: payload.memberPermissions,
-    }).pipe(Effect.exit);
-
-    if (exit._tag === "Success") {
-      yield* completeJobEffect(job.id);
-      yield* logEffect(
-        "info",
-        "BulkRoleAssignment",
-        "Job completed successfully",
-        { jobId: job.id, guildId: job.guild_id },
-      );
-    } else {
-      const err = exit.cause;
-      yield* failJobEffect(
-        job.id,
-        `Permission update failed: ${String(err)}. ` +
-          `All members have the role but server permissions were not changed. ` +
-          `Re-run /setup or manually update @everyone permissions.`,
-      );
-    }
-  }).pipe(Effect.withSpan("executePhase2"));

--- a/app/jobs/bulkRoleAssignment.ts
+++ b/app/jobs/bulkRoleAssignment.ts
@@ -3,6 +3,7 @@ import {
   Routes,
   type APIGuildMember,
 } from "discord-api-types/v10";
+import { ButtonStyle, ComponentType, MessageFlags } from "discord.js";
 import { Effect } from "effect";
 
 import { DatabaseService } from "#~/Database";
@@ -15,7 +16,9 @@ import {
   completeJobEffect,
   failJobEffect,
   recordJobErrorEffect,
+  registerNotificationBuilder,
   type Job,
+  type JobNotificationBuilder,
 } from "./jobRunner";
 
 export interface BulkRoleAssignmentCursor {
@@ -356,3 +359,72 @@ const executePhase1Effect = (job: Job, payload: BulkRoleAssignmentPayload) =>
     );
     yield* completeJobEffect(job.id);
   }).pipe(Effect.withSpan("executePhase1"));
+
+// ---------------------------------------------------------------------------
+// Notification builder — Components V2 message for mod-log
+// ---------------------------------------------------------------------------
+
+export const buildGateActivationNotification: JobNotificationBuilder = (
+  job,
+) => {
+  if (job.status === "completed") {
+    const payload = JSON.parse(job.payload) as BulkRoleAssignmentPayload;
+    return {
+      flags: MessageFlags.IsComponentsV2,
+      components: [
+        {
+          type: ComponentType.Container,
+          accent_color: 0x5865f2, // blurple
+          components: [
+            {
+              type: ComponentType.TextDisplay,
+              content: `## Member role assignment complete\n\nAssigned <@&${payload.roleId}> to **${job.progress_count}** existing members.`,
+            },
+            { type: ComponentType.Separator },
+            {
+              type: ComponentType.TextDisplay,
+              content:
+                "Click below when you're ready to activate the membership gate. This will:\n- Grant the member role permission to view channels\n- Deny @everyone permission to view channels (server-wide)\n\nNew members will only see the application channel until their application is approved.",
+            },
+            {
+              type: ComponentType.ActionRow,
+              components: [
+                {
+                  type: ComponentType.Button,
+                  label: "Activate Membership Gate",
+                  style: ButtonStyle.Primary,
+                  custom_id: `activate-gate|${job.guild_id}`,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  if (job.status === "failed") {
+    return {
+      flags: MessageFlags.IsComponentsV2,
+      components: [
+        {
+          type: ComponentType.Container,
+          accent_color: 0xed4245, // red
+          components: [
+            {
+              type: ComponentType.TextDisplay,
+              content: `## Member role assignment failed\n\n${job.last_error}\n\nThe membership gate has not been activated. Re-run \`/setup\` to retry.`,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  return null;
+};
+
+registerNotificationBuilder(
+  "bulk_role_assignment",
+  buildGateActivationNotification,
+);

--- a/app/jobs/bulkRoleAssignment.ts
+++ b/app/jobs/bulkRoleAssignment.ts
@@ -1,9 +1,10 @@
 import {
+  ButtonStyle,
   PermissionFlagsBits,
   Routes,
   type APIGuildMember,
 } from "discord-api-types/v10";
-import { ButtonStyle, ComponentType, MessageFlags } from "discord.js";
+import { ComponentType, MessageFlags } from "discord.js";
 import { Effect } from "effect";
 
 import { DatabaseService } from "#~/Database";
@@ -16,6 +17,7 @@ import {
   completeJobEffect,
   failJobEffect,
   recordJobErrorEffect,
+  registerJobHandler,
   registerNotificationBuilder,
   type Job,
   type JobNotificationBuilder,
@@ -27,6 +29,7 @@ export interface BulkRoleAssignmentCursor {
 
 export interface BulkRoleAssignmentFinalCursor {
   lastMemberId: string;
+  memberCount: number;
 }
 
 export interface BulkRoleAssignmentPayload {
@@ -58,6 +61,7 @@ export const scanFinalCursorEffect = (guildId: string) =>
   Effect.gen(function* () {
     let lastMemberId = "0";
     let after = "0";
+    let memberCount = 0;
     while (true) {
       const page = (yield* Effect.tryPromise({
         try: () =>
@@ -68,6 +72,7 @@ export const scanFinalCursorEffect = (guildId: string) =>
           new DiscordApiError({ operation: "listGuildMembers", cause: error }),
       })) as APIGuildMember[];
       if (page.length === 0) break;
+      memberCount += page.length;
       const lastUser = page[page.length - 1].user;
       if (lastUser) {
         lastMemberId = lastUser.id;
@@ -75,7 +80,7 @@ export const scanFinalCursorEffect = (guildId: string) =>
       }
       if (page.length < 1000) break;
     }
-    return { lastMemberId } as BulkRoleAssignmentFinalCursor;
+    return { lastMemberId, memberCount } as BulkRoleAssignmentFinalCursor;
   }).pipe(Effect.withSpan("scanFinalCursor", { attributes: { guildId } }));
 
 /**
@@ -304,7 +309,37 @@ const executePhase1Effect = (job: Job, payload: BulkRoleAssignmentPayload) =>
       yield* logEffect("info", "BulkRoleAssignment", "Final cursor set", {
         jobId: job.id,
         lastMemberId: finalCursor.lastMemberId,
+        memberCount: finalCursor.memberCount,
       });
+
+      // Post initial mod-log message with estimated runtime
+      if (job.notify_channel_id) {
+        const estimatedSeconds = finalCursor.memberCount; // ~1 member/sec
+        const estimatedMinutes = Math.ceil(estimatedSeconds / 60);
+        const estimatedHours = Math.floor(estimatedMinutes / 60);
+        const remainingMinutes = estimatedMinutes % 60;
+        const timeEstimate =
+          estimatedHours > 0
+            ? `~${estimatedHours}h ${remainingMinutes}m`
+            : `~${estimatedMinutes}m`;
+
+        yield* Effect.tryPromise({
+          try: () =>
+            ssrDiscordSdk.post(Routes.channelMessages(job.notify_channel_id!), {
+              body: {
+                content:
+                  `**Member role migration started**\n` +
+                  `Assigning <@&${payload.roleId}> to ~${finalCursor.memberCount.toLocaleString()} existing members.\n` +
+                  `Estimated time: ${timeEstimate}. Progress updates will be posted every 30 minutes.`,
+              },
+            }),
+          catch: (error) =>
+            new DiscordApiError({
+              operation: "notifyMigrationStart",
+              cause: error,
+            }),
+        }).pipe(Effect.catchAll(() => Effect.void));
+      }
     }
 
     const cursor = job.cursor
@@ -314,6 +349,11 @@ const executePhase1Effect = (job: Job, payload: BulkRoleAssignmentPayload) =>
     let currentCursor = cursor;
     let totalAssigned = job.progress_count;
     let totalErrors = job.error_count;
+
+    const startTime = Date.now();
+    const PROGRESS_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+    let lastProgressUpdate = startTime;
+    const totalMembers = finalCursor.memberCount;
 
     while (true) {
       const result = yield* processBatchEffect({
@@ -329,6 +369,47 @@ const executePhase1Effect = (job: Job, payload: BulkRoleAssignmentPayload) =>
       currentCursor = result.cursor;
 
       yield* checkpointJobEffect(job.id, currentCursor, totalAssigned);
+
+      // Post progress update every 30 minutes
+      const now = Date.now();
+      if (
+        job.notify_channel_id &&
+        now - lastProgressUpdate >= PROGRESS_INTERVAL_MS
+      ) {
+        lastProgressUpdate = now;
+        const elapsed = now - startTime;
+        const rate = totalAssigned / (elapsed / 1000); // members per second
+        const remaining = totalMembers - totalAssigned;
+        const etaSeconds = rate > 0 ? Math.ceil(remaining / rate) : 0;
+        const etaMinutes = Math.ceil(etaSeconds / 60);
+        const etaHours = Math.floor(etaMinutes / 60);
+        const etaRemainingMin = etaMinutes % 60;
+        const eta =
+          etaHours > 0
+            ? `~${etaHours}h ${etaRemainingMin}m`
+            : `~${etaMinutes}m`;
+        const pct =
+          totalMembers > 0
+            ? Math.round((totalAssigned / totalMembers) * 100)
+            : 0;
+
+        yield* Effect.tryPromise({
+          try: () =>
+            ssrDiscordSdk.post(Routes.channelMessages(job.notify_channel_id!), {
+              body: {
+                content:
+                  `**Member role migration progress**\n` +
+                  `${totalAssigned.toLocaleString()} / ~${totalMembers.toLocaleString()} members (${pct}%)\n` +
+                  `Estimated time remaining: ${eta}`,
+              },
+            }),
+          catch: (error) =>
+            new DiscordApiError({
+              operation: "notifyProgress",
+              cause: error,
+            }),
+        }).pipe(Effect.catchAll(() => Effect.void));
+      }
 
       if (result.errors > 0) {
         yield* recordJobErrorEffect(
@@ -424,6 +505,7 @@ export const buildGateActivationNotification: JobNotificationBuilder = (
   return null;
 };
 
+registerJobHandler("bulk_role_assignment", executeJobEffect);
 registerNotificationBuilder(
   "bulk_role_assignment",
   buildGateActivationNotification,

--- a/app/jobs/jobRunner.ts
+++ b/app/jobs/jobRunner.ts
@@ -1,5 +1,5 @@
 import { Routes } from "discord-api-types/v10";
-import { Effect, Fiber, FiberRef, Schedule } from "effect";
+import { Deferred, Effect, Fiber, FiberRef } from "effect";
 import type { Selectable } from "kysely";
 
 import { runEffect } from "#~/AppRuntime";
@@ -229,6 +229,8 @@ export const createJobEffect = (options: CreateJobOptions) =>
       guildId: options.guildId,
     });
 
+    yield* notifyJobAvailable;
+
     return job;
   }).pipe(
     Effect.withSpan("createJob", {
@@ -271,21 +273,49 @@ const handlers: Record<string, JobHandler> = {
   bulk_role_assignment: executeJobEffect,
 };
 
+// ---------------------------------------------------------------------------
+// Notification builders — per-job-type rich message support
+// ---------------------------------------------------------------------------
+
+export type JobNotificationBuilder = (
+  job: Job,
+) => Record<string, unknown> | null;
+
+const notificationBuilders: Record<string, JobNotificationBuilder> = {};
+
+export const registerNotificationBuilder = (
+  jobType: string,
+  builder: JobNotificationBuilder,
+) => {
+  notificationBuilders[jobType] = builder;
+};
+
 const notifyChannelEffect = (channelId: string, job: Job) =>
   Effect.gen(function* () {
-    const message =
-      job.status === "completed"
-        ? `Background job completed: **${job.job_type}** — ${job.progress_count} members processed.`
-        : job.status === "failed"
-          ? `Background job failed: **${job.job_type}** — ${job.last_error}`
-          : null;
+    let body: Record<string, unknown> | null = null;
 
-    if (!message) return;
+    const customBuilder = notificationBuilders[job.job_type];
+    if (customBuilder) {
+      body = customBuilder(job);
+    } else {
+      const message =
+        job.status === "completed"
+          ? `Background job completed: **${job.job_type}** — ${job.progress_count} members processed.`
+          : job.status === "failed"
+            ? `Background job failed: **${job.job_type}** — ${job.last_error}`
+            : null;
+
+      if (message) {
+        body = { content: message };
+      }
+    }
+
+    if (!body) return;
 
     yield* Effect.tryPromise({
       try: () =>
         ssrDiscordSdk.post(Routes.channelMessages(channelId), {
-          body: { content: message },
+          body,
         }),
       catch: (error) =>
         new DiscordApiError({ operation: "notifyChannel", cause: error }),
@@ -354,7 +384,33 @@ export const pollAndExecuteEffect = Effect.gen(function* () {
   Effect.withSpan("pollAndExecute"),
 );
 
-export const runJobPoller = pollAndExecuteEffect.pipe(
-  Effect.repeat(Schedule.fixed("30 seconds")),
-  Effect.catchAll(() => Effect.succeed(null)),
-);
+// ---------------------------------------------------------------------------
+// Signal-driven job runner — waits for a signal instead of polling
+// ---------------------------------------------------------------------------
+
+let jobSignal: Deferred.Deferred<void> | null = null;
+
+/** Signal the runner that a new job is available. */
+const notifyJobAvailable = Effect.gen(function* () {
+  if (jobSignal) {
+    yield* Deferred.succeed(jobSignal, void 0 as void);
+  }
+});
+
+/**
+ * Runs forever, waiting for `notifyJobAvailable` signals.
+ * On boot, runs once immediately to pick up any incomplete jobs from a prior crash.
+ */
+export const runJobRunner = Effect.gen(function* () {
+  // Resume any incomplete jobs left over from a prior crash
+  yield* pollAndExecuteEffect;
+
+  // Then wait for signals
+  while (true) {
+    const signal = yield* Deferred.make<void>();
+    jobSignal = signal;
+    yield* Deferred.await(signal);
+    jobSignal = null;
+    yield* pollAndExecuteEffect;
+  }
+}).pipe(Effect.catchAll(() => Effect.succeed(null)));

--- a/app/jobs/jobRunner.ts
+++ b/app/jobs/jobRunner.ts
@@ -10,8 +10,6 @@ import { DiscordApiError } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import { jobMetaRef, type ActiveJobMeta } from "#~/effects/supervisor";
 
-import { executeJobEffect } from "./bulkRoleAssignment";
-
 export type Job = Selectable<DB["background_jobs"]>;
 
 // ---------------------------------------------------------------------------
@@ -269,8 +267,10 @@ type JobHandler = (
   job: Job,
 ) => Effect.Effect<void, DiscordApiError | SqlError, DatabaseService>;
 
-const handlers: Record<string, JobHandler> = {
-  bulk_role_assignment: executeJobEffect,
+const handlers: Record<string, JobHandler> = {};
+
+export const registerJobHandler = (jobType: string, handler: JobHandler) => {
+  handlers[jobType] = handler;
 };
 
 // ---------------------------------------------------------------------------

--- a/app/server.ts
+++ b/app/server.ts
@@ -33,7 +33,11 @@ import { initDiscordBot } from "#~/discord/gateway";
 import onboardGuild from "#~/discord/onboardGuild";
 import { startReactjiChanneler } from "#~/discord/reactjiChanneler";
 import { applicationKey } from "#~/helpers/env.server";
-import { runJobPoller } from "#~/jobs/jobRunner";
+
+// Side-effect import: registers job handler and notification builder
+import "#~/jobs/bulkRoleAssignment";
+
+import { runJobRunner } from "#~/jobs/jobRunner";
 
 import { runtime } from "./AppRuntime";
 import { checkpointWal, runIntegrityCheck } from "./Database";
@@ -41,6 +45,10 @@ import { DiscordApiError } from "./effects/errors";
 import { logEffect } from "./effects/observability";
 import { initializeGroups } from "./effects/posthog";
 import { botStats } from "./helpers/metrics";
+
+declare global {
+  var __shutdownHandlersRegistered: boolean | undefined;
+}
 
 export const app = express();
 
@@ -117,7 +125,7 @@ const startup = Effect.gen(function* () {
 
   // Start escalation resolver scheduler (must be after client is ready)
   startEscalationResolver(discordClient);
-  runtime.runFork(runJobPoller);
+  runtime.runFork(runJobRunner);
 
   yield* logEffect("info", "Gateway", "Gateway initialization completed", {
     guildCount: discordClient.guilds.cache.size,
@@ -150,9 +158,14 @@ const startup = Effect.gen(function* () {
       )
       .then(() => runtime.dispose().then(() => console.log("ok")));
 
-  yield* logEffect("debug", "Server", "setting signal handlers");
-  process.on("SIGTERM", () => void handleShutdown("SIGTERM"));
-  process.on("SIGINT", () => void handleShutdown("SIGINT"));
+  // Only register signal handlers once — HMR re-runs startup, which would
+  // otherwise stack listeners and trigger MaxListenersExceededWarning.
+  if (!globalThis.__shutdownHandlersRegistered) {
+    globalThis.__shutdownHandlersRegistered = true;
+    yield* logEffect("debug", "Server", "setting signal handlers");
+    process.on("SIGTERM", () => void handleShutdown("SIGTERM"));
+    process.on("SIGINT", () => void handleShutdown("SIGINT"));
+  }
 });
 
 console.log("running program");

--- a/notes/2026-04-01_1_discord-rate-limits.md
+++ b/notes/2026-04-01_1_discord-rate-limits.md
@@ -1,0 +1,82 @@
+# Discord API Rate Limits Research
+
+## Global Rate Limits
+
+- **50 requests per second** per bot token (or per IP if no auth header)
+- Interaction endpoints (slash command responses, component callbacks) are exempt
+- 10,000 invalid requests (401, 403, 429) per 10 minutes triggers a Cloudflare IP ban
+  - 429s with `X-RateLimit-Scope: shared` are exempt from this count
+
+## Per-Route Rate Limits
+
+- Bucketed by HTTP method + path template, with top-level resource IDs creating
+  separate buckets
+- `PUT /guilds/{guild.id}/members/{member.id}/roles/{role.id}` — all role
+  assignments in the same guild share one bucket
+- Discord does not publish specific per-route numbers; apps must parse response
+  headers
+- Community reports: ~10 role updates per 10 seconds per guild (not officially
+  documented)
+
+## 429 Response Details
+
+### Headers on every response
+
+| Header                     | Description                          |
+| -------------------------- | ------------------------------------ |
+| `X-RateLimit-Limit`        | Max requests in the bucket           |
+| `X-RateLimit-Remaining`    | Remaining requests before reset      |
+| `X-RateLimit-Reset`        | Unix epoch timestamp of reset        |
+| `X-RateLimit-Reset-After`  | Seconds until reset                  |
+| `X-RateLimit-Bucket`       | Unique bucket identifier             |
+
+### Additional headers on 429 responses
+
+| Header               | Description                                    |
+| -------------------- | ---------------------------------------------- |
+| `X-RateLimit-Global` | Present if global rate limit hit               |
+| `X-RateLimit-Scope`  | `user`, `global`, or `shared` (per-resource)   |
+
+### 429 response body
+
+```json
+{
+  "message": "You are being rate limited.",
+  "retry_after": 1.234,
+  "global": false,
+  "code": 0
+}
+```
+
+## Bulk Operations
+
+- **No bulk role assignment endpoint exists.** One PUT per member, no exceptions.
+- Community reports: ~20,000 members takes "several hours" in a 500k-member server
+- Estimated throughput at ~1 req/s effective (guild bucket): 100k members ≈ 28 hours
+
+## discord.js REST Client (`@discordjs/rest`)
+
+### Automatic 429 handling
+
+- **Pre-emptive queuing**: checks `X-RateLimit-Remaining` and queues requests
+  before hitting limits
+- **Unlimited 429 retries**: sleeps for `retry_after` then retries; does NOT
+  increment the retry counter
+- **Only 5xx errors** increment the retry counter (default: 3 retries)
+
+### Default configuration
+
+| Option                    | Default        |
+| ------------------------- | -------------- |
+| `retries`                 | 3 (5xx only)   |
+| `globalRequestsPerSecond` | 50             |
+| `timeout`                 | 15,000ms       |
+| `offset`                  | 50ms           |
+| `rejectOnRateLimit`       | null           |
+
+### Implication for bulk role assignment
+
+A tight sequential loop of PUT calls is safe — discord.js queues and paces
+requests internally. It won't error out on rate limits, it just slows down.
+Memory pressure from queuing is not a concern since requests are awaited
+sequentially.

--- a/notes/2026-04-08_1_manual-gate-activation-plan.md
+++ b/notes/2026-04-08_1_manual-gate-activation-plan.md
@@ -1,0 +1,232 @@
+# Manual Membership Gate Activation — Implementation Plan
+
+## Context
+
+The membership approvals feature onboards a community by (1) assigning
+`@Member` to all existing users and (2) locking down the server via
+`@everyone` permission changes. For a 100k+ member community, Phase 1 can take
+many hours. The current flow runs Phase 2 automatically after Phase 1, with no
+moderator in the loop and no clear indication to the admin that the server is
+in a half-configured state.
+
+This plan introduces a manual confirmation step: Phase 1 runs asynchronously,
+and a "Activate Membership Gate" button is posted to the mod-log when it
+completes. A moderator clicks the button to trigger Phase 2.
+
+## Goals
+
+- Admin clearly understands the bulk role assignment is asynchronous
+- Moderators are notified when Phase 1 completes
+- Phase 2 (permission changes) requires explicit human confirmation
+- Button works indefinitely until pressed (one-shot, no expiry)
+- Preserve existing crash-recovery semantics
+
+## Non-Goals
+
+- Changing the signal-driven job runner architecture
+- Adding rate limiting (discord.js handles 429s)
+- Adding job priorities
+- Changing the applicant runtime flow
+
+## UX Flow
+
+### 1. Setup confirmation (modified)
+
+When admin clicks "Confirm ✓" in `/setup` with Member Applications enabled, the
+synchronous setup still creates the role, channel, and Apply-to-Join button.
+The "Setup Complete" message is rewritten to:
+
+> ## Setup in Progress
+>
+> Created @Member role and #apply-here. Now assigning the Member role to all
+> existing members — this can take several hours for large servers.
+>
+> You'll be notified in <#mod-log> when this is complete, where you can
+> activate the membership gate.
+
+### 2. Phase 1 completion notification (new)
+
+Posted to mod-log when `bulk_role_assignment` completes successfully:
+
+> ## Member role assignment complete
+>
+> Assigned @Member to **N** existing members.
+>
+> Click below when you're ready to activate the membership gate. This will:
+> - Grant @Member permission to view channels
+> - Deny @everyone permission to view channels (server-wide)
+>
+> New members will only see #apply-here until their application is approved.
+>
+> [ **Activate Membership Gate** ] (primary button)
+
+### 3. Gate activation (new interaction)
+
+When a moderator clicks the button:
+- Verify caller has the mod role (use existing mod-role check pattern)
+- Run Phase 2 logic (currently in `executePhase2Effect`)
+- On success: edit the original message to remove the button and append a
+  "✓ Gate activated by <@mod> at <time>" confirmation
+- On failure: reply ephemerally with the error and leave the button active
+  for retry
+
+### 4. Phase 1 failure notification (modified copy)
+
+> ## Member role assignment failed
+>
+> <error message>
+>
+> The membership gate has not been activated. Re-run `/setup` to retry.
+
+## Implementation Steps
+
+### Step 1 — Extract Phase 2 into a reusable effect
+
+**File:** `app/jobs/bulkRoleAssignment.ts`
+
+`executePhase2Effect` currently reads from the job row for `roleId`,
+`everyonePermissions`, and `memberPermissions`. Extract the core logic into a
+new exported effect that takes these as parameters:
+
+```ts
+export const activateMembershipGateEffect = (params: {
+  guildId: string;
+  roleId: string;
+  everyonePermissions: bigint;
+  memberPermissions: bigint;
+}) => Effect.gen(function* () {
+  // Grant @Member ViewChannel
+  // Then deny @everyone ViewChannel
+  // Rollback @Member on failure
+});
+```
+
+The existing `executePhase2Effect` can call this, or be replaced by it.
+
+### Step 2 — Remove automatic Phase 2 from the job handler
+
+**File:** `app/jobs/bulkRoleAssignment.ts`
+
+In `executeJobEffect`, after Phase 1 completes with zero errors, call
+`completeJobEffect(job.id)` directly instead of `advancePhaseEffect`. Remove
+the Phase 2 branch from the handler.
+
+**File:** `app/helpers/setupAll.server.ts`
+
+Change `createJob` call to `totalPhases: 1`.
+
+### Step 3 — Enhance `notifyChannelEffect` for rich messages
+
+**File:** `app/jobs/jobRunner.ts`
+
+`notifyChannelEffect` currently sends `{ content: message }`. Refactor so
+per-job-type notification builders can return a full Components V2 payload.
+
+One approach: add an optional `buildNotification` function to the job handler
+registry that takes the completed `Selectable<BackgroundJobs>` and returns
+either a plain string or a Components V2 message body. Fall back to the
+existing plain-text default if no builder is registered.
+
+```ts
+type JobNotificationBuilder = (job: Selectable<BackgroundJobs>) => {
+  content?: string;
+  flags?: number;
+  components?: unknown[];
+};
+
+const notificationBuilders: Record<string, JobNotificationBuilder> = {
+  bulk_role_assignment: buildGateActivationNotification,
+};
+```
+
+### Step 4 — Build the gate activation notification
+
+**File:** `app/jobs/bulkRoleAssignment.ts` (or a new file)
+
+Export a `buildGateActivationNotification(job)` function that returns a
+Components V2 container with:
+- Header text and progress count
+- An action row with a primary button:
+  `customId: activate-gate|{guildId}`
+
+The `guildId` is already stored on the job row.
+
+### Step 5 — Add the `activate-gate` button handler
+
+**File:** `app/commands/memberApplications.ts` (or a new `membershipGate.ts`)
+
+Register a new component handler for `activate-gate|{guildId}`:
+
+1. Parse `guildId` from `customId`
+2. Verify `interaction.member` has the mod role (use `fetchSettingsEffect` to
+   get `SETTINGS.modRole` and check `interaction.member.roles.cache`)
+3. Load `application_config` by `guild_id` to get `role_id`
+4. Fetch current `@everyone` and `@Member` permissions via
+   `GET /guilds/{id}/roles` (or look them up from the job payload if still
+   available — safer to re-fetch)
+5. Call `activateMembershipGateEffect({ guildId, roleId, ... })`
+6. On success:
+   - `interactionUpdate` the original message to remove the button and append
+     the activation confirmation
+   - Optionally log to mod-log separately
+7. On failure:
+   - `interactionReply` ephemeral with the error
+   - Leave the original message and button intact for retry
+
+### Step 6 — Update the "Setup Complete" message
+
+**File:** `app/commands/setupHandlers.ts`
+
+Find the `buildSetupSuccessMessage` (or equivalent) that produces the green
+"Setup Complete ✓" container. When Member Applications is enabled, change the
+header and body to reflect the in-progress async state and point to mod-log.
+
+When Member Applications is NOT enabled, keep the existing message unchanged.
+
+### Step 7 — Tests
+
+- `bulkRoleAssignment.test.ts`: update to assert that Phase 1 success marks
+  the job `completed` (not `processing` with phase 2), and that no permission
+  PATCH calls are made by the handler itself.
+- New test for `activateMembershipGateEffect`: mock the REST client and verify
+  the two PATCH calls are made in the correct order, and rollback fires on
+  the second failure.
+- New test for the `activate-gate` button handler: verify mod-role check,
+  success path, and failure path.
+
+## Edge Cases
+
+- **Button clicked twice in rapid succession**: the second click should see
+  the gate already active. We could rely on the `interactionUpdate` removing
+  the button to prevent this, but a race is possible. The handler should be
+  idempotent — check current `@everyone` permissions before patching; if
+  ViewChannel is already denied, reply "Gate is already active" and edit the
+  message accordingly.
+
+- **Bot restarts after Phase 1 completes but before notification posts**: the
+  job is marked `completed` but the mod-log message never went out. On boot,
+  `runJobRunner` processes jobs but we'd need to ensure notification retry.
+  Alternative: only mark `completed` after the notification succeeds.
+  (Out of scope for this change? Flag as a known gap.)
+
+- **Non-mod clicks the button**: ephemeral error reply, button stays active.
+
+- **`application_config` row missing when button clicked**: shouldn't happen
+  but guard with an error reply directing to re-run `/setup`.
+
+## Open Questions
+
+- Should we post a second mod-log message confirming gate activation, or only
+  edit the original notification?
+- When the original message is edited, should the button be replaced with a
+  disabled "✓ Activated" button, or removed entirely?
+
+## Files Touched
+
+- `app/jobs/bulkRoleAssignment.ts`
+- `app/jobs/jobRunner.ts`
+- `app/helpers/setupAll.server.ts`
+- `app/commands/setupHandlers.ts`
+- `app/commands/memberApplications.ts` (or new `membershipGate.ts`)
+- `app/jobs/bulkRoleAssignment.test.ts`
+- New test files for the gate handler


### PR DESCRIPTION
## Summary

- Splits the bulk role assignment job from automatic permission changes — Phase 1 (role assignment) runs asynchronously, Phase 2 (permission gating) requires explicit moderator confirmation via an "Activate Membership Gate" button in #mod-log
- Adds mod-log notifications: initial migration start message with estimated runtime, progress updates every 30 minutes, and a Components V2 completion message with the activation button
- Hides #apply-here from @everyone during the migration period, revealed only when the gate is activated
- Fixes circular dependency between jobRunner.ts and bulkRoleAssignment.ts that caused "Unknown job type" failures
- Adds signal-driven job runner (replaces 30-second polling), HMR-safe signal handler registration, and debug logging for ticket modal guard failures

## Key changes

- `bulkRoleAssignment.ts` — `activateMembershipGateEffect` extracted as reusable effect, job completes after Phase 1, notification builder with gate activation button, progress tracking with 30-min mod-log updates
- `jobRunner.ts` — Dynamic handler/notification builder registries (`registerJobHandler`, `registerNotificationBuilder`), signal-driven runner via Effect `Deferred`
- `memberApplications.ts` — `activate-gate` button handler with mod role verification, idempotency check, #apply-here channel reveal on activation
- `setupAll.server.ts` — #apply-here created hidden from @everyone, mod role overwrite added, `totalPhases: 1`
- `setupHandlers.ts` — "Setup in Progress" message with numbered explanation of followup behavior

## Test plan

- [x] All 233 tests pass
- [x] TypeScript compilation clean
- [x] Manual test: `/setup` with member applications enabled creates hidden #apply-here, posts migration start to mod-log
- [ ] Manual test: bulk role assignment completes, gate activation button appears in mod-log
- [ ] Manual test: clicking "Activate Membership Gate" reveals #apply-here and gates server
- [ ] Manual test: non-mod clicking button gets ephemeral error
- [ ] Manual test: double-click shows "already active" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)