### PR TITLE
fix: fork event-bus pipelines as daemons so they survive startup

### DIFF
--- a/app/server.ts
+++ b/app/server.ts
@@ -206,6 +206,12 @@ const startup = Effect.gen(function* () {
   // Pipeline (re)start — runs every reload for HMR support.
   // Interrupt stale fibers, fork fresh pipelines with updated handler code.
   // The event bus queue buffers events during the brief swap.
+  //
+  // forkDaemon (NOT fork): these fibers must outlive `startup`, the fiber
+  // running this code. Plain Effect.fork makes them children of `startup`, so
+  // they're interrupted the instant it completes — silently killing every
+  // pipeline before it drains a single event. HMR cleanup is handled by the
+  // explicit Fiber.interrupt above, not by parent-scope teardown.
   if (globalThis.__pipelineFibers) {
     yield* Effect.all(
       globalThis.__pipelineFibers.map((f) => Fiber.interrupt(f)),
@@ -213,12 +219,12 @@ const startup = Effect.gen(function* () {
     yield* logEffect("info", "Server", "Interrupted old pipeline fibers");
   }
   globalThis.__pipelineFibers = [
-    yield* deletionLoggerPipeline.pipe(Effect.fork),
-    yield* automodPipeline.pipe(Effect.fork),
-    yield* modActionLoggerPipeline.pipe(Effect.fork),
-    yield* activityTrackerPipeline.pipe(Effect.fork),
-    yield* onboardGuildPipeline.pipe(Effect.fork),
-    yield* reactjiChannelerPipeline.pipe(Effect.fork),
+    yield* deletionLoggerPipeline.pipe(Effect.forkDaemon),
+    yield* automodPipeline.pipe(Effect.forkDaemon),
+    yield* modActionLoggerPipeline.pipe(Effect.forkDaemon),
+    yield* activityTrackerPipeline.pipe(Effect.forkDaemon),
+    yield* onboardGuildPipeline.pipe(Effect.forkDaemon),
+    yield* reactjiChannelerPipeline.pipe(Effect.forkDaemon),
   ];
   yield* logEffect("info", "Server", "Pipeline fibers forked");
 });


### PR DESCRIPTION
## What

The six event-bus pipelines were forked with `Effect.fork` inside the `startup` fiber. `Effect.fork` binds a child fiber's lifetime to its parent's scope, so all six were interrupted the instant `startup` completed — before draining a single event.

Affected pipelines: `automod` (spam detection), `deletionLogger`, `modActionLogger`, `activityTracker`, `onboardGuild`, `reactjiChanneler`.

## Symptom

Messages arrive, are enriched, and are enqueued on the bus — but never processed. **Spam was never evaluated**, and deletion/mod-action logging, activity tracking, onboarding, and reactji channeling were all silently dead. Present in the current `rc/v2026.22` build on UAT.

## Fix

`Effect.fork` → `Effect.forkDaemon` so the pipelines run in the global scope and outlive `startup`. HMR cleanup is unchanged — the explicit `Fiber.interrupt` of the previous run's fibers still runs on reload. Added a comment at the fork site so it isn't reverted.

## Verification

Reproduced locally with `npm run dev`: a log on the pipeline's first line never fired (fiber forked, then immediately interrupted). After the change, all six pipelines enter their body and every message is evaluated end-to-end (`pipeline received event` → `Message evaluated`).

`npm run validate` → 351 tests pass, `tsc -b` clean, 0 eslint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)