### PR TITLE
fix(permissions): surface optional Manage Server permission in /check-requirements

### DIFF
--- a/app/commands/checkRequirements.test.ts
+++ b/app/commands/checkRequirements.test.ts
@@ -1,6 +1,9 @@
+import { PermissionFlagsBits } from "discord-api-types/v10";
+
 import {
   buildHoneypotResult,
   buildLogChannelResult,
+  buildOptionalPermissionResults,
 } from "./checkRequirements";
 
 describe("buildLogChannelResult", () => {
@@ -98,5 +101,38 @@ describe("buildHoneypotResult", () => {
     expect(result.ok).toBe(true);
     expect(result.detail).toBe("<#555>");
     expect(result.detail).not.toContain("missing");
+  });
+});
+
+describe("buildOptionalPermissionResults", () => {
+  it("reports the enabled feature when the permission is granted", () => {
+    const results = buildOptionalPermissionResults(() => true);
+    const manageServer = results.find((r) => r.name === "Manage Server");
+    expect(manageServer).toEqual({
+      name: "Manage Server",
+      ok: true,
+      optional: true,
+      detail: "Granted — automod rule change logging enabled",
+    });
+  });
+
+  it("reports the disabled feature as optional when the permission is missing", () => {
+    const results = buildOptionalPermissionResults(() => false);
+    const manageServer = results.find((r) => r.name === "Manage Server");
+    expect(manageServer).toEqual({
+      name: "Manage Server",
+      ok: false,
+      optional: true,
+      detail: "Not granted (optional) — automod rule change logging disabled",
+    });
+  });
+
+  it("checks the ManageGuild flag specifically", () => {
+    const checked: bigint[] = [];
+    buildOptionalPermissionResults((flag) => {
+      checked.push(flag);
+      return true;
+    });
+    expect(checked).toContain(PermissionFlagsBits.ManageGuild);
   });
 });

--- a/app/commands/checkRequirements.ts
+++ b/app/commands/checkRequirements.ts
@@ -15,7 +15,10 @@ import {
   interactionEditReply,
 } from "#~/effects/discordSdk.ts";
 import { logEffect } from "#~/effects/observability.ts";
-import { REQUIRED_PERMISSIONS } from "#~/helpers/botPermissions";
+import {
+  OPTIONAL_PERMISSIONS,
+  REQUIRED_PERMISSIONS,
+} from "#~/helpers/botPermissions";
 import type { SlashCommand } from "#~/helpers/discord";
 import { commandStats } from "#~/helpers/metrics";
 import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
@@ -73,6 +76,27 @@ export function buildHoneypotResult(
         ? validChannelIds.map((id) => `<#${id}>`).join(", ")
         : "No honeypot channels found",
   };
+}
+
+/**
+ * Build CheckResults for optional permissions. A missing optional permission
+ * renders as 🔵 (informational) and never fails the overall check — it just
+ * names the feature that stays disabled without it.
+ */
+export function buildOptionalPermissionResults(
+  hasPermission: (flag: bigint) => boolean,
+): CheckResult[] {
+  return OPTIONAL_PERMISSIONS.map(({ flag, name, feature }) => {
+    const ok = hasPermission(flag);
+    return {
+      name,
+      ok,
+      optional: true,
+      detail: ok
+        ? `Granted — ${feature} enabled`
+        : `Not granted (optional) — ${feature} disabled`,
+    };
+  });
 }
 
 export const Command = {
@@ -412,6 +436,12 @@ export const Command = {
               ? "All required permissions granted"
               : `Missing: ${missing.map((p) => p.name).join(", ")}`,
         });
+
+        results.push(
+          ...buildOptionalPermissionResults((flag) =>
+            botMember.permissions.has(flag),
+          ),
+        );
       } else {
         results.push({
           name: "Bot Permissions",

--- a/app/helpers/botPermissions.ts
+++ b/app/helpers/botPermissions.ts
@@ -28,6 +28,19 @@ export const REQUIRED_PERMISSIONS = [
   { flag: PermissionFlagsBits.ViewAuditLog, name: "View Audit Log" },
 ] as const;
 
+/** Permissions that unlock specific features but are not required for core
+ *  operation. Excluded from invite URLs (BOT_PERMISSIONS); surfaced as
+ *  optional (🔵) by /check-requirements so the degraded feature is visible.
+ *  Discord only delivers AUTO_MODERATION_RULE_* gateway events to apps with
+ *  Manage Server, so automod rule logging silently no-ops without it. */
+export const OPTIONAL_PERMISSIONS = [
+  {
+    flag: PermissionFlagsBits.ManageGuild,
+    name: "Manage Server",
+    feature: "automod rule change logging",
+  },
+] as const;
+
 /** OR of all required permission flags — used in invite URLs. */
 export const BOT_PERMISSIONS = REQUIRED_PERMISSIONS.reduce(
   (acc, { flag }) => acc | flag,


### PR DESCRIPTION
## Problem

UAT testing of #315 (automod rule logging) found that editing an automod rule produced no `#mod-log` post. The gateway raw-event log proved Discord never delivered `AUTO_MODERATION_RULE_UPDATE` to the bot at all — the handler and the `AutoModerationConfiguration` intent are wired correctly, but Discord only sends `AUTO_MODERATION_RULE_*` events to apps that hold the **Manage Server** permission in the guild.

`REQUIRED_PERMISSIONS` never included `ManageGuild`, and that list is the single source of truth for `/check-requirements`, the onboarding check, and the invite URL — so every guild installed via our own invite link gets a bot that silently can't power this feature, while `/check-requirements` reports all permissions granted.

## Fix

Add an **optional permissions tier** instead of escalating the invite for all installs:

- `OPTIONAL_PERMISSIONS` in `app/helpers/botPermissions.ts` — `ManageGuild` mapped to the feature it gates. Deliberately **not** ORed into `BOT_PERMISSIONS`, so the invite URL's trust ask is unchanged.
- `/check-requirements` now renders it with the existing optional (🔵) semantics:
  - 🟢 `Manage Server: Granted — automod rule change logging enabled`
  - 🔵 `Manage Server: Not granted (optional) — automod rule change logging disabled`
- Missing optional permissions never flip the summary to the red "run /setup" state.

## Testing

- 3 new pure-function tests for `buildOptionalPermissionResults` (existing test conventions); full suite 354 passing.
- UAT verification pending: grant the UAT bot role Manage Server, edit an automod rule, confirm the raw `AUTO_MODERATION_RULE_UPDATE` event arrives and `#mod-log` posts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)