### PR TITLE
fix: surface escalation errors and request missing bot permissions

### DIFF
--- a/app/commands/escalate/directActions.ts
+++ b/app/commands/escalate/directActions.ts
@@ -215,7 +215,14 @@ export const banUserAndDeleteMessages = (
           DELETE_MESSAGE_SECONDS,
         ),
       catch: (error) => new DiscordApiError({ operation: "ban", cause: error }),
-    });
+    }).pipe(
+      Effect.withSpan("discord.ban", {
+        attributes: {
+          userId: reportedUserId,
+          deleteMessageSeconds: DELETE_MESSAGE_SECONDS,
+        },
+      }),
+    );
 
     yield* logEffect(
       "info",

--- a/app/commands/escalate/handlers.ts
+++ b/app/commands/escalate/handlers.ts
@@ -181,11 +181,13 @@ const expedite = (interaction: MessageComponentInteraction) =>
     Effect.catchAll((error) =>
       logEffect("error", "EscalationHandlers", "Expedite failed", {
         error,
-      }).pipe(() =>
-        interactionFollowUp(interaction, {
-          content: "Something went wrong while executing the resolution.",
-          flags: [MessageFlags.Ephemeral],
-        }).pipe(Effect.catchAll(() => Effect.void)),
+      }).pipe(
+        Effect.zipRight(
+          interactionFollowUp(interaction, {
+            content: "Something went wrong while executing the resolution.",
+            flags: [MessageFlags.Ephemeral],
+          }).pipe(Effect.catchAll(() => Effect.void)),
+        ),
       ),
     ),
   );
@@ -235,10 +237,12 @@ const escalate = (interaction: MessageComponentInteraction) =>
     Effect.catchAll((error) =>
       logEffect("error", "EscalationHandlers", "Error handling escalation", {
         error,
-      }).pipe(() =>
-        interactionEditReply(interaction, {
-          content: "Failed to process escalation",
-        }).pipe(Effect.catchAll(() => Effect.void)),
+      }).pipe(
+        Effect.zipRight(
+          interactionEditReply(interaction, {
+            content: "Failed to process escalation",
+          }).pipe(Effect.catchAll(() => Effect.void)),
+        ),
       ),
     ),
   );
@@ -270,10 +274,12 @@ export const EscalationHandlers = {
       Effect.catchAll((error) =>
         logEffect("error", "EscalationHandlers", "Error deleting messages", {
           error,
-        }).pipe(() =>
-          interactionEditReply(interaction, {
-            content: "Failed to delete messages",
-          }).pipe(Effect.catchAll(() => Effect.void)),
+        }).pipe(
+          Effect.zipRight(
+            interactionEditReply(interaction, {
+              content: "Failed to delete messages",
+            }).pipe(Effect.catchAll(() => Effect.void)),
+          ),
         ),
       ),
     ),
@@ -296,11 +302,13 @@ export const EscalationHandlers = {
       Effect.catchAll((error) =>
         logEffect("error", "EscalationHandlers", "Error kicking user", {
           error,
-        }).pipe(() =>
-          interactionReply(interaction, {
-            content: "Failed to kick user",
-            flags: [MessageFlags.Ephemeral],
-          }).pipe(Effect.catchAll(() => Effect.void)),
+        }).pipe(
+          Effect.zipRight(
+            interactionReply(interaction, {
+              content: "Failed to kick user",
+              flags: [MessageFlags.Ephemeral],
+            }).pipe(Effect.catchAll(() => Effect.void)),
+          ),
         ),
       ),
       Effect.withSpan("escalation-kickUser", {
@@ -336,11 +344,13 @@ export const EscalationHandlers = {
       Effect.catchAll((error) =>
         logEffect("error", "EscalationHandlers", "Error banning user", {
           error,
-        }).pipe(() =>
-          interactionReply(interaction, {
-            content: "Failed to ban user",
-            flags: [MessageFlags.Ephemeral],
-          }).pipe(Effect.catchAll(() => Effect.void)),
+        }).pipe(
+          Effect.zipRight(
+            interactionReply(interaction, {
+              content: "Failed to ban user",
+              flags: [MessageFlags.Ephemeral],
+            }).pipe(Effect.catchAll(() => Effect.void)),
+          ),
         ),
       ),
     ),
@@ -373,11 +383,13 @@ export const EscalationHandlers = {
           "EscalationHandlers",
           "Error banning user and deleting messages",
           { error },
-        ).pipe(() =>
-          interactionReply(interaction, {
-            content: "Failed to ban user and delete messages",
-            flags: [MessageFlags.Ephemeral],
-          }).pipe(Effect.catchAll(() => Effect.void)),
+        ).pipe(
+          Effect.zipRight(
+            interactionReply(interaction, {
+              content: "Failed to ban user and delete messages",
+              flags: [MessageFlags.Ephemeral],
+            }).pipe(Effect.catchAll(() => Effect.void)),
+          ),
         ),
       ),
     ),
