### PR TITLE
fix(spam): idempotent recordReport + structured back-fill error logs

### DIFF
--- a/app/features/spam/spamResponseHandler.ts
+++ b/app/features/spam/spamResponseHandler.ts
@@ -266,6 +266,11 @@ const logSpamReport = (message: Message, verdict: SpamVerdict) =>
     // We record them against the same mod-log thread post as the trigger message
     // so mods can see the full duplicate sequence, and so deleteAllReportedForUser
     // can clean them all up on kick.
+    //
+    // recordReport is idempotent (ON CONFLICT DO NOTHING on the unique index),
+    // so subsequent spam events for the same user re-presenting overlapping
+    // priorDuplicates is expected and not an error — we just count how many
+    // were genuinely new vs already on file.
     if (
       result &&
       verdict.priorDuplicates &&
@@ -277,8 +282,12 @@ const logSpamReport = (message: Message, verdict: SpamVerdict) =>
       const logChannelId = result.thread.id;
       const backfillExtra = `Back-filled prior duplicate. ${extra}`;
 
+      let backfilled = 0;
+      let alreadyRecorded = 0;
+      let failed = 0;
+
       for (const prior of verdict.priorDuplicates) {
-        yield* recordReport({
+        const outcome = yield* recordReport({
           reportedMessageId: prior.messageId,
           reportedChannelId: prior.channelId,
           reportedUserId: userId,
@@ -288,22 +297,49 @@ const logSpamReport = (message: Message, verdict: SpamVerdict) =>
           reason: ReportReasons.spam,
           extra: backfillExtra,
         }).pipe(
-          Effect.catchAll((error) =>
-            logEffect(
+          Effect.map((r): "inserted" | "skipped" =>
+            r.wasInserted ? "inserted" : "skipped",
+          ),
+          Effect.catchTag("SqlError", (e) => {
+            // Pull structured fields off the underlying sqlite error so the
+            // warn log carries the actual constraint name / sqlite code
+            // instead of an opaque "SqlError: Failed to execute statement".
+            const cause = e.cause as
+              | { code?: unknown; message?: unknown }
+              | null
+              | undefined;
+            return logEffect(
               "warn",
               "SpamResponse",
               "Failed to back-fill prior duplicate into reported_messages",
-              { messageId: prior.messageId, error: String(error) },
-            ),
-          ),
+              {
+                messageId: prior.messageId,
+                error: {
+                  _tag: "SqlError",
+                  code:
+                    typeof cause?.code === "string" ? cause.code : undefined,
+                  message:
+                    typeof cause?.message === "string"
+                      ? cause.message
+                      : undefined,
+                },
+              },
+            ).pipe(Effect.as("failed" as const));
+          }),
         );
+
+        if (outcome === "inserted") backfilled++;
+        else if (outcome === "skipped") alreadyRecorded++;
+        else failed++;
       }
 
       yield* logEffect(
         "info",
         "SpamResponse",
-        `Back-filled ${verdict.priorDuplicates.length} prior duplicate(s)`,
-        { userId, guildId },
+        `Back-fill complete: ${backfilled} new, ${alreadyRecorded} already recorded${
+          failed > 0 ? `, ${failed} failed` : ""
+        }`,
+        { userId, guildId, backfilled, alreadyRecorded, failed },
       );
     }
 

--- a/app/models/reportedMessages.ts
+++ b/app/models/reportedMessages.ts
@@ -50,27 +50,47 @@ export const recordReport = (data: {
       reason: data.reason,
     });
 
-    const result = yield* db.insertInto("reported_messages").values({
-      id: reportId,
-      reported_message_id: data.reportedMessageId,
-      reported_channel_id: data.reportedChannelId,
-      reported_user_id: data.reportedUserId,
-      guild_id: data.guildId,
-      log_message_id: data.logMessageId,
-      log_channel_id: data.logChannelId,
-      reason: data.reason,
-      staff_id: data.staffId,
-      staff_username: data.staffUsername,
-      extra: data.extra,
-      created_at: new Date().toISOString(),
-    });
+    // Idempotent insert: the unique index idx_unique_message_reason_guild on
+    // (reported_message_id, reason, guild_id) means a second attempt to record
+    // the same (message, reason) pair in the same guild would otherwise raise
+    // SQLITE_CONSTRAINT_UNIQUE. DO NOTHING preserves the first-written log
+    // pointer (so mods can still navigate to the original thread post).
+    const result = yield* db
+      .insertInto("reported_messages")
+      .values({
+        id: reportId,
+        reported_message_id: data.reportedMessageId,
+        reported_channel_id: data.reportedChannelId,
+        reported_user_id: data.reportedUserId,
+        guild_id: data.guildId,
+        log_message_id: data.logMessageId,
+        log_channel_id: data.logChannelId,
+        reason: data.reason,
+        staff_id: data.staffId,
+        staff_username: data.staffUsername,
+        extra: data.extra,
+        created_at: new Date().toISOString(),
+      })
+      .onConflict((oc) =>
+        oc.columns(["reported_message_id", "reason", "guild_id"]).doNothing(),
+      );
 
-    yield* logEffect("info", "ReportedMessage", "Report recorded", {
-      reportedUserId: data.reportedUserId,
-      guildId: data.guildId,
-    });
+    // SQLite returns a single InsertResult; numInsertedOrUpdatedRows is 0n on
+    // conflict-skip and 1n on actual insert.
+    const wasInserted = Number(result[0]?.numInsertedOrUpdatedRows ?? 0n) > 0;
 
-    return { wasInserted: true, result, reportId };
+    yield* logEffect(
+      "info",
+      "ReportedMessage",
+      wasInserted ? "Report recorded" : "Report already recorded — skipped",
+      {
+        reportedUserId: data.reportedUserId,
+        guildId: data.guildId,
+        wasInserted,
+      },
+    );
+
+    return { wasInserted, result, reportId };
   }).pipe(
     Effect.annotateSpans({ guildId: data.guildId, reason: data.reason }),
 


### PR DESCRIPTION
## Summary

UAT image `sha-0bccd9e3` was logging two related patterns on every spam event:

1. `WARN "Failed to back-fill prior duplicate" error="SqlError: Failed to execute statement"` — repeated on the **same** messageIds across consecutive rounds.
2. `INFO "Back-filled N prior duplicate(s)"` — counted attempts, not successes, so the prior-round failures were silently masked as success.

Both are fixed here.

## Root causes

**Constraint violation.** Migration `20250726201405_add_unique_constraint_reported_messages.ts` adds a unique index on `(reported_message_id, reason, guild_id)`. The back-fill loop in `logSpamReport` called `recordReport` for every entry in `verdict.priorDuplicates` — and on the *next* spam event for the same user, the velocity tracker still surfaces the same prior messages, so the re-INSERT hits the constraint.

**Opaque error.** The `SqlError` from `@effect/sql-kysely` is already tagged (`{ _tag: "SqlError", cause: SqliteError, message? }`); no wrapper was stripping context. The loss happened at the log site: `error: String(error)` collapsed it to `"SqlError: Failed to execute statement"`. The underlying `better-sqlite3` `SqliteError` carries `code: "SQLITE_CONSTRAINT_UNIQUE"` and the full constraint-naming `message` on `cause`.

## Fix

- **`app/models/reportedMessages.ts`** — `recordReport` adds `.onConflict((oc) => oc.columns([...]).doNothing())`. `wasInserted` now reflects `InsertResult.numInsertedOrUpdatedRows > 0` instead of being hardcoded `true` — which also flips the previously dead-code `if (!recordResult.wasInserted)` branch at `userLog.ts:189` into a meaningful warning path.
- **`app/features/spam/spamResponseHandler.ts`** — back-fill loop replaces `catchAll(String(error))` with `catchTag("SqlError", ...)` that extracts `cause.code` / `cause.message` into structured log fields. Summary log now reads `"Back-fill complete: N new, M already recorded[, K failed]"` with counts from a per-row outcome discriminant.

### Why `doNothing()` and not `doUpdateSet({ log_message_id, log_channel_id })`

`deleteAllReportedForUser` only reads `reported_message_id` and `reported_channel_id` — it does not care which log thread the row points at. Preserving the first-write pointer also preserves historical mod-thread traceability. No downstream caller benefits from updating the log pointer on conflict.

## Verification done

- `sqlite3 :memory:` repro of the schema + the exact SQL Kysely emits: first INSERT → `changes=1`, second INSERT with same conflict key → `changes=0`, raw INSERT (no ON CONFLICT) → `UNIQUE constraint failed: reported_messages.reported_message_id, reported_messages.reason, reported_messages.guild_id` — matches the prod symptom.
- `npm test` — all 351 tests pass.
- `tsc --noEmit` and `eslint` clean on edited files (pre-existing route-types errors are unrelated).

## Test plan

- [ ] **Dev-bot integration repro (required before marking ready):** post 5 identical messages from a fresh test account in the dev guild, trigger the spam pipeline twice, confirm: no `Failed to back-fill` warnings on the second pass, and the new `Back-fill complete: N new, M already recorded` line accurately reflects what happened.
- [ ] After merge, watch UAT logs (`kubectl -n staging logs mod-bot-uat-0`) for the disappearance of the `Failed to back-fill prior duplicate` warnings.

## Out of scope (separate PR)

The same `String(error)` / opaque-error pattern is present at the Discord-API call sites in this file (`Failed to softban spammer`, `Failed to timeout user`, `Failed to apply restriction`, etc.). Tracked but intentionally not touched in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)