### PR TITLE
feat: make the spam pipeline observable end-to-end

### DIFF
--- a/app/discord/eventBus.ts
+++ b/app/discord/eventBus.ts
@@ -112,7 +112,31 @@ export const DiscordEventBusLive = Layer.scoped(
 
     client.on(Events.MessageCreate, (message) => {
       const event = enrichMessageCreate(message);
-      if (event) Effect.runFork(Queue.offer(queue, event));
+      if (event) {
+        Effect.runFork(Queue.offer(queue, event));
+        return;
+      }
+      // Diagnostic: a human, in-guild message whose member didn't resolve is
+      // dropped here and never reaches any pipeline. This is the one non-obvious
+      // drop reason — surface it so it isn't silent.
+      if (
+        !message.author.bot &&
+        !message.author.system &&
+        message.inGuild() &&
+        !message.member
+      ) {
+        log(
+          "debug",
+          "DiscordEventBus",
+          "MessageCreate dropped: member unresolved",
+          {
+            messageId: message.id,
+            authorId: message.author.id,
+            channelId: message.channelId,
+            guildId: message.guildId,
+          },
+        );
+      }
     });
 
     client.on(Events.MessageDelete, (message) => {

--- a/app/discord/events.ts
+++ b/app/discord/events.ts
@@ -154,3 +154,7 @@ const GUILD_MESSAGE_TYPES = new Set([
 export const isGuildMessageEvent = (
   event: DiscordEvent,
 ): event is GuildMessageEvent => GUILD_MESSAGE_TYPES.has(event.type);
+
+export const isGuildMemberMessage = (
+  event: DiscordEvent,
+): event is GuildMemberMessage => event.type === "GuildMemberMessage";

--- a/app/discord/pipelines/automod.ts
+++ b/app/discord/pipelines/automod.ts
@@ -4,9 +4,28 @@ import { Effect, Stream } from "effect";
 
 import type { RuntimeContext } from "#~/AppRuntime";
 import { DiscordEventBus } from "#~/discord/eventBus";
-import { logEffect } from "#~/effects/observability";
+import {
+  isGuildMemberMessage,
+  type GuildMemberMessage,
+} from "#~/discord/events";
+import { filterLog, logEffect } from "#~/effects/observability";
 import { SpamDetectionService } from "#~/features/spam/service";
 import { isStaff } from "#~/helpers/discord";
+
+// `messageId` is the correlation id threaded through every spam-pipeline log
+// line, so one message can be followed end-to-end with a single grep.
+const logContext = (e: GuildMemberMessage) => ({
+  messageId: e.message.id,
+  authorId: e.message.author.id,
+  channelId: e.message.channelId,
+  guildId: e.guild.id,
+});
+
+// Only user-authored content is scanned; join notifications, boosts, etc. are
+// skipped.
+const isStandardMessage = (e: GuildMemberMessage) =>
+  e.message.type === MessageType.Default ||
+  e.message.type === MessageType.Reply;
 
 export const automodPipeline: Effect.Effect<void, never, RuntimeContext> =
   Effect.gen(function* () {
@@ -14,38 +33,51 @@ export const automodPipeline: Effect.Effect<void, never, RuntimeContext> =
     const spamService = yield* SpamDetectionService;
 
     yield* stream.pipe(
-      Stream.filter((e) => e.type === "GuildMemberMessage"),
+      // Narrows the stream to GuildMemberMessage so the rest of the pipeline
+      // sees the concrete type. Non-message events are dropped silently — every
+      // pipeline gets every event, so logging those drops would be pure noise.
+      Stream.filter(isGuildMemberMessage),
 
-      // Skip staff messages
-      Stream.filter(
-        (e) => e.type === "GuildMemberMessage" && !isStaff(e.member),
-      ),
-
-      // Skip system messages (join notifications, boosts, etc.) — only scan user-authored content
-      Stream.filter(
+      // Drops are logged (not silently filtered) so "not flagged" can be told
+      // apart from "never evaluated". `filterLog` runs each predicate once and
+      // logs only the dropped path.
+      filterLog(
+        (e) => !isStaff(e.member),
         (e) =>
-          e.type === "GuildMemberMessage" &&
-          (e.message.type === MessageType.Default ||
-            e.message.type === MessageType.Reply),
+          logEffect("debug", "Automod", "Skipped: staff author", logContext(e)),
+      ),
+      filterLog(isStandardMessage, (e) =>
+        logEffect("debug", "Automod", "Skipped: non-standard type", {
+          ...logContext(e),
+          messageType: e.message.type,
+        }),
       ),
 
-      Stream.mapEffect((e) => {
-        if (e.type !== "GuildMemberMessage") return Effect.void;
-        return Effect.gen(function* () {
+      Stream.mapEffect((e) =>
+        Effect.gen(function* () {
           const verdict = yield* spamService.checkMessage(e.message, e.member);
+
+          // Logged for every evaluated message, including tier:none — proof the
+          // pipeline saw the message and what it decided.
+          yield* logEffect("debug", "Automod", "Message evaluated", {
+            ...logContext(e),
+            tier: verdict.tier,
+            score: verdict.totalScore,
+            signals: verdict.signals.map((s) => s.name),
+          });
+
           if (verdict.tier !== "none") {
             yield* spamService.executeResponse(verdict, e.message, e.member);
           }
         }).pipe(
           Effect.catchAll((err) =>
             logEffect("warn", "Automod", "Pipeline handler failed", {
-              messageId: e.message.id,
-              guildId: e.guild.id,
+              ...logContext(e),
               error: String(err),
             }),
           ),
-        );
-      }),
+        ),
+      ),
 
       Stream.runDrain,
     );

--- a/app/effects/featureFlags.ts
+++ b/app/effects/featureFlags.ts
@@ -1,6 +1,7 @@
 import { Context, Effect, Layer, Schema, type ParseResult } from "effect";
 
 import { FeatureDisabledError } from "#~/effects/errors";
+import { logEffect } from "#~/effects/observability";
 import { PostHogService, PostHogServiceLive } from "#~/effects/posthog";
 
 export const BooleanFlag = Schema.Literal(
@@ -51,7 +52,16 @@ export const FeatureFlagServiceLive = Layer.scoped(
           }),
         ).pipe(
           Effect.map((result) => result ?? false),
-          Effect.catchAll(() => Effect.succeed(false as boolean)),
+          // A PostHog outage otherwise silently disables a paid feature for every
+          // guild with zero signal — warn so it's visible, then fail closed.
+          Effect.catchAll((error) =>
+            logEffect(
+              "warn",
+              "FeatureFlagService",
+              "PostHog flag check failed, defaulting to disabled",
+              { flag, guildId, error: String(error) },
+            ).pipe(Effect.as(false as boolean)),
+          ),
           Effect.tap((enabled) => Effect.annotateCurrentSpan({ enabled })),
           Effect.withSpan("FeatureFlagService.isPostHogEnabled", {
             attributes: { flag, guildId },

--- a/app/effects/observability.ts
+++ b/app/effects/observability.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Effect, Stream } from "effect";
 
 /**
  * Effect-native logging utilities.
@@ -54,3 +54,25 @@ export const tapLog =
   ) =>
   <E, R>(self: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>
     Effect.tap(self, (a) => logEffect(level, service, message, getContext(a)));
+
+/**
+ * Stream filter that explains its drops. The predicate is evaluated exactly
+ * once per element: elements that pass flow through untouched, dropped elements
+ * run `onDrop` (typically a `logEffect` call) before being discarded. This lets
+ * a pipeline say *why* it filtered something without a double-evaluated
+ * predicate or a separate `tap` that fires on the kept path too.
+ *
+ * @example
+ * stream.pipe(
+ *   filterLog(
+ *     (e) => !isStaff(e.member),
+ *     (e) => logEffect("debug", "Automod", "Skipped: staff author", ctx(e)),
+ *   ),
+ * )
+ */
+export const filterLog =
+  <A>(predicate: (a: A) => boolean, onDrop: (a: A) => Effect.Effect<void>) =>
+  <E, R>(self: Stream.Stream<A, E, R>): Stream.Stream<A, E, R> =>
+    Stream.filterEffect(self, (a) =>
+      predicate(a) ? Effect.succeed(true) : onDrop(a).pipe(Effect.as(false)),
+    );

--- a/app/features/spam/service.ts
+++ b/app/features/spam/service.ts
@@ -162,6 +162,13 @@ export const SpamDetectionServiceLive = Layer.effect(
         Effect.gen(function* () {
           const guildId = message.guild!.id;
 
+          // Correlate this trace with the message so spans can be looked up by
+          // messageId (the same correlation id used across the pipeline logs).
+          yield* Effect.annotateCurrentSpan({
+            messageId: message.id,
+            authorId: message.author.id,
+          });
+
           // Check if moderator — mods are exempt from honeypot
           const isMod = yield* isModeratorOrAdmin(member, guildId);
           if (isMod) {

--- a/app/features/spam/velocityGate.ts
+++ b/app/features/spam/velocityGate.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect";
 
 import type { IFeatureFlagService } from "#~/effects/featureFlags";
+import { logEffect } from "#~/effects/observability";
 
 import { analyzeVelocity } from "./velocityAnalyzer";
 
@@ -40,6 +41,18 @@ export const gatedVelocitySignals = (
     } else {
       enabled = yield* flags.isPostHogEnabled("velocity-spam", guildId);
       cache.set(guildId, { value: enabled, expiresAt: now + ttlMs });
+      // Logged on cache-miss only (≤ once per guild per TTL) so a guild silently
+      // missing velocity detection is visible — `enabled:false` here means the
+      // velocity-spam flag is off for that guild.
+      yield* logEffect(
+        "debug",
+        "SpamDetection",
+        "velocity-spam flag evaluated",
+        {
+          guildId,
+          enabled,
+        },
+      );
     }
 
     return enabled ? analyzeVelocity(recentMessages, contentHash) : [];

--- a/app/server.ts
+++ b/app/server.ts
@@ -53,7 +53,10 @@ import { botStats } from "./helpers/metrics";
 
 export const app = express();
 
-const logger = pinoHttp();
+// Tag HTTP access logs with a `service` field so a single service-based filter
+// (e.g. `grep -v '"service":"http"'`) separates infra noise from app logs, which
+// already carry `service`.
+const logger = pinoHttp({ customProps: () => ({ service: "http" }) });
 app.use(logger);
 
 // Suppress Chrome DevTools 404 warnings


### PR DESCRIPTION
## Why

Diagnosing *"a user sent 4 identical messages across threads but wasn't flagged"* on UAT was blocked because the spam pipeline is **silent on its happy path**. The only per-message log (`Gateway.Raw` `MESSAGE_CREATE`) carries just `{guildId, channelId}` — no author, no content, no verdict. So **"evaluated, found nothing" was indistinguishable from "never evaluated / dropped upstream,"** and feature-flag gating + filter drops happened with zero signal.

This PR makes a message followable end-to-end by `messageId`.

## Changes (logging only — behavior unchanged)

| Item | File | Change |
|------|------|--------|
| **F** | `server.ts` | `pinoHttp` access logs now carry `service:"http"` → one `service`-based filter separates infra noise (`grep -v '"service":"http"'`) from app logs |
| **A/B/C/G** | `discord/pipelines/automod.ts` | `Stream.filter(isGuildMemberMessage)` narrows the type; two `filterLog` stages log **drop reasons** (`staff` / `non-standard type`) on the dropped path only (predicate evaluated once, no separate `tap`); the final `mapEffect` logs **every verdict incl. `tier:none`** (tier, score, signal names). `messageId` threaded as the correlation id via `logContext(e)` |
| **A/B/C/G** | `effects/observability.ts`, `discord/events.ts` | New `filterLog` Stream combinator (runs an effect per *dropped* element, alongside `tapLog`) and an `isGuildMemberMessage` type guard (alongside `isGuildMessageEvent`) |
| **G** | `features/spam/service.ts` | `annotateCurrentSpan({ messageId, authorId })` in `checkMessage` so traces are findable by message |
| **C** | `discord/eventBus.ts` | Logs the one non-obvious upstream drop — a human, in-guild `MessageCreate` with unresolved `member` (never reaches any pipeline) |
| **D** | `features/spam/velocityGate.ts` | Debug-logs the `velocity-spam` flag result on cache-miss → a guild silently missing velocity detection is visible |
| **D** | `effects/featureFlags.ts` | `isPostHogEnabled` **warns** on the swallowed error path — a PostHog outage was silently disabling a paid feature for every guild |

All `debug` except two genuine `warn`s (flag-check failure, pipeline handler failure). UAT already logs at `debug`.

## Test plan

- [x] `npm run validate` — 351 tests pass, `tsc -b` exit 0, eslint 0 errors
- [ ] Deploy to UAT, re-run the 4-identical-message test, then `grep '"service":"Automod"'` + `grep velocity-spam` — verdict/flag lines should pin the non-detection to member-drop, flag-false, or tracker-not-accumulating in one pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
