### PR TITLE
Remove top-level await and legacy DB bridge

### DIFF
--- a/app/AppRuntime.ts
+++ b/app/AppRuntime.ts
@@ -1,15 +1,16 @@
 import { Effect, Layer, Logger, LogLevel, ManagedRuntime } from "effect";
-import type { PostHog } from "posthog-node";
 
-import { DatabaseLayer, DatabaseService, type EffectKysely } from "#~/Database";
+import { DatabaseLayer } from "#~/Database";
 import { MessageCacheServiceLive } from "#~/discord/messageCacheService";
-import { NotFoundError } from "#~/effects/errors";
 import {
   FeatureFlagService,
   FeatureFlagServiceLive,
   type BooleanFlag,
 } from "#~/effects/featureFlags";
-import { PostHogService, PostHogServiceLive } from "#~/effects/posthog";
+import {
+  PostHogService,
+  PostHogServiceLive,
+} from "#~/effects/posthog";
 import { SupervisorServiceLive } from "#~/effects/supervisor";
 import { TracingLive } from "#~/effects/tracing.js";
 import { SpamDetectionServiceLive } from "#~/features/spam/service.ts";
@@ -46,47 +47,6 @@ export type RuntimeContext = ManagedRuntime.ManagedRuntime.Context<
   typeof runtime
 >;
 