@@ -407,11 +419,13 @@ export const EscalationHandlers = {
       Effect.catchAll((error) =>
         logEffect("error", "EscalationHandlers", "Error restricting user", {
           error,
-        }).pipe(() =>
-          interactionReply(interaction, {
-            content: "Failed to restrict user",
-            flags: [MessageFlags.Ephemeral],
-          }).pipe(Effect.catchAll(() => Effect.void)),
+        }).pipe(
+          Effect.zipRight(
+            interactionReply(interaction, {
+              content: "Failed to restrict user",
+              flags: [MessageFlags.Ephemeral],
+            }).pipe(Effect.catchAll(() => Effect.void)),
+          ),
         ),
       ),
     ),
@@ -441,11 +455,13 @@ export const EscalationHandlers = {
       Effect.catchAll((error) =>
         logEffect("error", "EscalationHandlers", "Error timing out user", {
           error,
-        }).pipe(() =>
-          interactionReply(interaction, {
-            content: "Failed to timeout user",
-            flags: [MessageFlags.Ephemeral],
-          }).pipe(Effect.catchAll(() => Effect.void)),
+        }).pipe(
+          Effect.zipRight(
+            interactionReply(interaction, {
+              content: "Failed to timeout user",
+              flags: [MessageFlags.Ephemeral],
+            }).pipe(Effect.catchAll(() => Effect.void)),
+          ),
         ),
       ),
     ),

--- a/app/helpers/botPermissions.ts
+++ b/app/helpers/botPermissions.ts
@@ -15,8 +15,10 @@ export const REQUIRED_PERMISSIONS = [
     flag: PermissionFlagsBits.SendMessagesInThreads,
     name: "Send Messages in Threads",
   },
+  { flag: PermissionFlagsBits.EmbedLinks, name: "Embed Links" },
   { flag: PermissionFlagsBits.ViewChannel, name: "View Channels" },
   { flag: PermissionFlagsBits.KickMembers, name: "Kick Members" },
+  { flag: PermissionFlagsBits.BanMembers, name: "Ban Members" },
   { flag: PermissionFlagsBits.ModerateMembers, name: "Moderate Members" },
   {
     flag: PermissionFlagsBits.CreatePrivateThreads,

--- a/app/models/session.server.ts
+++ b/app/models/session.server.ts
@@ -9,6 +9,7 @@ import { AuthorizationCode } from "simple-oauth2";
 
 import { db, run, runTakeFirst, runTakeFirstOrThrow } from "#~/AppRuntime";
 import { type DB } from "#~/Database";
+import { BOT_PERMISSIONS } from "#~/helpers/botPermissions";
 import {
   applicationId,
   discordSecret,
@@ -228,8 +229,7 @@ export async function initOauthLogin({
 
   // Add bot-specific parameters
   if (flow !== "user") {
-    // Core permissions: ManageRoles + SendMessages + ManageMessages + ReadMessageHistory + ModerateMembers
-    authParams.permissions = "1099512100352";
+    authParams.permissions = BOT_PERMISSIONS.toString();
     if (guildId) {
       authParams.guild_id = guildId;
     }


### PR DESCRIPTION
## Summary
- Replace 7 instances of `logEffect(...).pipe(() => ...)` in escalate handlers — the thunk silently discarded the upstream log Effect, which is why a missing-permissions ban surfaced as an "unspecified failure" with no log entry
- Wrap `ban()` with `Effect.withSpan("discord.ban")` so traces show the Discord API failure directly
- Add `BanMembers` and `EmbedLinks` to `REQUIRED_PERMISSIONS` — both are exercised in code (`bans.create`, embeds in `deletionLogger`/`modreport`) but were never requested at install time, so existing installs run on whatever role defaults the server happens to grant
- Replace the hardcoded OAuth permission integer in `session.server.ts` with `BOT_PERMISSIONS.toString()` so the install URL stays in sync with the single source of truth

## Test plan
- [ ] Re-invite the bot to a test guild via the install URL — confirm "Ban Members" and "Embed Links" are pre-checked in Discord's grant screen
- [ ] Run `/check-requirements` — confirm the Bot Permissions check now includes Ban Members and Embed Links
- [ ] Trigger an escalation ban where the bot has Ban Members — confirm success
- [ ] Trigger an escalation ban where the bot lacks Ban Members — confirm a real error log appears with the Discord 50013 detail (not just "Failed to ban user and delete messages")
- [ ] Verify deletion-log embeds render after granting Embed Links

Note: existing installs won't auto-upgrade — server admins need to re-invite via the new URL or grant the permissions manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)