### PR TITLE
Back-merge release → main: CI-gated auto-merge + merge-commit hardening

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What does this PR change, and why? 1–3 sentences. -->
+
+## Testing
+
+<!-- How did you verify it? Note anything reviewers should check. -->
+
+- [ ]
+
+---
+
+<details>
+<summary>ℹ️ How this PR gets merged &amp; released</summary>
+
+- **This PR (→ `main`) is squash-merged** — keep the title meaningful; it becomes the `main` commit.
+- From `main`, changes ship through an automated cycle you don't manage:
+  1. **Weekly RC** (Mon cron) cuts `rc/vYYYY.WW` from `main`, opens an RC PR → `release`.
+  2. **UAT**: pushing to `rc/*` auto-deploys https://uat.euno-staging.reactiflux.com; put fixes on the `rc/*` branch.
+  3. **Promote**: approving the RC PR auto-merges it into `release` **as a merge commit** → draft Release → publish → prod.
+  4. **Back-merge**: publishing the Release auto-opens a `release → main` PR (merge commit) so release-only fixes return to `main`.
+- ⚠️ RC and back-merge PRs are bot-generated and **merge-commit-only** (the `release` ruleset blocks squash). Squashing them would sever history and break the back-merge.
+
+Full details: CONTRIBUTING.md → Release Candidate Workflow.
+
+</details>

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,0 +1,111 @@
+name: Back-merge release into main
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: backmerge-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backmerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: Euno-HQ
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Determine back-merge ref
+        id: ref
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ -n "${RELEASE_TAG}" ]; then
+            REF="${RELEASE_TAG}"
+          else
+            REF="manual-$(date -u +%Y%m%d%H%M%S)"
+          fi
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "branch=backmerge/${REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether release is already merged into main
+        id: guard
+        run: |
+          git fetch origin main release
+          if git merge-base --is-ancestor origin/release origin/main; then
+            echo "merged=true" >> "$GITHUB_OUTPUT"
+            echo "release is already an ancestor of main; nothing to back-merge."
+          else
+            echo "merged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for an existing open back-merge PR
+        id: existing
+        if: steps.guard.outputs.merged == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          EXISTING=$(gh pr list --base main --state open \
+            --json number,headRefName \
+            --jq 'map(select(.headRefName | startswith("backmerge/"))) | .[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "number=${EXISTING}" >> "$GITHUB_OUTPUT"
+            echo "An open back-merge PR already exists: #${EXISTING}; skipping."
+          fi
+
+      - name: Create back-merge branch at release tip
+        if: steps.guard.outputs.merged == 'false' && steps.existing.outputs.number == ''
+        env:
+          BRANCH: ${{ steps.ref.outputs.branch }}
+        run: |
+          git push --force origin "origin/release:refs/heads/${BRANCH}"
+
+      - name: Open back-merge PR and enable auto-merge
+        if: steps.guard.outputs.merged == 'false' && steps.existing.outputs.number == ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ steps.ref.outputs.branch }}
+          REF: ${{ steps.ref.outputs.ref }}
+        run: |
+          cat > /tmp/backmerge-body.md <<EOF
+          Automated back-merge of release into main after publishing ${REF}.
+
+          Brings release-only fixes (pushed to rc/* during UAT) back into the development line.
+
+          * Clean + CI-green: this PR auto-merges with no action needed.
+          * Conflicts or red CI: auto-merge stays pending. To resolve, run:
+
+              git fetch origin
+              git checkout ${BRANCH}
+              git merge origin/main
+              # resolve conflicts, commit, and push
+          EOF
+
+          gh label create backmerge --color BFD4F2 \
+            --description "Automated back-merge of release into main" 2>/dev/null || true
+
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "Back-merge release ${REF} into main" \
+            --label backmerge \
+            --body-file /tmp/backmerge-body.md)
+          echo "Opened ${PR_URL}"
+
+          gh pr merge "${PR_URL}" --auto --merge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,10 @@ env:
   HUSKY: 0
 
 on:
+  pull_request:
   push:
-    branches-ignore:
-      - "main"
+    branches:
+      - main
 
 jobs:
   lint:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -13,10 +13,21 @@ jobs:
   create-rc:
     runs-on: ubuntu-latest
     steps:
+      # App token (not GITHUB_TOKEN) so the RC branch push and PR trigger ci.yml/cd.yml —
+      # required checks can never go green on a PR opened by GITHUB_TOKEN.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: Euno-HQ
+
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Ensure release branch exists
         run: |
@@ -52,7 +63,7 @@ jobs:
         if: steps.check-commits.outputs.count != '0'
         id: existing-pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           EXISTING=$(gh pr list \
             --base release \
@@ -119,6 +130,8 @@ jobs:
           fi
 
           sed 's/^ \{10\}//' > /tmp/pr-body.md <<EOF
+          > ⚠️ **Approving this PR auto-merges it into \`release\` as a merge commit.** Approve only after UAT passes. The merge commit preserves ancestry, which the automated \`release\` → \`main\` back-merge depends on.
+
           ## Release Candidate ${VERSION}
 
           ### Commits ${RANGE_LABEL}
@@ -142,21 +155,27 @@ jobs:
       - name: Update existing RC pull request
         if: steps.check-commits.outputs.count != '0' && steps.existing-pr.outputs.number
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.existing-pr.outputs.number }}
         run: |
           echo "Updating existing RC PR #${PR_NUMBER}"
           gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.md
+          # Idempotent: ensure auto-merge (merge commit) stays enabled.
+          gh pr merge "$PR_NUMBER" --auto --merge
 
       - name: Create new RC pull request
         if: steps.check-commits.outputs.count != '0' && !steps.existing-pr.outputs.number
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           echo "Creating new RC PR for ${VERSION}"
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base release \
             --head "rc/${VERSION}" \
             --title "RC: ${VERSION}" \
-            --body-file /tmp/pr-body.md
+            --body-file /tmp/pr-body.md)
+          echo "Created ${PR_URL}"
+          # Enable auto-merge as a merge commit: it lands once the release gate
+          # (1 approval + CI checks) is satisfied. Approval is the post-UAT sign-off.
+          gh pr merge "$PR_URL" --auto --merge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,10 @@ directory.
 
 ## Development workflow
 
-- PRs to main use merge commits (not squash-and-merge).
+- Merge method is per PR type (enforced by branch rulesets): feature PRs → `main` are
+  **squash-merged**; RC PRs (`rc/* → release`) and back-merge PRs (`release → main`) use
+  **merge commits**. Merge commits preserve the ancestry the `release → main` back-merge
+  depends on. See CONTRIBUTING.md → PR merge strategy.
 - Do not push directly to `main` or `release`.
 - When an RC PR is open (`rc/v*` branch → `release`), bug fixes for the release
   should target the `rc/v*` branch.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,11 +57,18 @@ Production releases follow a weekly release candidate (RC) cycle:
    - Push bug fixes directly to the `rc/v*` branch (each push re-deploys UAT)
 
 3. **Promote to production**: When testing is complete:
-   - Merge the RC PR into `release`
+   - **Approve** the RC PR — it auto-merges into `release` as a merge commit once CI
+     passes (pushing a new fix to `rc/*` dismisses the approval, so you re-approve the
+     final state). Do not squash; the `release` ruleset only allows merge commits.
    - A draft GitHub Release is automatically created
    - Review and publish the GitHub Release to trigger production deployment
 
-4. **Ad-hoc releases**: The RC workflow can be triggered manually via
+4. **Back-merge to `main`**: Publishing the Release automatically opens a
+   `release → main` PR (a merge commit) so any fixes made on `rc/*` during testing flow
+   back into the development line. It is CI-gated and auto-merges when clean; if it
+   conflicts, it waits for a human to resolve. See `.github/workflows/backmerge.yml`.
+
+5. **Ad-hoc releases**: The RC workflow can be triggered manually via
    `workflow_dispatch` for urgent releases outside the weekly cycle.
 
 **Important:** The `release` branch is managed by automation. Do not push to it
@@ -69,8 +76,19 @@ directly.
 
 ### PR merge strategy
 
-PRs to `main` use **merge commits** (not squash-and-merge). This preserves
-individual commit history on main.
+Merge method depends on the PR type. The `main` and `release` branch rulesets
+enforce these — you can't pick the wrong one:
+
+| PR | Merge method | Notes |
+|----|--------------|-------|
+| Feature → `main` | **Squash** | The PR title becomes the commit on `main`, so keep it meaningful. |
+| `rc/*` → `release` | **Merge commit** (auto-merge) | Bot-opened; approving it auto-merges once CI passes. Squash/rebase are blocked on `release`. |
+| `release` → `main` (back-merge) | **Merge commit** | Bot-opened after a Release is published; returns release-only fixes to `main`. |
+
+Why merge commits for the RC and back-merge PRs: squashing (or rebasing) creates
+new commits with no ancestry link to `main`, which turns the `release → main`
+back-merge into a conflict **every cycle**. Feature PRs to `main` can squash freely,
+because `rc/*` branches are cut from `main` regardless of how those commits look.
 
 # Implementation notes
 

--- a/notes/2026-05-25_1_backmerge-release-to-main-design.md
+++ b/notes/2026-05-25_1_backmerge-release-to-main-design.md
@@ -1,0 +1,163 @@
+# Back-merge `release` → `main` — Design
+
+**Date:** 2026-05-25
+**Status:** Approved design, pending implementation plan
+**Branch:** `feat-backmerge-release-to-main`
+
+## Problem
+
+RC branches are cut from `main` (`git checkout -b rc/vYYYY.WW origin/main` in
+`release-candidate.yml`). During UAT testing, bug fixes are pushed *directly* to
+the `rc/*` branch, then the RC PR merges into `release`. Those fix commits — and
+the `release` branch's merge commits — never return to `main`. Over time `release`
+diverges from `main`: fixes that shipped to production silently go missing from the
+development line. There is no workflow and no documented process to reconcile this
+(only a TODO in `notes/2025-12-14_1_ci-cd-architecture-review.md`).
+
+## Goals
+
+- Automatically reconcile `release` back into `main` after each production release.
+- A bad merge must never silently break `main` — CI gates the landing.
+- No human action required for the common (clean) case.
+- Don't duplicate CI logic; `ci.yml` is the single source of truth.
+- Honor existing conventions: merge commits (not squash), no unattended direct
+  pushes to `main` for un-gated content.
+
+## Non-goals
+
+- Changing how RC branches are cut or how fixes are applied during UAT.
+- Cherry-pick-based reconciliation (see "Why merge, not cherry-pick").
+- Back-merging drafts that were never published.
+
+## Locked decisions
+
+1. **Trigger: on `release: published`.** Back-merge fires from the same event that
+   deploys production (`promote-release.yml`'s `deploy-production`). `main` receives
+   release-only fixes exactly when they actually ship — "what's in prod is in main."
+   An abandoned/never-published draft is never back-merged.
+
+2. **Oversight: auto-merge when clean, via a gated PR.** The back-merge always opens
+   a `release → main` PR and enables GitHub auto-merge. A clean, CI-green PR merges
+   itself with zero human action; a PR with conflicts or red CI stays open for a
+   human. CI is a true **pre-merge gate**, not after-the-fact detection.
+
+### Why merge, not cherry-pick
+
+A true merge records ancestry, so once `release` is merged its commits are never
+re-proposed. Cherry-picking rewrites SHAs, causing the *same* conflicts to resurface
+on every subsequent back-merge. Merge is the resilient steady-state mechanism;
+cherry-pick stays useful only for one-off emergency hotfixes.
+
+## Design
+
+### 1. `ci.yml` — single CI source of truth
+
+Today `ci.yml` triggers on `push: { branches-ignore: [main] }`. Change to:
+
+```yaml
+on:
+  pull_request:
+  push:
+    branches: [main]
+```
+
+- `pull_request` runs CI against the **merge ref** (head merged into base), so it
+  validates exactly what would land on `main`. This is what gates the back-merge PR,
+  and it tightens every other PR as a side benefit.
+- `push: [main]` covers the landed commit on `main`.
+- **Behavior change to flag:** non-PR branch pushes will no longer auto-run CI
+  (today every branch push runs it). The team flow is PR-based, so this is acceptable
+  and removes redundant runs — but it is a real change in behavior.
+
+Job names (`ESLint`, `TypeScript`, `Vitest`) are unchanged so they can be referenced
+as required status checks.
+
+### 2. `main` branch protection (one-time GitHub settings change)
+
+Not code — configured in repo settings, documented here and in the implementation
+plan as an explicit step:
+
+- Mark CI jobs **`ESLint`, `TypeScript`, `Vitest`** as **required status checks** on
+  `main`.
+- Enable **Allow auto-merge** on the repository.
+
+This is what makes auto-merge *wait* for green rather than merging instantly. It also
+closes the pre-existing gap that `main` has no required status checks
+(see `project_cicd_architecture` memory / `notes/2025-12-14_1_...`).
+
+### 3. New workflow `.github/workflows/backmerge.yml`
+
+Trigger:
+
+```yaml
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: backmerge-main
+  cancel-in-progress: false
+```
+
+Steps (single job):
+
+1. **Checkout** with `fetch-depth: 0` (needs full history of both branches).
+2. **Idempotency guard:** if `git merge-base --is-ancestor origin/release origin/main`
+   succeeds, exit cleanly — `release` is already integrated, nothing to do. After any
+   successful back-merge this is true, so re-runs and no-fix cycles are safe no-ops.
+   Also skip if an open `backmerge/*` PR already exists.
+3. **Create branch** `backmerge/<release-tag>` at `origin/release` and push it.
+4. **Open PR** `base: main`, `head: backmerge/<tag>`, labeled `backmerge`, with a body
+   explaining it is an automated back-merge and how to resolve conflicts locally.
+5. **Enable auto-merge:** `gh pr merge <pr> --auto --merge` (merge commit, honoring the
+   merge-commit policy).
+6. GitHub then takes over:
+   - CI runs on the PR (via `ci.yml` `pull_request`).
+   - **Clean + green → auto-merges, no human action.**
+   - **Conflict or red CI → auto-merge stays pending; PR waits for a human.** Resolution:
+     check out `backmerge/<tag>`, `git merge origin/main`, resolve, push — CI re-runs and
+     auto-merge completes (or merge manually).
+
+#### Critical auth detail
+
+The branch push **and** PR creation must use the **GitHub App token**
+(`APP_ID` / `APP_PRIVATE_KEY`, already used in `cd.yml` and `promote-release.yml`),
+**not** the default `GITHUB_TOKEN`. Events triggered by `GITHUB_TOKEN` do **not** start
+new workflow runs, so `ci.yml` would never run on the bot-created PR and the gate would
+never be satisfiable. A GitHub App installation token is a distinct actor and does
+trigger CI.
+
+Required workflow permissions: `contents: write`, `pull-requests: write`.
+
+## Resilience properties / edge cases
+
+- **True merge commit** on `main` → already-integrated history is never re-proposed
+  (no recurring-conflict trap).
+- **Idempotent** — safe to re-run; safe when there are no release-only changes.
+- **No silent breakage** — code lands only if conflict-free *and* CI-green; otherwise it
+  becomes a visible PR.
+- **Empty-diff releases** (RC merged with zero direct fixes): `release` still carries its
+  own merge commit not on `main`, so a PR is opened and auto-merges (CI passes on an
+  empty diff). Slightly noisy but preserves the "release is an ancestor of main"
+  invariant the idempotency guard relies on. Acceptable; optimize later if noisy.
+- **Race with new `main` commits during the run:** the PR's merge ref recomputes;
+  auto-merge merges when mergeable. No special handling needed (PR model, not direct push).
+- **Concurrency:** `backmerge-main` group prevents two releases' back-merges from racing.
+
+## Forward dependency note
+
+If `main` protection is later changed to *require pull requests*, no part of this design
+breaks — it already uses a PR for every back-merge. (This is a deliberate improvement over
+an earlier direct-push variant that would have broken under that change.)
+
+## Files / changes
+
+- `.github/workflows/ci.yml` — change triggers (single CI source of truth).
+- `.github/workflows/backmerge.yml` — new workflow.
+- Repo settings (manual, documented): required status checks on `main` + allow auto-merge.
+- Optional: a `backmerge` label.
+
+## Open questions
+
+- None blocking. Possible future optimization: skip opening a PR when the back-merge diff
+  is empty (would require an alternative way to advance the idempotency invariant).

--- a/notes/2026-05-25_1_backmerge-release-to-main-design.md
+++ b/notes/2026-05-25_1_backmerge-release-to-main-design.md
@@ -188,11 +188,14 @@ which also blocked `backmerge.yml`'s own `gh pr merge --merge`. **Fixed 2026-05-
 `allow_merge_commit` enabled (squash kept, rebase off).
 
 Team policy (2026-05-26):
-- **RC PR (`rc/* → release`): merge commit, via auto-merge.** `release-candidate.yml`
-  enables auto-merge (`--merge`) on the RC PR and prepends a first-line note to the PR
-  body: approving the PR auto-merges it into `release` (as a merge commit) — approve only
-  after UAT passes. **Dependency:** `release` must require an approving review, otherwise
-  auto-merge can't be enabled / would merge instantly and skip UAT.
+- **RC PR (`rc/* → release`): merge commit, via auto-merge.** ✅ `release-candidate.yml`
+  generates an App token (so the RC branch push + PR trigger `ci.yml`/`cd.yml` — a PR
+  opened by `GITHUB_TOKEN` would never get checks and stay stuck), prepends a first-line
+  note to the PR body (approve only after UAT; approval auto-merges as a merge commit),
+  and enables `gh pr merge --auto --merge`. Gated by the **"Release PR gate"** ruleset
+  (id 16897399): 1 approving review (dismiss-stale on push), `build`/`ESLint`/`TypeScript`/
+  `Vitest` checks, and **`allowed_merge_methods: ["merge"]`** — squash/rebase are blocked on
+  `release`, so the RC PR *cannot* be squashed (footgun closed at the platform level).
 - **Back-merge PR (`release → main`): merge commit** — already `--merge` in `backmerge.yml`.
 - **Feature PRs to `main`: squash** (team preference). Safe for the back-merge: RC is cut
   from `main`, so what those commits are (squashed or not) doesn't matter; only the
@@ -202,10 +205,11 @@ Team policy (2026-05-26):
 
 - `.github/workflows/ci.yml` — change triggers (single CI source of truth). ✅ done
 - `.github/workflows/backmerge.yml` — new workflow. ✅ done
-- `.github/workflows/release-candidate.yml` — enable auto-merge (`--merge`) on the RC PR +
-  first-line body note. ⬜ pending (needs `release` approval gate)
-- Repo settings: required checks on `main` (✅ done via ruleset), `allow_auto_merge` (✅),
-  `allow_merge_commit` (✅ 2026-05-26), and a required review on `release` (⬜ pending).
+- `.github/workflows/release-candidate.yml` — App token + first-line body note + RC PR
+  auto-merge (`--merge`). ✅ done
+- Repo settings: `main` required checks via "Checks pass" ruleset (✅), `allow_auto_merge`
+  (✅), `allow_merge_commit` (✅), `release` gate via "Release PR gate" ruleset — review +
+  CI checks + merge-only (✅, 2026-05-26).
 - Optional: a `backmerge` label.
 
 ## Open questions

--- a/notes/2026-05-25_1_backmerge-release-to-main-design.md
+++ b/notes/2026-05-25_1_backmerge-release-to-main-design.md
@@ -169,11 +169,43 @@ If `main` protection is later changed to *require pull requests*, no part of thi
 breaks — it already uses a PR for every back-merge. (This is a deliberate improvement over
 an earlier direct-push variant that would have broken under that change.)
 
+## Merge-method prerequisite (CRITICAL — found via squash simulation 2026-05-26)
+
+**The back-merge only works if the RC PR lands on `release` as a true merge commit.**
+This is load-bearing, not stylistic.
+
+Simulation (squash-merge `rc/v2026.20` into `release`, then back-merge `release → main`):
+- **Merge commit** RC→release: `merge-base(release, main)` = rc tip → back-merge **clean,
+  0 conflicts** (git knows rc's commits are already on main).
+- **Squash** RC→release: `merge-base(release, main)` = old release tip → back-merge
+  **CONFLICT** (e.g. `app/commands/report/modActionLogger.ts`). The squash commit is a
+  fresh snapshot with no ancestry to rc's commits, so git re-merges the entire RC diff
+  against a stale base and collides wherever `main` has since moved. Squash here is
+  morally a cherry-pick — the exact recurring-conflict trap this design avoids.
+
+Repo state when found: `allow_merge_commit:false, allow_squash_merge:true` (squash-only),
+which also blocked `backmerge.yml`'s own `gh pr merge --merge`. **Fixed 2026-05-26:**
+`allow_merge_commit` enabled (squash kept, rebase off).
+
+Team policy (2026-05-26):
+- **RC PR (`rc/* → release`): merge commit, via auto-merge.** `release-candidate.yml`
+  enables auto-merge (`--merge`) on the RC PR and prepends a first-line note to the PR
+  body: approving the PR auto-merges it into `release` (as a merge commit) — approve only
+  after UAT passes. **Dependency:** `release` must require an approving review, otherwise
+  auto-merge can't be enabled / would merge instantly and skip UAT.
+- **Back-merge PR (`release → main`): merge commit** — already `--merge` in `backmerge.yml`.
+- **Feature PRs to `main`: squash** (team preference). Safe for the back-merge: RC is cut
+  from `main`, so what those commits are (squashed or not) doesn't matter; only the
+  RC→release and release→main steps must be merge commits.
+
 ## Files / changes
 
-- `.github/workflows/ci.yml` — change triggers (single CI source of truth).
-- `.github/workflows/backmerge.yml` — new workflow.
-- Repo settings (manual, documented): required status checks on `main` + allow auto-merge.
+- `.github/workflows/ci.yml` — change triggers (single CI source of truth). ✅ done
+- `.github/workflows/backmerge.yml` — new workflow. ✅ done
+- `.github/workflows/release-candidate.yml` — enable auto-merge (`--merge`) on the RC PR +
+  first-line body note. ⬜ pending (needs `release` approval gate)
+- Repo settings: required checks on `main` (✅ done via ruleset), `allow_auto_merge` (✅),
+  `allow_merge_commit` (✅ 2026-05-26), and a required review on `release` (⬜ pending).
 - Optional: a `backmerge` label.
 
 ## Open questions

--- a/notes/2026-05-25_1_backmerge-release-to-main-design.md
+++ b/notes/2026-05-25_1_backmerge-release-to-main-design.md
@@ -85,6 +85,25 @@ This is what makes auto-merge *wait* for green rather than merging instantly. It
 closes the pre-existing gap that `main` has no required status checks
 (see `project_cicd_architecture` memory / `notes/2025-12-14_1_...`).
 
+**Verified & corrected 2026-05-26.** The May 25 config was a repository **ruleset**
+("Checks pass", id `16854963`), not classic branch protection — and it was
+misconfigured: `enforcement: disabled`, targeting `~ALL` branches, and bundling a
+`Restrict updates` rule that (with no bypass actors) would have blocked *all* updates
+to a branch, including PR merges. Corrected via the rulesets API to:
+
+- `enforcement: active`
+- target `~DEFAULT_BRANCH` (main only)
+- rules: `deletion`, `non_fast_forward`, `required_status_checks`; the `update`
+  (Restrict updates) rule **removed** so PR merges/auto-merge to main still work
+- required checks: `build`, `ESLint`, `TypeScript`, `Vitest`
+  (team chose to keep `build` from `cd.yml` in addition to the `ci.yml` checks)
+- `strict_required_status_checks_policy: false` (avoid auto-merge stalls when main advances)
+- repo `allow_auto_merge` was already `true`
+
+Caveat: `build` is produced by `cd.yml` (`on: push`), so it reports on same-repo branch
+pushes; fork PRs (which don't trigger `cd.yml`) would lack `build`. This team pushes
+branches directly, so not a concern in practice.
+
 ### 3. New workflow `.github/workflows/backmerge.yml`
 
 Trigger:

--- a/notes/2026-05-26_1_backmerge-release-to-main-plan.md
+++ b/notes/2026-05-26_1_backmerge-release-to-main-plan.md
@@ -1,0 +1,321 @@
+# Back-merge `release` → `main` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically open a CI-gated, auto-merging PR that brings `release` back into `main` whenever a GitHub Release is published, so production fixes stop disappearing from the development line.
+
+**Architecture:** Three changes. (1) `ci.yml` becomes the single CI source of truth — it runs on `pull_request` (testing the merge ref) and on `push` to `main`. (2) `main` branch protection requires the CI checks and the repo allows auto-merge — this is what makes auto-merge *wait* for green. (3) A new `backmerge.yml` workflow fires on `release: published`, and (after an idempotency guard) pushes a `backmerge/<tag>` branch at the `release` tip, opens a `release → main` PR, and enables GitHub auto-merge. GitHub then runs CI and merges automatically when clean+green, or leaves the PR for a human on conflict/failure.
+
+**Tech Stack:** GitHub Actions, `gh` CLI (`github-script` not needed), `actions/create-github-app-token`, `actionlint` for static validation.
+
+**Testing model (read first):** Workflow YAML has no unit-test harness, and this repo keeps workflow logic inline (see `cd.yml`, `promote-release.yml`), so we follow that pattern rather than extracting scripts. "Tests" here = `actionlint` static checks + observed live runs. `backmerge.yml` includes a `workflow_dispatch` trigger specifically so it can be run manually for verification without publishing a real release; the idempotency guard makes a manual run a safe no-op when `release` and `main` haven't diverged.
+
+**Prerequisite:** Tooling check — install `actionlint` once. Run: `brew install actionlint` (expected: installs, or "already installed"). Fallback YAML validity check if brew is unavailable: `python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1])); print('ok')" <file>`.
+
+---
+
+### Task 1: Make `ci.yml` the single CI source of truth
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `on:` block only)
+
+- [ ] **Step 1: Change the trigger block**
+
+Replace exactly this block:
+
+```yaml
+on:
+  push:
+    branches-ignore:
+      - "main"
+```
+
+with:
+
+```yaml
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+```
+
+Leave everything else (`name`, `concurrency`, `env: HUSKY: 0`, and all three jobs `ESLint` / `TypeScript` / `Vitest`) unchanged. The job `name:` values must stay `ESLint`, `TypeScript`, `Vitest` — they are referenced as required status checks in Task 2.
+
+- [ ] **Step 2: Validate the workflow statically**
+
+Run: `actionlint .github/workflows/ci.yml`
+Expected: no output, exit code 0. (Fallback: the `python3 ... yaml.safe_load` one-liner prints `ok`.)
+
+- [ ] **Step 3: Confirm intent in the diff**
+
+Run: `git diff .github/workflows/ci.yml`
+Expected: only the `on:` block changed — `pull_request:` added, `push` now scoped to `main`. No job changes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: run CI on pull_request and main
+
+Run CI against the PR merge ref (validates exactly what lands) and on pushes
+to main, instead of every non-main branch push. Makes ci.yml the single CI
+source of truth so the back-merge PR is gated by the same checks. Non-PR
+branch pushes no longer auto-run CI; the team flow is PR-based."
+```
+
+---
+
+### Task 2: Verify (and fix if needed) `main` branch protection + auto-merge
+
+This step was applied manually on 2026-05-25 but not verified (per the design doc). The back-merge gate does not work unless BOTH are true: the CI jobs are required status checks on `main`, AND the repo allows auto-merge. If required checks are missing, `gh pr merge --auto` either errors or merges immediately with no gate.
+
+**Files:**
+- Modify (record only): `notes/2026-05-25_1_backmerge-release-to-main-design.md` (append a verification result line)
+
+- [ ] **Step 1: Check required status checks on `main`**
+
+Run:
+```bash
+gh api repos/Euno-HQ/discord/branches/main/protection \
+  --jq '{strict: .required_status_checks.strict, contexts: .required_status_checks.contexts}'
+```
+Expected: `contexts` contains `"ESLint"`, `"TypeScript"`, and `"Vitest"`. Recommended `strict: false` (see Step 3). If the call 404s or `required_status_checks` is null, the checks are NOT configured → go to Step 3.
+
+- [ ] **Step 2: Check the repo allows auto-merge**
+
+Run: `gh api repos/Euno-HQ/discord --jq '.allow_auto_merge'`
+Expected: `true`. If `false`, run: `gh api -X PATCH repos/Euno-HQ/discord -f allow_auto_merge=true` and re-check.
+
+- [ ] **Step 3: Apply required checks only if Step 1 showed them missing/incorrect**
+
+Skip if Step 1 already passed. Otherwise run:
+```bash
+gh api -X PATCH repos/Euno-HQ/discord/branches/main/protection/required_status_checks \
+  -f strict=false \
+  -f 'contexts[]=ESLint' -f 'contexts[]=TypeScript' -f 'contexts[]=Vitest'
+```
+`strict=false` is deliberate: with `strict=true`, every new commit on `main` would force the back-merge branch to update before auto-merge could complete, causing churn. Re-run Step 1 to confirm.
+
+- [ ] **Step 4: Record the verified result and commit**
+
+Edit the design doc line that currently reads:
+`As of May 25th, this step has been performed, but has not been verified as correctly configured.`
+to:
+`Verified 2026-05-26: required checks ESLint/TypeScript/Vitest present on main (strict=false); allow_auto_merge=true.`
+(Adjust the text to match what you actually observed.)
+
+```bash
+git add notes/2026-05-25_1_backmerge-release-to-main-design.md
+git commit -m "docs: record verified main branch-protection config for back-merge gate"
+```
+
+---
+
+### Task 3: Add the `backmerge.yml` workflow
+
+**Files:**
+- Create: `.github/workflows/backmerge.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/backmerge.yml` with exactly this content:
+
+```yaml
+name: Back-merge release into main
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: backmerge-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backmerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: Euno-HQ
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Determine back-merge ref
+        id: ref
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ -n "${RELEASE_TAG}" ]; then
+            REF="${RELEASE_TAG}"
+          else
+            REF="manual-$(date -u +%Y%m%d%H%M%S)"
+          fi
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "branch=backmerge/${REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether release is already merged into main
+        id: guard
+        run: |
+          git fetch origin main release
+          if git merge-base --is-ancestor origin/release origin/main; then
+            echo "merged=true" >> "$GITHUB_OUTPUT"
+            echo "release is already an ancestor of main; nothing to back-merge."
+          else
+            echo "merged=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for an existing open back-merge PR
+        id: existing
+        if: steps.guard.outputs.merged == 'false'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          EXISTING=$(gh pr list --base main --state open \
+            --json number,headRefName \
+            --jq 'map(select(.headRefName | startswith("backmerge/"))) | .[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "number=${EXISTING}" >> "$GITHUB_OUTPUT"
+            echo "An open back-merge PR already exists: #${EXISTING}; skipping."
+          fi
+
+      - name: Create back-merge branch at release tip
+        if: steps.guard.outputs.merged == 'false' && steps.existing.outputs.number == ''
+        env:
+          BRANCH: ${{ steps.ref.outputs.branch }}
+        run: |
+          git push --force origin "origin/release:refs/heads/${BRANCH}"
+
+      - name: Open back-merge PR and enable auto-merge
+        if: steps.guard.outputs.merged == 'false' && steps.existing.outputs.number == ''
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BRANCH: ${{ steps.ref.outputs.branch }}
+          REF: ${{ steps.ref.outputs.ref }}
+        run: |
+          cat > /tmp/backmerge-body.md <<EOF
+          Automated back-merge of release into main after publishing ${REF}.
+
+          Brings release-only fixes (pushed to rc/* during UAT) back into the development line.
+
+          * Clean + CI-green: this PR auto-merges with no action needed.
+          * Conflicts or red CI: auto-merge stays pending. To resolve, run:
+
+              git fetch origin
+              git checkout ${BRANCH}
+              git merge origin/main
+              # resolve conflicts, commit, and push
+          EOF
+
+          gh label create backmerge --color BFD4F2 \
+            --description "Automated back-merge of release into main" 2>/dev/null || true
+
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "Back-merge release ${REF} into main" \
+            --label backmerge \
+            --body-file /tmp/backmerge-body.md)
+          echo "Opened ${PR_URL}"
+
+          gh pr merge "${PR_URL}" --auto --merge
+```
+
+Notes baked into this file:
+- App token (not `GITHUB_TOKEN`) is used for checkout push and all `gh` calls, so the PR-open event triggers `ci.yml` (events from `GITHUB_TOKEN` don't start new workflow runs).
+- The PR body uses 4-space indentation for the command block (no backticks) to avoid heredoc command-substitution issues while still expanding `${REF}`/`${BRANCH}`.
+- `git push --force` only runs when no open back-merge PR exists, so it cannot disrupt a PR under review; it just refreshes a stale branch.
+
+- [ ] **Step 2: Validate statically**
+
+Run: `actionlint .github/workflows/backmerge.yml`
+Expected: no output, exit 0. (Fallback: `python3 ... yaml.safe_load` prints `ok`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/backmerge.yml
+git commit -m "feat: add back-merge release->main workflow
+
+On release publish (or manual dispatch), open a CI-gated release->main PR and
+enable GitHub auto-merge: clean+green auto-merges, conflicts/failures wait for
+a human. Idempotency guard (release already ancestor of main) and existing-PR
+check make it safe to re-run."
+```
+
+---
+
+### Task 4: Live end-to-end verification
+
+This validates the two behaviors that static linting can't: that `ci.yml` now runs on PRs, and that `backmerge.yml` runs and opens (or correctly no-ops) a back-merge PR. It requires pushing the branch and using `workflow_dispatch`.
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Push the branch and open the feature PR**
+
+```bash
+git push -u origin feat-backmerge-release-to-main
+gh pr create --base main --head feat-backmerge-release-to-main \
+  --title "Back-merge release into main (CI gate + workflow)" \
+  --body "Implements notes/2026-05-25_1 design: ci.yml single-source triggers, backmerge.yml, verified branch protection."
+```
+Expected: PR created.
+
+- [ ] **Step 2: Confirm `ci.yml` runs on this PR via `pull_request`**
+
+Run: `gh pr checks feat-backmerge-release-to-main --watch`
+Expected: checks named `ESLint`, `TypeScript`, `Vitest` appear and complete. This proves Task 1's `pull_request` trigger works and that these are the contexts to require (Task 2).
+
+- [ ] **Step 3: Dispatch the back-merge workflow against this branch**
+
+Run:
+```bash
+gh workflow run "Back-merge release into main" --ref feat-backmerge-release-to-main
+sleep 5
+gh run list --workflow=backmerge.yml --limit 1
+```
+Then watch the latest run: `gh run watch $(gh run list --workflow=backmerge.yml --limit 1 --json databaseId --jq '.[0].databaseId')`
+
+Expected — one of:
+- If `release` is already an ancestor of `main`: the `guard` step logs "release is already an ancestor of main; nothing to back-merge." and later steps are skipped. Safe no-op confirming the guard. ✅
+- If `release` has diverged: a real `backmerge/manual-<timestamp>` branch + PR are created and auto-merge is enabled. Inspect with `gh pr list --label backmerge`. This is the genuine feature working. ✅
+
+- [ ] **Step 4: If Step 3 created a back-merge PR, confirm gating**
+
+Run: `gh pr view <backmerge-pr-number> --json autoMergeRequest,mergeStateStatus`
+Expected: `autoMergeRequest` is non-null (auto-merge enabled). The PR merges itself once CI is green and it's conflict-free; if `mergeStateStatus` indicates conflicts, it waits — confirming the human-fallback path.
+
+- [ ] **Step 5: Record outcome**
+
+Note in the feature PR (a comment) which branch of Step 3 occurred (no-op vs. real PR) and that CI ran via `pull_request`. No commit needed.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Design §1 (ci.yml single source) → Task 1. ✅
+- Design §2 (branch protection required checks + allow auto-merge) → Task 2 (verify/fix). ✅
+- Design §3 (backmerge.yml: trigger, idempotency guard, existing-PR check, branch from release, PR, auto-merge, App-token auth, permissions, concurrency) → Task 3. ✅
+- Design "Resilience/edge cases" (idempotent re-run, empty-diff, race, concurrency) → covered by the guard + existing-PR check + `concurrency` group in Task 3; live-checked in Task 4. ✅
+- Design "Critical auth detail" (App token so CI fires) → Task 3 file + note, proven in Task 4 Step 2. ✅
+
+**Placeholder scan:** `<release-tag>`/`<tag>`/`<backmerge-pr-number>` appear only as runtime values shown in command examples, not as unfilled plan content. All workflow code is complete. No TBD/TODO. ✅
+
+**Type/name consistency:** Job/context names `ESLint`/`TypeScript`/`Vitest` are identical across Task 1 (unchanged jobs), Task 2 (required contexts), and Task 4 (observed checks). Step outputs (`ref.outputs.branch`, `guard.outputs.merged`, `existing.outputs.number`) are referenced consistently with how they're written. ✅
+
+**Open item:** Empty-diff releases still open a self-merging PR (noisy but correct, per design); intentionally not optimized.


### PR DESCRIPTION
## Summary

Adds an automated, CI-gated back-merge of `release` into `main` so production fixes (pushed to `rc/*` during UAT) stop disappearing from the development line — and hardens the release path so that back-merge stays conflict-free.

## Code in this PR
- **`.github/workflows/backmerge.yml`** (new) — on `release: published` (or manual dispatch), opens a `release → main` PR and enables GitHub auto-merge. Clean + green → auto-merges with no human action; conflict or red CI → waits for a human. Idempotency guard (`release` already an ancestor of `main`) + existing-PR check make it safe to re-run. Uses the GitHub App token so the PR triggers CI.
- **`.github/workflows/ci.yml`** — now runs on `pull_request` (tests the merge ref) and `push: main`, instead of every non-main branch push. Single CI source of truth; this is what gates the back-merge PR.
- **`.github/workflows/release-candidate.yml`** — switches to the GitHub App token (a PR opened by `GITHUB_TOKEN` never triggers CI, so its required checks could never go green), prepends a first-line note that approving the RC PR auto-merges it into `release` as a merge commit, and enables `gh pr merge --auto --merge`.
- **`notes/`** — design spec, implementation plan, and the squash-vs-merge-commit simulation finding.

## Already-live config (applied via API; independent of this merge)
- `main` **"Checks pass"** ruleset: requires `build` / `ESLint` / `TypeScript` / `Vitest`.
- `release` **"Release PR gate"** ruleset: 1 review (dismiss-stale) + those 4 checks + **`allowed_merge_methods: ["merge"]`** (the RC PR cannot be squashed).
- Repo merge methods: merge + squash enabled (rebase off); `allow_auto_merge` on.

## Why merge-commit-only on `release`
Local simulation: squash-merging the RC PR into `release` severs ancestry and makes the `release → main` back-merge conflict every cycle (squash ≈ cherry-pick — proven with a real conflict in `app/commands/report/modActionLogger.ts`). A true merge commit back-merges cleanly. The release ruleset enforces this at the platform level.

## Test plan
- [x] `actionlint` clean on all three workflows
- [x] vitest suite green (340 tests)
- [x] squash-vs-merge-commit back-merge simulated locally (squash → conflict; merge commit → clean)
- [ ] CI runs on this PR via the new `pull_request` trigger (verifies the `ci.yml` change and the `main` gate)
- [ ] After merge: `gh workflow run "Back-merge release into main"` — expected to be a safe no-op today, since `release` is currently an ancestor of `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