-// Extract the PostHog client for use by metrics.ts (null when no API key configured).
-export const [posthogClient, db]: [PostHog | null, EffectKysely] =
-  await Promise.all([
-    runtime.runPromise(PostHogService),
-    runtime.runPromise(DatabaseService),
-  ]);
-
-// --- Bridge functions for legacy async/await code ---
-
-/**
- * Convenience helpers for legacy async/await code that needs to run
- * EffectKysely query builders as Promises.
- *
- * @deprecated
- * @param effect
- */
-export const run = <A>(effect: Effect.Effect<A, unknown, never>): Promise<A> =>
-  Effect.runPromise(effect);
-
-/**
- * @deprecated
- */
-export const runTakeFirst = <A>(
-  effect: Effect.Effect<A[], unknown, never>,
-): Promise<A | undefined> =>
-  Effect.runPromise(Effect.map(effect, (rows) => rows[0]));
-
-/**
- * @deprecated
- */
-export const runTakeFirstOrThrow = <A>(
-  effect: Effect.Effect<A[], unknown, never>,
-): Promise<A> =>
-  Effect.runPromise(
-    Effect.flatMap(effect, (rows) =>
-      rows[0] !== undefined
-        ? Effect.succeed(rows[0])
-        : Effect.fail(new NotFoundError({ resource: "db record", id: "" })),
-    ),
-  );
-
 // Run an Effect through the ManagedRuntime, returning a Promise.
 export const runEffect = <A, E>(
   effect: Effect.Effect<A, E, RuntimeContext>,
@@ -109,9 +69,10 @@ export const runGatedFeature = <A>(
   runtime.runPromise(
     Effect.gen(function* () {
       const flags = yield* FeatureFlagService;
+      const posthog = yield* PostHogService;
       const enabled = yield* flags.isPostHogEnabled(flag, guildId);
       if (!enabled) {
-        posthogClient?.capture({
+        posthog?.capture({
           distinctId: guildId,
           event: "premium gate hit",
           properties: { flag, $groups: { guild: guildId } },

--- a/app/commands/setupHandlers.test.ts
+++ b/app/commands/setupHandlers.test.ts
@@ -15,8 +15,10 @@ import {
 
 // Mock modules with side effects before importing the module under test
 vi.mock("#~/AppRuntime", () => ({
-  db: {},
-  runTakeFirst: vi.fn(),
+  runEffect: vi.fn(),
+}));
+vi.mock("#~/Database", () => ({
+  DatabaseService: {},
 }));
 vi.mock("#~/effects/discordSdk", () => ({}));
 vi.mock("#~/effects/observability", () => ({

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -8,7 +8,8 @@ import {
 } from "discord.js";
 import { Effect } from "effect";
 
-import { db, runTakeFirst } from "#~/AppRuntime";
+import { runEffect } from "#~/AppRuntime";
+import { DatabaseService } from "#~/Database";
 import {
   interactionDeferUpdate,
   interactionEditReply,
@@ -145,11 +146,15 @@ export async function initSetupForm(
     if (settings.restricted) defaults.restrictedRoleId = settings.restricted;
 
     // Check for existing honeypot channel
-    const honeypot = await runTakeFirst(
-      db
-        .selectFrom("honeypot_config")
-        .select("channel_id")
-        .where("guild_id", "=", guildId),
+    const honeypot = await runEffect(
+      Effect.gen(function* () {
+        const db = yield* DatabaseService;
+        const rows = yield* db
+          .selectFrom("honeypot_config")
+          .select("channel_id")
+          .where("guild_id", "=", guildId);
+        return rows[0];
+      }),
     );
     if (honeypot) {
       defaults.honeypotChannel = honeypot.channel_id;
@@ -159,11 +164,15 @@ export async function initSetupForm(
 
     // tickets_config has no guild_id, so match by channel ownership
     if (guildChannelIds) {
-      const ticketRows = await runTakeFirst(
-        db
-          .selectFrom("tickets_config")
-          .select("channel_id")
-          .where("channel_id", "is not", null),
+      const ticketRows = await runEffect(
+        Effect.gen(function* () {
+          const db = yield* DatabaseService;
+          const rows = yield* db
+            .selectFrom("tickets_config")
+            .select("channel_id")
+            .where("channel_id", "is not", null);
+          return rows[0];
+        }),
       );
       if (
         ticketRows?.channel_id &&

--- a/app/discord/activityTracker.ts
+++ b/app/discord/activityTracker.ts
@@ -1,7 +1,8 @@
 import { ChannelType, Events, type Client } from "discord.js";
 import { Effect } from "effect";
 
-import { db, runGatedFeature } from "#~/AppRuntime";
+import { runGatedFeature } from "#~/AppRuntime";
+import { DatabaseService } from "#~/Database";
 import { logEffect } from "#~/effects/observability";
 import { getMessageStats } from "#~/helpers/discord.js";
 import { threadStats } from "#~/helpers/metrics";
@@ -40,8 +41,9 @@ export async function startActivityTracking(client: Client) {
       "analytics",
       msg.guildId,
       Effect.gen(function* () {
+        const db = yield* DatabaseService;
         const info = yield* getMessageStats(msg);
-        const channelInfo = yield* Effect.promise(() => getOrFetchChannel(msg));
+        const channelInfo = yield* getOrFetchChannel(msg);
 
         yield* db.insertInto("message_stats").values({
           ...info,
@@ -89,6 +91,7 @@ export async function startActivityTracking(client: Client) {
       "analytics",
       msg.guildId,
       Effect.gen(function* () {
+        const db = yield* DatabaseService;
         const info = yield* getMessageStats(msg);
 
         yield* db
@@ -131,6 +134,7 @@ export async function startActivityTracking(client: Client) {
       "analytics",
       msg.guildId,
       Effect.gen(function* () {
+        const db = yield* DatabaseService;
         yield* db.deleteFrom("message_stats").where("message_id", "=", msg.id);
 
         yield* logEffect("debug", "ActivityTracker", "Message stats deleted", {
@@ -163,6 +167,7 @@ export async function startActivityTracking(client: Client) {
       "analytics",
       guildId,
       Effect.gen(function* () {
+        const db = yield* DatabaseService;
         yield* db
           .updateTable("message_stats")
           .where("message_id", "=", reaction.message.id)
@@ -194,6 +199,7 @@ export async function startActivityTracking(client: Client) {
       "analytics",
       guildId,
       Effect.gen(function* () {
+        const db = yield* DatabaseService;
         yield* db
           .updateTable("message_stats")
           .where("message_id", "=", reaction.message.id)

--- a/app/discord/reactjiChanneler.ts
+++ b/app/discord/reactjiChanneler.ts
@@ -1,6 +1,8 @@
 import { Events, type Client } from "discord.js";
 
-import { db, runTakeFirst } from "#~/AppRuntime";
+import { runEffect } from "#~/AppRuntime";
+import { DatabaseService } from "#~/Database";
+import { Effect } from "effect";
 import { featureStats } from "#~/helpers/metrics";
 import { log } from "#~/helpers/observability";
 
@@ -40,12 +42,16 @@ export async function startReactjiChanneler(client: Client) {
       }
 
       // Look up config for this guild + emoji combination
-      const config = await runTakeFirst(
-        db
-          .selectFrom("reactji_channeler_config")
-          .selectAll()
-          .where("guild_id", "=", guildId)
-          .where("emoji", "=", emoji),
+      const config = await runEffect(
+        Effect.gen(function* () {
+          const db = yield* DatabaseService;
+          const rows = yield* db
+            .selectFrom("reactji_channeler_config")
+            .selectAll()
+            .where("guild_id", "=", guildId)
+            .where("emoji", "=", emoji);
+          return rows[0] ?? null;
+        }),
       );
 
       if (!config) {

--- a/app/discord/utils.ts
+++ b/app/discord/utils.ts
@@ -1,43 +1,50 @@
 import type { Message, TextChannel } from "discord.js";
+import { Effect } from "effect";
 
-import { db, run, runTakeFirst } from "#~/AppRuntime";
+import { DatabaseService } from "#~/Database";
 import { log } from "#~/helpers/observability";
 
-export async function getOrFetchChannel(msg: Message) {
-  // TODO: cache eviction?
-  const channelInfo = await runTakeFirst(
-    db.selectFrom("channel_info").selectAll().where("id", "=", msg.channelId),
-  );
+export const getOrFetchChannel = (msg: Message) =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
+    const rows = yield* db
+      .selectFrom("channel_info")
+      .selectAll()
+      .where("id", "=", msg.channelId);
+    const channelInfo = rows[0];
 
-  if (channelInfo) {
-    log("debug", "ActivityTracker", "Channel info found in cache", {
+    if (channelInfo) {
+      log("debug", "ActivityTracker", "Channel info found in cache", {
+        channelId: msg.channelId,
+        channelName: channelInfo.name,
+        category: channelInfo.category,
+      });
+      return channelInfo;
+    }
+
+    log("debug", "ActivityTracker", "Fetching channel info from Discord", {
       channelId: msg.channelId,
-      channelName: channelInfo.name,
-      category: channelInfo.category,
     });
-    return channelInfo;
-  }
 
-  log("debug", "ActivityTracker", "Fetching channel info from Discord", {
-    channelId: msg.channelId,
+    const data = yield* Effect.tryPromise({
+      try: () => msg.channel.fetch() as Promise<TextChannel>,
+      catch: (e) => e,
+    });
+    const values = {
+      id: msg.channelId,
+      category: data.parent?.name ?? null,
+      category_id: data.parent?.id ?? null,
+      name: data.name,
+    };
+
+    yield* db.insertInto("channel_info").values(values);
+
+    log("debug", "ActivityTracker", "Channel info added to cache", {
+      channelId: msg.channelId,
+      channelName: data.name,
+      category: data.parent?.name,
+      categoryId: data.parent?.id,
+    });
+
+    return values;
   });
-
-  const data = (await msg.channel.fetch()) as TextChannel;
-  const values = {
-    id: msg.channelId,
-    category: data.parent?.name ?? null,
-    category_id: data.parent?.id ?? null,
-    name: data.name,
-  };
-
-  await run(db.insertInto("channel_info").values(values));
-
-  log("debug", "ActivityTracker", "Channel info added to cache", {
-    channelId: msg.channelId,
-    channelName: data.name,
-    category: data.parent?.name,
-    categoryId: data.parent?.id,
-  });
-
-  return values;
-}

--- a/app/features/Admin/helpers.server.ts
+++ b/app/features/Admin/helpers.server.ts
@@ -1,6 +1,9 @@
 import { data } from "react-router";
 
-import { posthogClient } from "#~/AppRuntime";
+import { Effect } from "effect";
+
+import { runEffect } from "#~/AppRuntime";
+import { PostHogService } from "#~/effects/posthog";
 import { requireUser } from "#~/models/session.server";
 import { StripeService } from "#~/models/stripe.server";
 
@@ -13,10 +16,19 @@ export async function requireAdmin(request: Request) {
 }
 
 export async function fetchFeatureFlags(guildId: string) {
-  if (!posthogClient) return null;
-  return (await posthogClient.getAllFlags(guildId, {
-    groups: { guild: guildId },
-  })) as Record<string, string | boolean>;
+  return runEffect(
+    Effect.gen(function* () {
+      const posthog = yield* PostHogService;
+      if (!posthog) return null;
+      return yield* Effect.tryPromise({
+        try: () =>
+          posthog.getAllFlags(guildId, {
+            groups: { guild: guildId },
+          }) as Promise<Record<string, string | boolean>>,
+        catch: () => null,
+      });
+    }).pipe(Effect.catchAll(() => Effect.succeed(null))),
+  );
 }
 
 export async function fetchStripeDetails(stripeCustomerId: string) {

--- a/app/helpers/cohortAnalysis.ts
+++ b/app/helpers/cohortAnalysis.ts
@@ -1,7 +1,9 @@
+import { Effect } from "effect";
 import { sql } from "kysely";
 import { partition } from "lodash-es";
 
-import { run } from "#~/AppRuntime";
+import { runEffect } from "#~/AppRuntime";
+import { DatabaseService } from "#~/Database";
 import type { CodeStats } from "#~/helpers/discord";
 import { descriptiveStats, percentile } from "#~/helpers/statistics";
 import { createMessageStatsQuery } from "#~/models/activity.server";
@@ -265,78 +267,92 @@ export async function getCohortMetrics(
   end: string,
   minMessageThreshold = 10,
 ): Promise<UserCohortMetrics[]> {
-  // Get aggregated user data
-  const userStatsQuery = createMessageStatsQuery(guildId, start, end)
-    .select((eb) => [
-      "author_id",
-      eb.fn.count<number>("author_id").as("message_count"),
-      eb.fn.sum<number>("word_count").as("word_count"),
-      eb.fn.sum<number>("react_count").as("reaction_count"),
-      eb.fn("group_concat", ["code_stats"]).as("code_stats_json"),
-      eb
-        .fn("date", [eb("sent_at", "/", eb.lit(1000)), sql.lit("unixepoch")])
-        .as("date"),
-    ])
-    .groupBy("author_id")
-    .having((eb) =>
-      eb(eb.fn.count<number>("author_id"), ">=", minMessageThreshold),
-    );
+  return runEffect(
+    Effect.gen(function* () {
+      const db = yield* DatabaseService;
 
-  const userStats = await run(userStatsQuery);
+      // Get aggregated user data
+      const userStatsQuery = createMessageStatsQuery(db, guildId, start, end)
+        .select((eb) => [
+          "author_id",
+          eb.fn.count<number>("author_id").as("message_count"),
+          eb.fn.sum<number>("word_count").as("word_count"),
+          eb.fn.sum<number>("react_count").as("reaction_count"),
+          eb.fn("group_concat", ["code_stats"]).as("code_stats_json"),
+          eb
+            .fn("date", [
+              eb("sent_at", "/", eb.lit(1000)),
+              sql.lit("unixepoch"),
+            ])
+            .as("date"),
+        ])
+        .groupBy("author_id")
+        .having((eb) =>
+          eb(eb.fn.count<number>("author_id"), ">=", minMessageThreshold),
+        );
 
-  // Get daily activity for streak calculation
-  const dailyActivityQuery = createMessageStatsQuery(guildId, start, end)
-    .select(({ fn, eb, lit }) => [
-      "author_id",
-      fn.count<number>("author_id").as("message_count"),
-      eb
-        .fn("date", [eb("sent_at", "/", lit(1000)), sql.lit("unixepoch")])
-        .as("date"),
-    ])
-    .groupBy(["author_id", "date"])
-    .where(
-      "author_id",
-      "in",
-      userStats.map((u) => u.author_id),
-    );
+      const userStats = yield* userStatsQuery;
 
-  const dailyActivity = await run(dailyActivityQuery);
+      // Get daily activity for streak calculation
+      const dailyActivityQuery = createMessageStatsQuery(
+        db,
+        guildId,
+        start,
+        end,
+      )
+        .select(({ fn, eb, lit }) => [
+          "author_id",
+          fn.count<number>("author_id").as("message_count"),
+          eb
+            .fn("date", [eb("sent_at", "/", lit(1000)), sql.lit("unixepoch")])
+            .as("date"),
+        ])
+        .groupBy(["author_id", "date"])
+        .where(
+          "author_id",
+          "in",
+          userStats.map((u) => u.author_id),
+        );
 
-  // Group daily activity by user
-  const dailyActivityByUser = dailyActivity.reduce(
-    (acc, record) => {
-      const userId = record.author_id;
-      if (!acc[userId]) acc[userId] = [];
-      acc[userId].push({
-        date: record.date as string,
-        messageCount: record.message_count,
+      const dailyActivity = yield* dailyActivityQuery;
+
+      // Group daily activity by user
+      const dailyActivityByUser = dailyActivity.reduce(
+        (acc, record) => {
+          const userId = record.author_id;
+          if (!acc[userId]) acc[userId] = [];
+          acc[userId].push({
+            date: record.date as string,
+            messageCount: record.message_count,
+          });
+          return acc;
+        },
+        {} as Record<string, { date: string; messageCount: number }[]>,
+      );
+
+      return userStats.map((user) => {
+        const codeStatsArray = user.code_stats_json
+          ? JSON.stringify(user.code_stats_json).split(",").filter(Boolean)
+          : [];
+
+        const userDailyActivity = fillDateGaps(
+          dailyActivityByUser[user.author_id] || [],
+          start,
+          end,
+          { messageCount: 0 },
+        );
+
+        return {
+          userId: user.author_id,
+          messageCount: user.message_count,
+          wordCount: user.word_count || 0,
+          reactionCount: user.reaction_count || 0,
+          codeStats: aggregateCodeStats(codeStatsArray),
+          streakData: calculateStreakData(userDailyActivity),
+        };
       });
-      return acc;
-    },
-    {} as Record<string, { date: string; messageCount: number }[]>,
+    }),
   );
-
-  return userStats.map((user) => {
-    const codeStatsArray = user.code_stats_json
-      ? JSON.stringify(user.code_stats_json).split(",").filter(Boolean)
-      : [];
-
-    const userDailyActivity = fillDateGaps(
-      dailyActivityByUser[user.author_id] || [],
-      start,
-      end,
-      { messageCount: 0 },
-    );
-
-    return {
-      userId: user.author_id,
-      messageCount: user.message_count,
-      wordCount: user.word_count || 0,
-      reactionCount: user.reaction_count || 0,
-      codeStats: aggregateCodeStats(codeStatsArray),
-      streakData: calculateStreakData(userDailyActivity),
-    };
-  });
 }
 
 export function calculateCohortBenchmarks(

--- a/app/helpers/metrics.ts
+++ b/app/helpers/metrics.ts
@@ -8,8 +8,18 @@ import type {
   UserContextMenuCommandInteraction,
 } from "discord.js";
 
-import { posthogClient } from "#~/AppRuntime.ts";
+import type { PostHog } from "posthog-node";
+
+import { runtime } from "#~/AppRuntime";
+import { PostHogService } from "#~/effects/posthog";
 import { log } from "#~/helpers/observability";
+
+let _posthog: PostHog | null | undefined;
+
+/** Must be called once at startup before event handlers fire. */
+export async function initPostHogMetrics(): Promise<void> {
+  _posthog = await runtime.runPromise(PostHogService);
+}
 
 type EventValue = string | number | boolean;
 type EmitEventData = Record<string, EventValue | EventValue[]>;
@@ -316,10 +326,10 @@ const emitEvent = (
     user_id: userId,
     event_type: eventName,
     event_properties: data,
-    client: Boolean(posthogClient),
+    client: Boolean(_posthog),
   });
 
-  posthogClient?.capture({
+  _posthog?.capture({
     distinctId: userId ?? "system",
     event: eventName,
     properties: {

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -11,7 +11,9 @@ import {
   type RESTPostAPIGuildChannelJSONBody,
 } from "discord-api-types/v10";
 
-import { db, run, runTakeFirst } from "#~/AppRuntime";
+import { runEffect } from "#~/AppRuntime";
+import { DatabaseService } from "#~/Database";
+import { Effect } from "effect";
 import { DEFAULT_MESSAGE_TEXT } from "#~/commands/setupHoneypot";
 import { DEFAULT_BUTTON_TEXT } from "#~/commands/setupTickets";
 import { ssrDiscordSdk } from "#~/discord/api";
@@ -107,20 +109,34 @@ export async function setupAll(
   await registerGuild(guildId);
 
   // --- Load existing config to skip unchanged values ---
-  const existingAppConfig = await runTakeFirst(
-    db
-      .selectFrom("application_config")
-      .select(["channel_id", "role_id"])
-      .where("guild_id", "=", guildId),
+  const existingAppConfig = await runEffect(
+    Effect.gen(function* () {
+      const db = yield* DatabaseService;
+      const rows = yield* db
+        .selectFrom("application_config")
+        .select(["channel_id", "role_id"])
+        .where("guild_id", "=", guildId);
+      return rows[0];
+    }),
   );
-  const existingHoneypot = await runTakeFirst(
-    db
-      .selectFrom("honeypot_config")
-      .select("channel_id")
-      .where("guild_id", "=", guildId),
+  const existingHoneypot = await runEffect(
+    Effect.gen(function* () {
+      const db = yield* DatabaseService;
+      const rows = yield* db
+        .selectFrom("honeypot_config")
+        .select("channel_id")
+        .where("guild_id", "=", guildId);
+      return rows[0];
+    }),
   );
-  const existingTicket = await runTakeFirst(
-    db.selectFrom("tickets_config").select("channel_id"),
+  const existingTicket = await runEffect(
+    Effect.gen(function* () {
+      const db = yield* DatabaseService;
+      const rows = yield* db
+        .selectFrom("tickets_config")
+        .select("channel_id");
+      return rows[0];
+    }),
   );
 
   // --- Logs category (created if mod-log or deletion-log needs creation) ---
@@ -279,22 +295,25 @@ export async function setupAll(
     });
 
     // Step 6: Insert into application_config (upsert on re-setup)
-    await run(
-      db
-        .insertInto("application_config")
-        .values({
-          guild_id: guildId,
-          channel_id: applicationChannelId,
-          role_id: resolvedMemberRoleId,
-          message_id: appMessage.id,
-        })
-        .onConflict((c) =>
-          c.column("guild_id").doUpdateSet({
-            channel_id: applicationChannelId,
-            role_id: resolvedMemberRoleId,
+    await runEffect(
+      Effect.gen(function* () {
+        const db = yield* DatabaseService;
+        yield* db
+          .insertInto("application_config")
+          .values({
+            guild_id: guildId,
+            channel_id: applicationChannelId!,
+            role_id: resolvedMemberRoleId!,
             message_id: appMessage.id,
-          }),
-        ),
+          })
+          .onConflict((c) =>
+            c.column("guild_id").doUpdateSet({
+              channel_id: applicationChannelId!,
+              role_id: resolvedMemberRoleId!,
+              message_id: appMessage.id,
+            }),
+          );
+      }),
     );
 
     // Create a persistent background job for bulk role assignment.
@@ -359,14 +378,17 @@ export async function setupAll(
   }
 
   if (honeypotChannelId !== undefined) {
-    await run(
-      db
-        .insertInto("honeypot_config")
-        .values({
-          guild_id: guildId,
-          channel_id: honeypotChannelId,
-        })
-        .onConflict((c) => c.doNothing()),
+    await runEffect(
+      Effect.gen(function* () {
+        const db = yield* DatabaseService;
+        yield* db
+          .insertInto("honeypot_config")
+          .values({
+            guild_id: guildId,
+            channel_id: honeypotChannelId,
+          })
+          .onConflict((c) => c.doNothing());
+      }),
     );
   }
 
@@ -405,11 +427,14 @@ export async function setupAll(
       ],
     });
 
-    await run(
-      db.insertInto("tickets_config").values({
-        message_id: ticketMessage.id,
-        channel_id: ticketChannelId,
-        role_id: moderatorRoleId,
+    await runEffect(
+      Effect.gen(function* () {
+        const db = yield* DatabaseService;
+        yield* db.insertInto("tickets_config").values({
+          message_id: ticketMessage.id,
+          channel_id: ticketChannelId,
+          role_id: moderatorRoleId,
+        });
       }),
     );
   }

--- a/app/models/activity.server.ts
+++ b/app/models/activity.server.ts
@@ -1,7 +1,8 @@
+import { Effect } from "effect";
 import { sql } from "kysely";
 
-import { db, run } from "#~/AppRuntime";
-import { type DB } from "#~/Database";
+import { runEffect } from "#~/AppRuntime";
+import { DatabaseService, type DB, type EffectKysely } from "#~/Database";
 import { getUserCohortAnalysis } from "#~/helpers/cohortAnalysis";
 import { fillDateGaps } from "#~/helpers/dateUtils";
 import { getOrFetchUser } from "#~/helpers/userInfoCache";
@@ -22,6 +23,7 @@ const ALLOWED_CHANNELS: string[] = [];
  * Creates a base query for message_stats filtered by guild, date range, and optionally user
  */
 export function createMessageStatsQuery(
+  db: EffectKysely,
   guildId: MessageStats["guild_id"],
   start: string,
   end: string,
@@ -49,93 +51,116 @@ export async function getUserMessageAnalytics(
   start: string,
   end: string,
 ) {
-  // Build daily stats query
-  const dailyQuery = createMessageStatsQuery(guildId, start, end, userId)
-    .select(({ fn, eb, lit }) => [
-      fn.countAll<number>().as("messages"),
-      fn.sum<number>("word_count").as("word_count"),
-      fn.sum<number>("react_count").as("react_count"),
-      fn("round", [fn.avg("word_count"), lit(3)]).as("avg_words"),
-      eb
-        .fn("date", [eb("sent_at", "/", lit(1000)), sql.lit("unixepoch")])
-        .as("date"),
-    ])
-    .where((eb) =>
-      eb.or([
-        eb("channel_id", "in", ALLOWED_CHANNELS),
-        eb("channel_category", "in", ALLOWED_CATEGORIES),
-      ]),
-    )
-    .orderBy("date", "asc")
-    .groupBy("date");
+  return runEffect(
+    Effect.gen(function* () {
+      const db = yield* DatabaseService;
 
-  // Build category stats query
-  const categoryQuery = createMessageStatsQuery(guildId, start, end, userId)
-    .select(({ fn }) => [
-      fn.count<number>("channel_category").as("messages"),
-      "channel_category",
-    ])
-    .where((eb) =>
-      eb.or([
-        eb("channel_id", "in", ALLOWED_CHANNELS),
-        eb("channel_category", "in", ALLOWED_CATEGORIES),
-      ]),
-    )
-    .groupBy("channel_category");
+      // Build daily stats query
+      const dailyQuery = createMessageStatsQuery(db, guildId, start, end, userId)
+        .select(({ fn, eb, lit }) => [
+          fn.countAll<number>().as("messages"),
+          fn.sum<number>("word_count").as("word_count"),
+          fn.sum<number>("react_count").as("react_count"),
+          fn("round", [fn.avg("word_count"), lit(3)]).as("avg_words"),
+          eb
+            .fn("date", [eb("sent_at", "/", lit(1000)), sql.lit("unixepoch")])
+            .as("date"),
+        ])
+        .where((eb) =>
+          eb.or([
+            eb("channel_id", "in", ALLOWED_CHANNELS),
+            eb("channel_category", "in", ALLOWED_CATEGORIES),
+          ]),
+        )
+        .orderBy("date", "asc")
+        .groupBy("date");
 
-  // Build channel stats query
-  const channelQuery = createMessageStatsQuery(guildId, start, end, userId)
-    // @ts-expect-error - Kysely selector typing is complex
-    .select(({ fn }) => [
-      fn.count<number>("channel_id").as("messages"),
-      "channel_id",
-      "channel.name",
-    ])
-    .leftJoin(
-      "channel_info as channel",
-      "channel.id",
-      "message_stats.channel_id",
-    )
-    .where((eb) =>
-      eb.or([
-        eb("channel_id", "in", ALLOWED_CHANNELS),
-        eb("channel_category", "in", ALLOWED_CATEGORIES),
-      ]),
-    )
-    .orderBy("messages", "desc")
-    .groupBy("channel_id");
+      // Build category stats query
+      const categoryQuery = createMessageStatsQuery(
+        db,
+        guildId,
+        start,
+        end,
+        userId,
+      )
+        .select(({ fn }) => [
+          fn.count<number>("channel_category").as("messages"),
+          "channel_category",
+        ])
+        .where((eb) =>
+          eb.or([
+            eb("channel_id", "in", ALLOWED_CHANNELS),
+            eb("channel_category", "in", ALLOWED_CATEGORIES),
+          ]),
+        )
+        .groupBy("channel_category");
 
-  console.log("sql:", { compiled: dailyQuery.compile() });
+      // Build channel stats query
+      const channelQuery = createMessageStatsQuery(
+        db,
+        guildId,
+        start,
+        end,
+        userId,
+      )
+        // @ts-expect-error - Kysely selector typing is complex
+        .select(({ fn }) => [
+          fn.count<number>("channel_id").as("messages"),
+          "channel_id",
+          "channel.name",
+        ])
+        .leftJoin(
+          "channel_info as channel",
+          "channel.id",
+          "message_stats.channel_id",
+        )
+        .where((eb) =>
+          eb.or([
+            eb("channel_id", "in", ALLOWED_CHANNELS),
+            eb("channel_category", "in", ALLOWED_CATEGORIES),
+          ]),
+        )
+        .orderBy("messages", "desc")
+        .groupBy("channel_id");
 
-  const [dailyResults, categoryBreakdown, channelBreakdown, userInfo] =
-    await Promise.all([
-      run(dailyQuery),
-      run(categoryQuery),
-      run(channelQuery),
-      getOrFetchUser(userId),
-    ]);
+      console.log("sql:", { compiled: dailyQuery.compile() });
 
-  interface DailyBreakdown {
-    messages: number;
-    word_count: number;
-    react_count: number;
-    avg_words: number;
-    date: string;
-  }
-  // Only daily breakdown needs date gap filling
-  const dailyBreakdown = fillDateGaps<DailyBreakdown>(
-    dailyResults as DailyBreakdown[],
-    start,
-    end,
-    {
-      messages: 0,
-      word_count: 0,
-      react_count: 0,
-      avg_words: 0,
-    },
+      const [dailyResults, categoryBreakdown, channelBreakdown, userInfo] =
+        yield* Effect.all(
+          [
+            dailyQuery,
+            categoryQuery,
+            channelQuery,
+            Effect.tryPromise({
+              try: () => getOrFetchUser(userId),
+              catch: (e) => e,
+            }),
+          ],
+        ).pipe(Effect.withConcurrency("unbounded"));
+
+      interface DailyBreakdown {
+        messages: number;
+        word_count: number;
+        react_count: number;
+        avg_words: number;
+        date: string;
+      }
+      // Only daily breakdown needs date gap filling
+      const dailyBreakdown = fillDateGaps<DailyBreakdown>(
+        dailyResults as DailyBreakdown[],
+        start,
+        end,
+        {
+          messages: 0,
+          word_count: 0,
+          react_count: 0,
+          avg_words: 0,
+        },
+      );
+
+      return { dailyBreakdown, categoryBreakdown, channelBreakdown, userInfo };
+    }),
   );
-
-  return { dailyBreakdown, categoryBreakdown, channelBreakdown, userInfo };
 }
 
 export async function getEnhancedUserAnalytics(
@@ -160,130 +185,162 @@ export async function getTopParticipants(
   intervalStart: string,
   intervalEnd: string,
 ) {
-  const config = {
-    count: 100,
-    messageThreshold: 250,
-    wordThreshold: 2200,
-  };
+  return runEffect(
+    Effect.gen(function* () {
+      const db = yield* DatabaseService;
 
-  const baseQuery = createMessageStatsQuery(guildId, intervalStart, intervalEnd)
-    .selectAll()
-    .select(({ fn, eb, lit }) => [
-      fn("date", [eb("sent_at", "/", lit(1000)), sql.lit("unixepoch")]).as(
-        "date",
-      ),
-    ]);
-
-  // Apply channel filtering inline
-  const filteredQuery = baseQuery.where((eb) =>
-    eb.or([
-      eb("channel_id", "in", ALLOWED_CHANNELS),
-      eb("channel_category", "in", ALLOWED_CATEGORIES),
-    ]),
-  );
-
-  // get shortlist using inline selectors
-  const topMembersQuery = db
-    .with("interval_message_stats", () => filteredQuery)
-    // .with("interval_message_stats", () => baseQuery)
-    .selectFrom("interval_message_stats")
-    .select(({ fn }) => [
-      "author_id",
-      fn.sum<number>("word_count").as("total_word_count"),
-      fn.count<number>("author_id").as("message_count"),
-      fn.sum<number>("react_count").as("total_reaction_count"),
-      fn.count<number>("channel_category").distinct().as("category_count"),
-      fn.count<number>("channel_id").distinct().as("channel_count"),
-    ])
-    .orderBy("message_count desc")
-    .groupBy("author_id")
-    .having(({ eb, or, fn }) =>
-      or([
-        eb(fn.count<number>("author_id"), ">=", config.messageThreshold),
-        eb(fn.sum<number>("word_count"), ">=", config.wordThreshold),
-      ]),
-    )
-    .limit(config.count);
-  console.log(topMembersQuery.compile().sql);
-  const topMembers = await run(topMembersQuery);
-
-  const dailyParticipationQuery = db
-    .with("interval_message_stats", () => filteredQuery)
-    // .with("interval_message_stats", () => baseQuery)
-    .selectFrom("interval_message_stats")
-    .select(({ fn }) => [
-      "author_id",
-      "date",
-      fn.count<number>("author_id").as("message_count"),
-      fn.sum<number>("word_count").as("word_count"),
-      fn.count<number>("channel_id").distinct().as("channel_count"),
-      fn.count<number>("channel_category").distinct().as("category_count"),
-    ])
-    .distinct()
-    .groupBy("date")
-    .groupBy("author_id")
-    .where(
-      "author_id",
-      "in",
-      topMembers.map((m) => m.author_id),
-    );
-  console.log(dailyParticipationQuery.compile().sql);
-  const rawDailyParticipation = await run(dailyParticipationQuery);
-  // Group by author and fill date gaps inline
-  const groupedData = rawDailyParticipation.reduce((acc, record) => {
-    const { author_id, date } = record;
-    if (!acc[author_id]) acc[author_id] = [];
-    acc[author_id].push({ ...record, date: date as string });
-    return acc;
-  }, {} as GroupedResult);
-
-  const dailyParticipation: GroupedResult = {};
-  for (const authorId in groupedData) {
-    dailyParticipation[authorId] = fillDateGaps(
-      groupedData[authorId],
-      intervalStart,
-      intervalEnd,
-      { message_count: 0, word_count: 0, channel_count: 0, category_count: 0 },
-    );
-  }
-
-  const scores = topMembers.map((m) => {
-    const member = m as MemberData;
-    const participation = dailyParticipation[member.author_id];
-    const categoryCounts = participation
-      .map((p) => p.category_count)
-      .sort((a, b) => a - b);
-    const zeroDays = participation.filter((p) => p.message_count === 0).length;
-
-    return {
-      score: {
-        channelScore: scoreValue(member.channel_count, scoreLookups.channels),
-        messageScore: scoreValue(member.message_count, scoreLookups.messages),
-        wordScore: scoreValue(member.total_word_count, scoreLookups.words),
-        consistencyScore: Math.ceil(
-          categoryCounts[Math.floor(categoryCounts.length / 2)],
-        ),
-      },
-      metadata: {
-        percentZeroDays: zeroDays / participation.length,
-      },
-      data: { participation, member },
-    };
-  });
-
-  const withUsernames = await Promise.all(
-    scores.map(async (scores) => {
-      const user = await getOrFetchUser(scores.data.member.author_id);
-      return {
-        ...scores,
-        data: {
-          ...scores.data,
-          member: { ...scores.data.member, username: user?.global_name },
-        },
+      const config = {
+        count: 100,
+        messageThreshold: 250,
+        wordThreshold: 2200,
       };
+
+      const baseQuery = createMessageStatsQuery(
+        db,
+        guildId,
+        intervalStart,
+        intervalEnd,
+      )
+        .selectAll()
+        .select(({ fn, eb, lit }) => [
+          fn("date", [eb("sent_at", "/", lit(1000)), sql.lit("unixepoch")]).as(
+            "date",
+          ),
+        ]);
+
+      // Apply channel filtering inline
+      const filteredQuery = baseQuery.where((eb) =>
+        eb.or([
+          eb("channel_id", "in", ALLOWED_CHANNELS),
+          eb("channel_category", "in", ALLOWED_CATEGORIES),
+        ]),
+      );
+
+      // get shortlist using inline selectors
+      const topMembersQuery = db
+        .with("interval_message_stats", () => filteredQuery)
+        // .with("interval_message_stats", () => baseQuery)
+        .selectFrom("interval_message_stats")
+        .select(({ fn }) => [
+          "author_id",
+          fn.sum<number>("word_count").as("total_word_count"),
+          fn.count<number>("author_id").as("message_count"),
+          fn.sum<number>("react_count").as("total_reaction_count"),
+          fn.count<number>("channel_category").distinct().as("category_count"),
+          fn.count<number>("channel_id").distinct().as("channel_count"),
+        ])
+        .orderBy("message_count desc")
+        .groupBy("author_id")
+        .having(({ eb, or, fn }) =>
+          or([
+            eb(fn.count<number>("author_id"), ">=", config.messageThreshold),
+            eb(fn.sum<number>("word_count"), ">=", config.wordThreshold),
+          ]),
+        )
+        .limit(config.count);
+      console.log(topMembersQuery.compile().sql);
+      const topMembers = yield* topMembersQuery;
+
+      const dailyParticipationQuery = db
+        .with("interval_message_stats", () => filteredQuery)
+        // .with("interval_message_stats", () => baseQuery)
+        .selectFrom("interval_message_stats")
+        .select(({ fn }) => [
+          "author_id",
+          "date",
+          fn.count<number>("author_id").as("message_count"),
+          fn.sum<number>("word_count").as("word_count"),
+          fn.count<number>("channel_id").distinct().as("channel_count"),
+          fn.count<number>("channel_category").distinct().as("category_count"),
+        ])
+        .distinct()
+        .groupBy("date")
+        .groupBy("author_id")
+        .where(
+          "author_id",
+          "in",
+          topMembers.map((m) => m.author_id),
+        );
+      console.log(dailyParticipationQuery.compile().sql);
+      const rawDailyParticipation = yield* dailyParticipationQuery;
+      // Group by author and fill date gaps inline
+      const groupedData = rawDailyParticipation.reduce((acc, record) => {
+        const { author_id, date } = record;
+        if (!acc[author_id]) acc[author_id] = [];
+        acc[author_id].push({ ...record, date: date as string });
+        return acc;
+      }, {} as GroupedResult);
+
+      const dailyParticipation: GroupedResult = {};
+      for (const authorId in groupedData) {
+        dailyParticipation[authorId] = fillDateGaps(
+          groupedData[authorId],
+          intervalStart,
+          intervalEnd,
+          {
+            message_count: 0,
+            word_count: 0,
+            channel_count: 0,
+            category_count: 0,
+          },
+        );
+      }
+
+      const scores = topMembers.map((m) => {
+        const member = m as MemberData;
+        const participation = dailyParticipation[member.author_id];
+        const categoryCounts = participation
+          .map((p) => p.category_count)
+          .sort((a, b) => a - b);
+        const zeroDays = participation.filter(
+          (p) => p.message_count === 0,
+        ).length;
+
+        return {
+          score: {
+            channelScore: scoreValue(
+              member.channel_count,
+              scoreLookups.channels,
+            ),
+            messageScore: scoreValue(
+              member.message_count,
+              scoreLookups.messages,
+            ),
+            wordScore: scoreValue(member.total_word_count, scoreLookups.words),
+            consistencyScore: Math.ceil(
+              categoryCounts[Math.floor(categoryCounts.length / 2)],
+            ),
+          },
+          metadata: {
+            percentZeroDays: zeroDays / participation.length,
+          },
+          data: { participation, member },
+        };
+      });
+
+      const withUsernames = yield* Effect.all(
+        scores.map((scores) =>
+          Effect.tryPromise({
+            try: () => getOrFetchUser(scores.data.member.author_id),
+            catch: (e) => e,
+          }).pipe(
+            Effect.map((user) => ({
+              ...scores,
+              data: {
+                ...scores.data,
+                member: {
+                  ...scores.data.member,
+                  username: user?.global_name,
+                },
+              },
+            })),
+          ),
+        ),
+      ).pipe(Effect.withConcurrency("unbounded"));
+
+      return withUsernames;
     }),
   );
-  return withUsernames;
 }
 
 // copy-pasted out of TopMembers query result

--- a/app/models/guilds.server.test.ts
+++ b/app/models/guilds.server.test.ts
@@ -1,7 +1,11 @@
-import BetterSqlite3 from "better-sqlite3";
-import { Kysely, SqliteDialect } from "kysely";
+import { Effect, Layer, ManagedRuntime } from "effect";
+import { SqlClient } from "@effect/sql";
+import * as Reactivity from "@effect/experimental/Reactivity";
+import * as Sqlite from "@effect/sql-kysely/Sqlite";
+import { SqliteClient } from "@effect/sql-sqlite-node";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
+import { DatabaseService } from "#~/Database";
 import type { DB } from "#~/db";
 
 // The global setup mock only stubs `log`; guilds.server also uses trackPerformance
@@ -12,51 +16,41 @@ vi.mock("#~/helpers/observability", () => ({
   trackPerformance: (_op: string, fn: () => unknown) => fn(),
 }));
 
-// We build a real in-memory Kysely instance and wire it into the mocked
-// AppRuntime so that `guilds.server.ts` runs its queries against our test db.
-// The real AppRuntime uses @effect/sql-kysely which patches query builders to
-// also be Effect instances; the `run` helpers call Effect.runPromise on them.
-// In tests we skip the Effect layer and call `.execute()` directly.
-let testDb: Kysely<DB>;
-let rawDb: InstanceType<typeof BetterSqlite3>;
+let testRuntime: ManagedRuntime.ManagedRuntime<any, never>;
 
-vi.mock("#~/AppRuntime", () => {
-  return {
-    get db() {
-      return testDb;
-    },
-    // The real `run` calls Effect.runPromise on an EffectKysely query builder.
-    // A plain Kysely query builder is a thenable that resolves via .execute(),
-    // so we just await it.
-    run: async (qb: { execute: () => Promise<unknown> }) => qb.execute(),
-    runTakeFirst: async (qb: { execute: () => Promise<unknown[]> }) => {
-      const rows = await qb.execute();
-      return rows[0];
-    },
-    runTakeFirstOrThrow: async (qb: { execute: () => Promise<unknown[]> }) => {
-      const rows = await qb.execute();
-      if (rows[0] === undefined) throw new Error("No rows returned");
-      return rows[0];
-    },
-  };
-});
+vi.mock("#~/AppRuntime", () => ({
+  get runEffect() {
+    return <A, E>(effect: Effect.Effect<A, E, any>): Promise<A> =>
+      testRuntime.runPromise(effect);
+  },
+}));
 
-beforeEach(() => {
-  rawDb = new BetterSqlite3(":memory:");
-  rawDb.exec(`
-    CREATE TABLE guilds (
-      id TEXT PRIMARY KEY,
-      settings TEXT
-    )
-  `);
+beforeEach(async () => {
+  const SqliteLive = Layer.scoped(
+    SqlClient.SqlClient,
+    SqliteClient.make({ filename: ":memory:" }),
+  ).pipe(Layer.provide(Reactivity.layer));
 
-  testDb = new Kysely<DB>({
-    dialect: new SqliteDialect({ database: rawDb }),
-  });
+  const KyselyLive = Layer.effect(DatabaseService, Sqlite.make<DB>()).pipe(
+    Layer.provide(SqliteLive),
+  );
+
+  const TestLayer = Layer.mergeAll(SqliteLive, KyselyLive);
+  testRuntime = ManagedRuntime.make(TestLayer);
+
+  // Create the guilds table
+  await testRuntime.runPromise(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql.unsafe(
+        "CREATE TABLE guilds (id TEXT PRIMARY KEY, settings TEXT)",
+      );
+    }),
+  );
 });
 
 afterEach(async () => {
-  await testDb.destroy();
+  await testRuntime.dispose();
 });
 
 // Dynamic import so that the mock is in place before the module loads.
@@ -65,7 +59,14 @@ const loadModule = () => import("#~/models/guilds.server");
 describe("setSettings coalesce fix", () => {
   test("persists settings when existing settings column is NULL", async () => {
     // Simulate a guild row where settings is NULL (the bug scenario from #335)
-    rawDb.exec(`INSERT INTO guilds (id, settings) VALUES ('guild-null', NULL)`);
+    await testRuntime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        yield* sql.unsafe(
+          "INSERT INTO guilds (id, settings) VALUES ('guild-null', NULL)",
+        );
+      }),
+    );
 
     const { setSettings, fetchGuild } = await loadModule();
 
@@ -130,9 +131,15 @@ describe("registerGuild", () => {
 
     await registerGuild("guild-new");
 
-    const row = rawDb
-      .prepare("SELECT id, settings FROM guilds WHERE id = ?")
-      .get("guild-new") as { id: string; settings: string };
+    const row = await testRuntime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        const rows = yield* sql.unsafe<{ id: string; settings: string }>(
+          "SELECT id, settings FROM guilds WHERE id = 'guild-new'",
+        );
+        return rows[0];
+      }),
+    );
     expect(row).toBeDefined();
     expect(row.id).toBe("guild-new");
     expect(row.settings).toBe("{}");

--- a/app/models/guilds.server.ts
+++ b/app/models/guilds.server.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 
-import { db, run, runTakeFirst, runTakeFirstOrThrow } from "#~/AppRuntime";
+import { runEffect } from "#~/AppRuntime";
 import { DatabaseService, type DB } from "#~/Database";
 import { NotFoundError } from "#~/effects/errors.ts";
 import { log, trackPerformance } from "#~/helpers/observability";
@@ -37,8 +37,15 @@ export const fetchGuild = async (guildId: string) => {
     async () => {
       log("debug", "Guild", "Fetching guild", { guildId });
 
-      const guild = await runTakeFirst(
-        db.selectFrom("guilds").selectAll().where("id", "=", guildId),
+      const guild = await runEffect(
+        Effect.gen(function* () {
+          const db = yield* DatabaseService;
+          const rows = yield* db
+            .selectFrom("guilds")
+            .selectAll()
+            .where("id", "=", guildId);
+          return rows[0];
+        }),
       );
 
       log("debug", "Guild", guild ? "Guild found" : "Guild not found", {
@@ -59,14 +66,17 @@ export const registerGuild = async (guildId: string) => {
     async () => {
       log("info", "Guild", "Registering guild", { guildId });
 
-      await run(
-        db
-          .insertInto("guilds")
-          .values({
-            id: guildId,
-            settings: JSON.stringify({}),
-          })
-          .onConflict((oc) => oc.column("id").doNothing()),
+      await runEffect(
+        Effect.gen(function* () {
+          const db = yield* DatabaseService;
+          yield* db
+            .insertInto("guilds")
+            .values({
+              id: guildId,
+              settings: JSON.stringify({}),
+            })
+            .onConflict((oc) => oc.column("id").doNothing());
+        }),
       );
 
       log("info", "Guild", "Guild registered successfully", { guildId });
@@ -79,16 +89,19 @@ export const setSettings = async (
   guildId: string,
   settings: SettingsRecord,
 ) => {
-  await run(
-    db
-      .updateTable("guilds")
-      .set("settings", (eb) =>
-        eb.fn("json_patch", [
-          eb.fn("coalesce", ["settings", eb.val("{}")]),
-          eb.val(JSON.stringify(settings)),
-        ]),
-      )
-      .where("id", "=", guildId),
+  await runEffect(
+    Effect.gen(function* () {
+      const db = yield* DatabaseService;
+      yield* db
+        .updateTable("guilds")
+        .set("settings", (eb) =>
+          eb.fn("json_patch", [
+            eb.fn("coalesce", ["settings", eb.val("{}")]),
+            eb.val(JSON.stringify(settings)),
+          ]),
+        )
+        .where("id", "=", guildId);
+    }),
   );
 };
 
@@ -97,17 +110,24 @@ export const fetchSettings = async <T extends keyof typeof SETTINGS>(
   keys: T[],
 ) => {
   const result = Object.entries(
-    await runTakeFirstOrThrow(
-      db
-        .selectFrom("guilds")
-        // @ts-expect-error This is broken because of a migration from knex and
-        // old/bad use of jsonb for storing settings. The type is guaranteed here
-        // not by the codegen
-        .select<DB, "guilds", SettingsRecord>((eb) =>
-          keys.map((k) => eb.ref("settings", "->>").key(k).as(k)),
-        )
-        .where("id", "=", guildId),
-      // This cast is also evidence of the pattern being broken
+    await runEffect(
+      Effect.gen(function* () {
+        const db = yield* DatabaseService;
+        const rows = yield* db
+          .selectFrom("guilds")
+          // @ts-expect-error This is broken because of a migration from knex and
+          // old/bad use of jsonb for storing settings. The type is guaranteed here
+          // not by the codegen
+          .select<DB, "guilds", SettingsRecord>((eb) =>
+            keys.map((k) => eb.ref("settings", "->>").key(k).as(k)),
+          )
+          .where("id", "=", guildId);
+        if (rows[0] === undefined)
+          return yield* Effect.fail(
+            new NotFoundError({ resource: "db record", id: "" }),
+          );
+        return rows[0];
+      }),
     ),
   ) as [T, string][];
   return Object.fromEntries(result) as Pick<SettingsRecord, T>;

--- a/app/models/session.server.ts
+++ b/app/models/session.server.ts
@@ -7,8 +7,11 @@ import {
 } from "react-router";
 import { AuthorizationCode } from "simple-oauth2";
 
-import { db, run, runTakeFirst, runTakeFirstOrThrow } from "#~/AppRuntime";
-import { type DB } from "#~/Database";
+import { Effect } from "effect";
+
+import { runEffect } from "#~/AppRuntime";
+import { DatabaseService, type DB } from "#~/Database";
+import { NotFoundError } from "#~/effects/errors";
 import {
   applicationId,
   discordSecret,
@@ -71,15 +74,23 @@ const {
     sameSite: "lax",
   },
   async createData(data, expires) {
-    const result = await runTakeFirstOrThrow(
-      db
-        .insertInto("sessions")
-        .values({
-          id: randomUUID(),
-          data: JSON.stringify(data),
-          expires: expires?.toString(),
-        })
-        .returning("id"),
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const db = yield* DatabaseService;
+        const rows = yield* db
+          .insertInto("sessions")
+          .values({
+            id: randomUUID(),
+            data: JSON.stringify(data),
+            expires: expires?.toString(),
+          })
+          .returning("id");
+        if (rows[0] === undefined)
+          return yield* Effect.fail(
+            new NotFoundError({ resource: "db record", id: "" }),
+          );
+        return rows[0];
+      }),
     );
     if (!result.id) {
       console.error({ result, data, expires });
@@ -88,8 +99,15 @@ const {
     return result.id;
   },
   async readData(id) {
-    const result = await runTakeFirst(
-      db.selectFrom("sessions").where("id", "=", id).selectAll(),
+    const result = await runEffect(
+      Effect.gen(function* () {
+        const db = yield* DatabaseService;
+        const rows = yield* db
+          .selectFrom("sessions")
+          .where("id", "=", id)
+          .selectAll();
+        return rows[0];
+      }),
     );
 
     if (!result?.data) return null;
@@ -101,16 +119,24 @@ const {
       : result.data;
   },
   async updateData(id, data, expires) {
-    await run(
-      db
-        .updateTable("sessions")
-        .set("data", JSON.stringify(data))
-        .set("expires", expires?.toString() ?? null)
-        .where("id", "=", id),
+    await runEffect(
+      Effect.gen(function* () {
+        const db = yield* DatabaseService;
+        yield* db
+          .updateTable("sessions")
+          .set("data", JSON.stringify(data))
+          .set("expires", expires?.toString() ?? null)
+          .where("id", "=", id);
+      }),
     );
   },
   async deleteData(id) {
-    await run(db.deleteFrom("sessions").where("id", "=", id));
+    await runEffect(
+      Effect.gen(function* () {
+        const db = yield* DatabaseService;
+        yield* db.deleteFrom("sessions").where("id", "=", id);
+      }),
+    );
   },
 });
 export type DbSession = Awaited<ReturnType<typeof getDbSession>>;

--- a/app/models/subscriptions.server.ts
+++ b/app/models/subscriptions.server.ts
@@ -1,4 +1,6 @@
-import { db, run, runTakeFirst } from "#~/AppRuntime";
+import { Effect } from "effect";
+import { runEffect } from "#~/AppRuntime";
+import { DatabaseService } from "#~/Database";
 import { log, trackPerformance } from "#~/helpers/observability";
 import Sentry from "#~/helpers/sentry.server";
 
@@ -17,11 +19,15 @@ export const SubscriptionService = {
           guildId,
         });
 
-        const result = await runTakeFirst(
-          db
-            .selectFrom("guild_subscriptions")
-            .selectAll()
-            .where("guild_id", "=", guildId),
+        const result = await runEffect(
+          Effect.gen(function* () {
+            const db = yield* DatabaseService;
+            const rows = yield* db
+              .selectFrom("guild_subscriptions")
+              .selectAll()
+              .where("guild_id", "=", guildId);
+            return rows[0];
+          }),
         );
 
         if (result) {
@@ -68,29 +74,32 @@ export const SubscriptionService = {
         const existing = await this.getGuildSubscription(data.guild_id);
         const isUpdate = !!existing;
 
-        await run(
-          db
-            .insertInto("guild_subscriptions")
-            .values({
-              guild_id: data.guild_id,
-              stripe_customer_id: data.stripe_customer_id ?? null,
-              stripe_subscription_id: data.stripe_subscription_id ?? null,
-              product_tier: data.product_tier,
-              status: data.status ?? "active",
-              current_period_end: data.current_period_end ?? null,
-              created_at: new Date().toISOString(),
-              updated_at: new Date().toISOString(),
-            })
-            .onConflict((oc) =>
-              oc.column("guild_id").doUpdateSet({
+        await runEffect(
+          Effect.gen(function* () {
+            const db = yield* DatabaseService;
+            yield* db
+              .insertInto("guild_subscriptions")
+              .values({
+                guild_id: data.guild_id,
                 stripe_customer_id: data.stripe_customer_id ?? null,
                 stripe_subscription_id: data.stripe_subscription_id ?? null,
                 product_tier: data.product_tier,
                 status: data.status ?? "active",
                 current_period_end: data.current_period_end ?? null,
+                created_at: new Date().toISOString(),
                 updated_at: new Date().toISOString(),
-              }),
-            ),
+              })
+              .onConflict((oc) =>
+                oc.column("guild_id").doUpdateSet({
+                  stripe_customer_id: data.stripe_customer_id ?? null,
+                  stripe_subscription_id: data.stripe_subscription_id ?? null,
+                  product_tier: data.product_tier,
+                  status: data.status ?? "active",
+                  current_period_end: data.current_period_end ?? null,
+                  updated_at: new Date().toISOString(),
+                }),
+              );
+          }),
         );
 
         log(
@@ -140,15 +149,18 @@ export const SubscriptionService = {
           throw new Error(`No subscription found for guild ${guildId}`);
         }
 
-        await run(
-          db
-            .updateTable("guild_subscriptions")
-            .set({
-              status,
-              current_period_end: currentPeriodEnd ?? null,
-              updated_at: new Date().toISOString(),
-            })
-            .where("guild_id", "=", guildId),
+        await runEffect(
+          Effect.gen(function* () {
+            const db = yield* DatabaseService;
+            yield* db
+              .updateTable("guild_subscriptions")
+              .set({
+                status,
+                current_period_end: currentPeriodEnd ?? null,
+                updated_at: new Date().toISOString(),
+              })
+              .where("guild_id", "=", guildId);
+          }),
         );
 
         log(
@@ -339,37 +351,40 @@ export const SubscriptionService = {
       async () => {
         log("debug", "Subscription", "Fetching subscription metrics");
 
-        const [total, active, free, paid, inactive] = await Promise.all([
-          runTakeFirst(
-            db
-              .selectFrom("guild_subscriptions")
-              .select((eb) => eb.fn.countAll<number>().as("count")),
-          ),
-          runTakeFirst(
-            db
-              .selectFrom("guild_subscriptions")
-              .select((eb) => eb.fn.countAll<number>().as("count"))
-              .where("status", "=", "active"),
-          ),
-          runTakeFirst(
-            db
-              .selectFrom("guild_subscriptions")
-              .select((eb) => eb.fn.countAll<number>().as("count"))
-              .where("product_tier", "=", "free"),
-          ),
-          runTakeFirst(
-            db
-              .selectFrom("guild_subscriptions")
-              .select((eb) => eb.fn.countAll<number>().as("count"))
-              .where("product_tier", "=", "paid"),
-          ),
-          runTakeFirst(
-            db
-              .selectFrom("guild_subscriptions")
-              .select((eb) => eb.fn.countAll<number>().as("count"))
-              .where("status", "=", "inactive"),
-          ),
-        ]);
+        const [total, active, free, paid, inactive] = await runEffect(
+          Effect.gen(function* () {
+            const db = yield* DatabaseService;
+            return yield* Effect.all(
+              [
+                db
+                  .selectFrom("guild_subscriptions")
+                  .select((eb) => eb.fn.countAll<number>().as("count"))
+                  .pipe(Effect.map((rows) => rows[0])),
+                db
+                  .selectFrom("guild_subscriptions")
+                  .select((eb) => eb.fn.countAll<number>().as("count"))
+                  .where("status", "=", "active")
+                  .pipe(Effect.map((rows) => rows[0])),
+                db
+                  .selectFrom("guild_subscriptions")
+                  .select((eb) => eb.fn.countAll<number>().as("count"))
+                  .where("product_tier", "=", "free")
+                  .pipe(Effect.map((rows) => rows[0])),
+                db
+                  .selectFrom("guild_subscriptions")
+                  .select((eb) => eb.fn.countAll<number>().as("count"))
+                  .where("product_tier", "=", "paid")
+                  .pipe(Effect.map((rows) => rows[0])),
+                db
+                  .selectFrom("guild_subscriptions")
+                  .select((eb) => eb.fn.countAll<number>().as("count"))
+                  .where("status", "=", "inactive")
+                  .pipe(Effect.map((rows) => rows[0])),
+              ],
+              { concurrency: "unbounded" },
+            );
+          }),
+        );
 
         const metrics = {
           totalSubscriptions: total?.count ?? 0,
@@ -393,8 +408,11 @@ export const SubscriptionService = {
       async () => {
         log("debug", "Subscription", "Fetching all guild subscriptions");
 
-        const results = await run(
-          db.selectFrom("guild_subscriptions").selectAll(),
+        const results = await runEffect(
+          Effect.gen(function* () {
+            const db = yield* DatabaseService;
+            return yield* db.selectFrom("guild_subscriptions").selectAll();
+          }),
         );
 
         log("debug", "Subscription", "Fetched all subscriptions", {

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "crypto";
 
-import { db, run, runTakeFirst, runTakeFirstOrThrow } from "#~/AppRuntime";
-import { type DB } from "#~/Database";
+import { Effect } from "effect";
+
+import { runEffect } from "#~/AppRuntime";
+import { DatabaseService, type DB } from "#~/Database";
+import { NotFoundError } from "#~/effects/errors";
 import { log, trackPerformance } from "#~/helpers/observability";
 
 export type User = DB["users"];
@@ -12,8 +15,15 @@ export async function getUserById(id: User["id"]) {
     async () => {
       log("debug", "User", "Fetching user by ID", { userId: id });
 
-      const user = await runTakeFirst(
-        db.selectFrom("users").selectAll().where("id", "=", id),
+      const user = await runEffect(
+        Effect.gen(function* () {
+          const db = yield* DatabaseService;
+          const rows = yield* db
+            .selectFrom("users")
+            .selectAll()
+            .where("id", "=", id);
+          return rows[0];
+        }),
       );
 
       log("debug", "User", user ? "User found" : "User not found", {
@@ -35,8 +45,15 @@ export async function getUserByExternalId(externalId: User["externalId"]) {
     async () => {
       log("debug", "User", "Fetching user by external ID", { externalId });
 
-      const user = await runTakeFirst(
-        db.selectFrom("users").selectAll().where("externalId", "=", externalId),
+      const user = await runEffect(
+        Effect.gen(function* () {
+          const db = yield* DatabaseService;
+          const rows = yield* db
+            .selectFrom("users")
+            .selectAll()
+            .where("externalId", "=", externalId);
+          return rows[0];
+        }),
       );
 
       log(
@@ -64,8 +81,15 @@ export async function getUserByEmail(email: User["email"]) {
     async () => {
       log("debug", "User", "Fetching user by email", { email });
 
-      const user = await runTakeFirst(
-        db.selectFrom("users").selectAll().where("email", "=", email),
+      const user = await runEffect(
+        Effect.gen(function* () {
+          const db = yield* DatabaseService;
+          const rows = yield* db
+            .selectFrom("users")
+            .selectAll()
+            .where("email", "=", email);
+          return rows[0];
+        }),
       );
 
       log(
@@ -99,18 +123,26 @@ export async function createUser(
         authProvider: "discord",
       });
 
-      const out = await runTakeFirstOrThrow(
-        db
-          .insertInto("users")
-          .values([
-            {
-              id: randomUUID(),
-              email,
-              externalId,
-              authProvider: "discord",
-            },
-          ])
-          .returningAll(),
+      const out = await runEffect(
+        Effect.gen(function* () {
+          const db = yield* DatabaseService;
+          const rows = yield* db
+            .insertInto("users")
+            .values([
+              {
+                id: randomUUID(),
+                email,
+                externalId,
+                authProvider: "discord",
+              },
+            ])
+            .returningAll();
+          if (rows[0] === undefined)
+            return yield* Effect.fail(
+              new NotFoundError({ resource: "db record", id: "" }),
+            );
+          return rows[0];
+        }),
       );
 
       log("info", "User", "User created successfully", {
@@ -127,5 +159,10 @@ export async function createUser(
 }
 
 export async function deleteUserByEmail(email: User["email"]) {
-  return run(db.deleteFrom("users").where("email", "=", email));
+  return runEffect(
+    Effect.gen(function* () {
+      const db = yield* DatabaseService;
+      return yield* db.deleteFrom("users").where("email", "=", email);
+    }),
+  );
 }

--- a/app/routes/__auth/app.tsx
+++ b/app/routes/__auth/app.tsx
@@ -1,8 +1,11 @@
 import { useLoaderData } from "react-router";
 
-import { db, run } from "#~/AppRuntime";
+import { Effect } from "effect";
+
+import { runEffect } from "#~/AppRuntime";
 import { AddEunoCard } from "#~/components/AddEunoCard";
 import { ServerCard } from "#~/components/ServerCard";
+import { DatabaseService } from "#~/Database";
 import { ssrDiscordSdk, userDiscordSdkFromRequest } from "#~/discord/api";
 import { botInviteUrl } from "#~/helpers/botPermissions";
 import { getCachedGuilds } from "#~/helpers/guildCache.server";
@@ -55,49 +58,50 @@ export async function loader({ request }: Route.LoaderArgs) {
     Date.now() - 30 * 24 * 60 * 60 * 1000,
   ).toISOString();
 
-  const [dailyReportRows, modActionRows, escalationRows, allSubscriptions] =
-    await Promise.all([
-      // 1. Daily report counts for sparklines
-      run(
-        db
-          .selectFrom("reported_messages")
-          .select((eb) => [
-            "guild_id",
-            eb
-              .fn("strftime", [eb.val("%Y-%m-%d"), eb.ref("created_at")])
-              .as("day"),
-            eb.fn.countAll<number>().as("count"),
-          ])
-          .where("guild_id", "in", guildIds)
-          .where("created_at", ">=", thirtyDaysAgo)
-          .groupBy(["guild_id", "day"])
-          .orderBy("guild_id")
-          .orderBy("day"),
-      ),
+  const [dbResults, allSubscriptions] = await Promise.all([
+    runEffect(
+      Effect.gen(function* () {
+        const db = yield* DatabaseService;
+        return yield* Effect.all([
+          // 1. Daily report counts for sparklines
+          db
+            .selectFrom("reported_messages")
+            .select((eb) => [
+              "guild_id",
+              eb
+                .fn("strftime", [eb.val("%Y-%m-%d"), eb.ref("created_at")])
+                .as("day"),
+              eb.fn.countAll<number>().as("count"),
+            ])
+            .where("guild_id", "in", guildIds)
+            .where("created_at", ">=", thirtyDaysAgo)
+            .groupBy(["guild_id", "day"])
+            .orderBy("guild_id")
+            .orderBy("day"),
 
-      // 2. Mod action counts (30 days)
-      run(
-        db
-          .selectFrom("mod_actions")
-          .select((eb) => ["guild_id", eb.fn.countAll<number>().as("count")])
-          .where("guild_id", "in", guildIds)
-          .where("created_at", ">=", thirtyDaysAgo)
-          .groupBy("guild_id"),
-      ),
+          // 2. Mod action counts (30 days)
+          db
+            .selectFrom("mod_actions")
+            .select((eb) => ["guild_id", eb.fn.countAll<number>().as("count")])
+            .where("guild_id", "in", guildIds)
+            .where("created_at", ">=", thirtyDaysAgo)
+            .groupBy("guild_id"),
 
-      // 3. Open escalation counts
-      run(
-        db
-          .selectFrom("escalations")
-          .select((eb) => ["guild_id", eb.fn.countAll<number>().as("count")])
-          .where("guild_id", "in", guildIds)
-          .where("resolution", "is", null)
-          .groupBy("guild_id"),
-      ),
+          // 3. Open escalation counts
+          db
+            .selectFrom("escalations")
+            .select((eb) => ["guild_id", eb.fn.countAll<number>().as("count")])
+            .where("guild_id", "in", guildIds)
+            .where("resolution", "is", null)
+            .groupBy("guild_id"),
+        ]).pipe(Effect.withConcurrency("unbounded"));
+      }),
+    ),
 
-      // 4. All subscriptions
-      SubscriptionService.getAllSubscriptions(),
-    ]);
+    // 4. All subscriptions
+    SubscriptionService.getAllSubscriptions(),
+  ]);
+  const [dailyReportRows, modActionRows, escalationRows] = dbResults;
 
   // Build sparkline arrays (30 days, zero-filled)
   const sparklines = new Map<string, number[]>();

--- a/app/routes/__auth/guild.tsx
+++ b/app/routes/__auth/guild.tsx
@@ -1,7 +1,10 @@
 import { data, Link, useLoaderData } from "react-router";
 
-import { db, run } from "#~/AppRuntime";
+import { Effect } from "effect";
+
+import { runEffect } from "#~/AppRuntime";
 import { Sparkline } from "#~/components/Sparkline";
+import { DatabaseService } from "#~/Database";
 import { ssrDiscordSdk, userDiscordSdkFromRequest } from "#~/discord/api";
 import { getCachedGuilds } from "#~/helpers/guildCache.server";
 import { requireUser } from "#~/models/session.server";
@@ -44,70 +47,69 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     Date.now() - 30 * 24 * 60 * 60 * 1000,
   ).toISOString();
 
-  const [
-    dailyReportRows,
-    modActionsByType,
-    reportsByReason,
-    openEscalations,
-    tier,
-  ] = await Promise.all([
-    // Daily report counts for sparkline (30 days)
-    run(
-      db
-        .selectFrom("reported_messages")
-        .select((eb) => [
-          eb
-            .fn("strftime", [eb.val("%Y-%m-%d"), eb.ref("created_at")])
-            .as("day"),
-          eb.fn.countAll<number>().as("count"),
-        ])
-        .where("guild_id", "=", guildId)
-        .where("created_at", ">=", thirtyDaysAgo)
-        .groupBy("day")
-        .orderBy("day"),
-    ),
+  const [dbResults, tier] = await Promise.all([
+    runEffect(
+      Effect.gen(function* () {
+        const db = yield* DatabaseService;
+        return yield* Effect.all([
+          // Daily report counts for sparkline (30 days)
+          db
+            .selectFrom("reported_messages")
+            .select((eb) => [
+              eb
+                .fn("strftime", [eb.val("%Y-%m-%d"), eb.ref("created_at")])
+                .as("day"),
+              eb.fn.countAll<number>().as("count"),
+            ])
+            .where("guild_id", "=", guildId)
+            .where("created_at", ">=", thirtyDaysAgo)
+            .groupBy("day")
+            .orderBy("day"),
 
-    // Mod action counts grouped by action_type
-    run(
-      db
-        .selectFrom("mod_actions")
-        .select((eb) => ["action_type", eb.fn.countAll<number>().as("count")])
-        .where("guild_id", "=", guildId)
-        .where("created_at", ">=", thirtyDaysAgo)
-        .groupBy("action_type"),
-    ),
+          // Mod action counts grouped by action_type
+          db
+            .selectFrom("mod_actions")
+            .select((eb) => [
+              "action_type",
+              eb.fn.countAll<number>().as("count"),
+            ])
+            .where("guild_id", "=", guildId)
+            .where("created_at", ">=", thirtyDaysAgo)
+            .groupBy("action_type"),
 
-    // Report counts grouped by reason
-    run(
-      db
-        .selectFrom("reported_messages")
-        .select((eb) => ["reason", eb.fn.countAll<number>().as("count")])
-        .where("guild_id", "=", guildId)
-        .where("created_at", ">=", thirtyDaysAgo)
-        .groupBy("reason")
-        .orderBy("count", "desc"),
-    ),
+          // Report counts grouped by reason
+          db
+            .selectFrom("reported_messages")
+            .select((eb) => ["reason", eb.fn.countAll<number>().as("count")])
+            .where("guild_id", "=", guildId)
+            .where("created_at", ">=", thirtyDaysAgo)
+            .groupBy("reason")
+            .orderBy("count", "desc"),
 
-    // Open escalations (full rows, limited to 10)
-    run(
-      db
-        .selectFrom("escalations")
-        .select([
-          "id",
-          "reported_user_id",
-          "initiator_id",
-          "created_at",
-          "thread_id",
-        ])
-        .where("guild_id", "=", guildId)
-        .where("resolution", "is", null)
-        .orderBy("created_at", "desc")
-        .limit(10),
+          // Open escalations (full rows, limited to 10)
+          db
+            .selectFrom("escalations")
+            .select([
+              "id",
+              "reported_user_id",
+              "initiator_id",
+              "created_at",
+              "thread_id",
+            ])
+            .where("guild_id", "=", guildId)
+            .where("resolution", "is", null)
+            .orderBy("created_at", "desc")
+            .limit(10),
+        ]).pipe(Effect.withConcurrency("unbounded"));
+      }),
     ),
 
     // Subscription tier
     SubscriptionService.getProductTier(guildId),
   ]);
+
+  const [dailyReportRows, modActionsByType, reportsByReason, openEscalations] =
+    dbResults;
 
   // Build sparkline array (30 days, zero-filled)
   const sparkline = new Array(30).fill(0);

--- a/app/routes/export-data.tsx
+++ b/app/routes/export-data.tsx
@@ -1,4 +1,7 @@
-import { db, run, runTakeFirst } from "#~/AppRuntime";
+import { Effect } from "effect";
+
+import { runEffect } from "#~/AppRuntime";
+import { DatabaseService } from "#~/Database";
 import { log, trackPerformance } from "#~/helpers/observability";
 import { requireUser } from "#~/models/session.server";
 import { SubscriptionService } from "#~/models/subscriptions.server";
@@ -62,8 +65,15 @@ export async function loader({ request }: Route.LoaderArgs) {
         });
 
         // Get guild settings
-        const guild = await runTakeFirst(
-          db.selectFrom("guilds").selectAll().where("id", "=", guildId),
+        const guild = await runEffect(
+          Effect.gen(function* () {
+            const db = yield* DatabaseService;
+            const rows = yield* db
+              .selectFrom("guilds")
+              .selectAll()
+              .where("id", "=", guildId);
+            return rows[0];
+          }),
         );
 
         if (guild) {
@@ -87,12 +97,15 @@ export async function loader({ request }: Route.LoaderArgs) {
         }
 
         // Get message statistics (aggregated, no actual message content)
-        const messageStats = await run(
-          db
-            .selectFrom("message_stats")
-            .selectAll()
-            .where("guild_id", "=", guildId)
-            .limit(1000), // Limit to prevent huge exports
+        const messageStats = await runEffect(
+          Effect.gen(function* () {
+            const db = yield* DatabaseService;
+            return yield* db
+              .selectFrom("message_stats")
+              .selectAll()
+              .where("guild_id", "=", guildId)
+              .limit(1000); // Limit to prevent huge exports
+          }),
         );
 
         if (messageStats.length > 0) {
@@ -108,13 +121,16 @@ export async function loader({ request }: Route.LoaderArgs) {
         }
 
         // Get reported messages (sanitized)
-        const reportedMessages = await run(
-          db
-            .selectFrom("reported_messages")
-            .selectAll()
-            .where("guild_id", "=", guildId)
-            .where("deleted_at", "is", null)
-            .limit(100),
+        const reportedMessages = await runEffect(
+          Effect.gen(function* () {
+            const db = yield* DatabaseService;
+            return yield* db
+              .selectFrom("reported_messages")
+              .selectAll()
+              .where("guild_id", "=", guildId)
+              .where("deleted_at", "is", null)
+              .limit(100);
+          }),
         );
 
         if (reportedMessages.length > 0) {
@@ -188,23 +204,25 @@ export async function action({ request }: Route.ActionArgs) {
       }
 
       // Soft delete reported messages for this guild
-      await run(
-        db
-          .updateTable("reported_messages")
-          .set({ deleted_at: new Date().toISOString() })
-          .where("guild_id", "=", guildId),
+      await runEffect(
+        Effect.gen(function* () {
+          const db = yield* DatabaseService;
+          yield* db
+            .updateTable("reported_messages")
+            .set({ deleted_at: new Date().toISOString() })
+            .where("guild_id", "=", guildId);
+
+          yield* db
+            .deleteFrom("message_stats")
+            .where("guild_id", "=", guildId);
+
+          yield* db
+            .deleteFrom("guild_subscriptions")
+            .where("guild_id", "=", guildId);
+
+          yield* db.deleteFrom("guilds").where("id", "=", guildId);
+        }),
       );
-
-      // Delete message stats
-      await run(db.deleteFrom("message_stats").where("guild_id", "=", guildId));
-
-      // Delete subscription data
-      await run(
-        db.deleteFrom("guild_subscriptions").where("guild_id", "=", guildId),
-      );
-
-      // Delete guild settings
-      await run(db.deleteFrom("guilds").where("id", "=", guildId));
 
       log("info", "DataDelete", "Guild data deleted successfully", {
         userId: user.id,

--- a/app/routes/healthcheck.tsx
+++ b/app/routes/healthcheck.tsx
@@ -1,5 +1,9 @@
 // learn more: https://fly.io/docs/reference/configuration/#services-http_checks
-import { db, run } from "#~/AppRuntime";
+import { Effect } from "effect";
+
+import { SqlClient } from "@effect/sql";
+
+import { runEffect } from "#~/AppRuntime";
 
 import type { Route } from "./+types/healthcheck";
 
@@ -12,13 +16,13 @@ export async function loader({ request }: Route.LoaderArgs) {
     // if we can connect to the database and make a simple query
     // and make a HEAD request to ourselves, then we're good.
     await Promise.all([
-      run(
-        db
-          // @ts-expect-error because kysely doesn't generate types for sqlite_master
-          .selectFrom("sqlite_master")
-          // @ts-expect-error because kysely doesn't generate types for sqlite_master
-          .select("name")
-          .where("type", "=", "table"),
+      runEffect(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient;
+          yield* sql.unsafe(
+            "SELECT name FROM sqlite_master WHERE type = 'table'",
+          );
+        }),
       ),
       fetch(url.toString(), { method: "HEAD" }).then((r) => {
         if (!r.ok) {

--- a/app/server.ts
+++ b/app/server.ts
@@ -44,7 +44,7 @@ import { checkpointWal, runIntegrityCheck } from "./Database";
 import { DiscordApiError } from "./effects/errors";
 import { logEffect } from "./effects/observability";
 import { initializeGroups } from "./effects/posthog";
-import { botStats } from "./helpers/metrics";
+import { botStats, initPostHogMetrics } from "./helpers/metrics";
 
 declare global {
   var __shutdownHandlersRegistered: boolean | undefined;
@@ -108,6 +108,12 @@ const startup = Effect.gen(function* () {
 
   yield* logEffect("debug", "Server", "initializing Discord bot");
   const discordClient = yield* initDiscordBot;
+
+  // Initialize PostHog metrics client for fire-and-forget analytics
+  yield* Effect.tryPromise({
+    try: () => initPostHogMetrics(),
+    catch: (e) => new DiscordApiError({ operation: "initPostHogMetrics", cause: e }),
+  });
 
   yield* Effect.tryPromise({
     try: () =>


### PR DESCRIPTION
## Summary
- Remove top-level `await` from `AppRuntime.ts` that extracted `posthogClient` and `db` at module scope
- Delete deprecated `run`, `runTakeFirst`, `runTakeFirstOrThrow` bridge helpers — all DB access now goes through Effect's dependency injection
- Migrate all 18 consumer files to use `yield* DatabaseService` / `yield* PostHogService` inside `Effect.gen` blocks run through `runEffect`
- PostHog metrics use a lazy `initPostHogMetrics()` called at startup instead of a bare module-level client
- `getOrFetchChannel` returns an Effect instead of a Promise
- `createMessageStatsQuery` takes an explicit `db` parameter instead of closing over a module-level instance
- Route loaders consolidate parallel DB queries into `Effect.all`

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx vitest run` — all 278 tests pass (27 test files)
- [ ] Manual smoke test of `/setup` flow
- [ ] Verify bot startup and activity tracking work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)