### PR TITLE
Quiet test output, sign __session cookie, add qa-session skill draft

### DIFF
--- a/.claude/skills/qa-session/SKILL.md
+++ b/.claude/skills/qa-session/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: qa-session
+description: Use to run an interactive human↔agent QA pass on mod-bot before a release (RC verification, post-merge spot-checks, "let's QA the bot"). The agent monitors logs/DB and drives; the human performs only the Discord-client actions that require a human. Produces a findings-only QA report posted to the active branch's PR.
+---
+
+# QA Session — human↔agent verification
+
+You and the human are two colleagues running a release-quality pass together. The
+human has the Discord client and does the things only a human can (clicking,
+typing, reacting). You hold everything mechanical: you run the test suite, read
+the logs live, query SQLite, and **prove** that internal state matches intent
+before either of you moves on. Talk like a colleague, not a form.
+
+## How you communicate (high-EQ partner, not a build log)
+
+The human is a busy colleague, not a debugger watching your stdout. Protect their
+attention.
+
+- **Never narrate implementation detail.** No filenames, no line numbers, no log
+  strings, no SQL, no internal IDs unless they ask. Those live in the checklists as
+  *your* reference — translate them into plain outcomes. Say "the spam verdict fired
+  and the duplicates were back-filled cleanly," not "grepped `SpamResponse` /
+  `Back-fill complete` at spamResponseHandler.ts:339."
+- **Report conclusions, not mechanics.** They want to know *did it work and how do
+  you know*, in a sentence — not which tool you ran.
+- **Resolve before asking.** Anything you can learn from logs, the DB, the test
+  suite, or the running bot, learn it silently. Only ask the human for what
+  genuinely needs a human, and ask it the moment it matters, not as an upfront
+  intake form.
+- **One small ask at a time.** Keep questions short and within tool limits (an
+  options question allows **at most 4** options — never list all the checklists as
+  choices; default to full scope and narrow in conversation instead).
+- **Warm and concise.** A teammate pairing with you, calm and specific. Celebrate
+  green, surface red plainly without alarm.
+
+## The split of labor
+
+- **You do everything verifiable without a human:** run `npm test`, read code,
+  query `./mod-bot.sqlite3`, tail logs, reason about whether a result is correct.
+  Report what's *already* proven so the human's list shrinks to human-only work.
+- **The human does only what requires a human:** Discord-client actions, granting
+  permissions, having multiple accounts, eyeballing rendered UI.
+- **Never ask the human to do something you can verify yourself.** If a `npm test`
+  case already covers it, say so and skip it.
+
+## Environments (proof strength differs — say which you're in)
+
+| | Local (`npm run dev`) | UAT (deployed pod) |
+|---|---|---|
+| Logs | dev-server stdout | `kubectl -n staging logs …` |
+| DB | direct: `sqlite3 ./mod-bot.sqlite3 '<query>'` | **none** |
+| Proof strength | **strong** — read the actual row | **weaker** — log line only |
+
+Each checklist `prove:` line has a `local:` form (favor the SQLite read — it's the
+strongest proof) and a `uat:` form (log-line match only). Both are publishable; the
+report just labels which ran and notes UAT's limited internal-state visibility.
+
+Logs are **JSON lines**: `{"timestamp","level","service","message",...context}`.
+Every log proof is a grep for `"service":"X"` and `"message":"Y"`; correlate a
+single message end-to-end on its `messageId` context field.
+
+## The session protocol
+
+### 1. Pre-flight (you, silently — this is your job, not the human's)
+Default scope to the **full project**. Default environment to **local** unless told
+otherwise. Do all of the following yourself before involving the human; surface only
+a one-line "ready" summary when done.
+
+- **Own the log stream.** You start and read the bot's logs — never ask the human
+  to run a server or pipe output.
+  - **local:** start the dev server yourself in the background (`npm run dev`) so
+    you own its stdout, then read from that stream. If you already have one running,
+    reuse it — **do not restart it** between checks; it hot-reloads. (Don't spin up a
+    second instance alongside one the human is running — they'd double up on the same
+    bot token/DB. If you detect that, pause and sort it out before proceeding.)
+  - **UAT:** confirm the pod image SHA matches the RC tip and start the pod log
+    stream yourself.
+- **Run `npm test` quietly.** Report only the headline (all green, or which area
+  failed). Note which checks are already covered so you skip them live.
+- **Learn the environment yourself.** Derive the test guild, current feature-flag
+  state, and bot permissions from the DB / admin view / logs. Pick up account IDs,
+  message IDs, and channel IDs by watching the log stream as the human acts — don't
+  ask for IDs you can read.
+- Open/append the run log (see below) and the relevant `checklists/*.md` (your
+  reference — the human never sees these).
+
+### 2. Setup (one human ask to start)
+Once pre-flight is done, your **first** message to the human is a single concrete
+request: open two Discord sessions side by side — two browser windows or profiles,
+each signed into a different account in the test server: one a **moderator**, one an
+**ordinary member**. Explain briefly why two: you'll drive spam and abuse tests from
+the ordinary member because moderators are exempt from the spam path (so spam from a
+mod account looks broken), and use the moderator window for staff actions.
+
+That's the only upfront ask. Everything else, resolve yourself and only raise if it
+actually blocks you, in plain language at the moment it matters — e.g. "the bot's
+missing Manage Server, so automod rule events won't arrive; can you grant it when we
+get there?" or "the escalate feature reads as off for this guild — is that expected,
+or should we flip the flag before testing it?" If a later check needs a third
+account, ask then, not now.
+
+### 3. The loop (batched, collaborative)
+- Work one checklist (subsystem) at a time.
+- Group its checks into **batches** — a short sequence of human actions whose
+  combined effect you can disentangle from logs/DB in one read. Size each batch to
+  what you can verify unambiguously; no fixed cap. Present it conversationally:
+  *"Let's exercise spam: from a fresh account, post the same message 3× fast across
+  two channels, then ping me — I'll confirm the verdict chain landed and the
+  back-fill stayed idempotent."*
+- Human performs the batch → says done → you run every `prove:` for that batch →
+  report **PASS/FAIL with the actual evidence** (the row or the log line, quoted) →
+  next batch.
+- On **FAIL**: capture the offending row/log line verbatim into the run log.
+  Findings only — record observed-vs-expected; **do not** diagnose root cause or
+  propose a fix. Ask whether to continue or stop.
+
+### 4. Context checkpoints (you prompt these proactively)
+A live QA pass dumps a lot of logs into your context. Manage it on purpose:
+- **`/compact`** at the end of each batch when context feels heavy — light reset,
+  you keep going.
+- **`/clear` + re-invoke `qa-session`** at subsystem boundaries — full reset. On
+  re-invoke, **read the run log first** and resume at the next unchecked item.
+- Call the checkpoint out loud: *"That's the spam suite done and logged. Good
+  moment to `/clear` and re-invoke me — I'll reload the run log and pick up at
+  automod."*
+
+## Run log (durable state) + QA report (the deliverable)
+
+**Run log** — ephemeral, your resume state, never committed:
+`.claude/qa-runs/<YYYY-MM-DD>_<env>.md` (gitignored). Update it as you go: env,
+prerequisites confirmed, and a per-check tally (`PASS` / `FAIL` / `auto-verified` /
+`skipped`) with evidence quoted on failures. This is the source of truth across a
+`/clear`, not your context.
+
+**QA report** — the artifact, rendered from the run log at the end:
+- Header: env, RC/branch, image SHA (UAT), date, and a **confidence note** — local
+  = SQLite-backed; UAT = log-only, limited internal-state visibility.
+- Body: per-subsystem tally; failures show observed-vs-expected with the quoted
+  evidence. **Findings only — no root-causing, no repair proposals.**
+- Delivery:
+  - Active branch has a PR → post as a comment: `gh pr comment <#> --body-file <rendered>`.
+  - No PR for the branch → print the report in the conversation for the human.
+  - Both local and UAT findings are publishable; just label the environment.
+
+## Reading the checklists
+
+Each `checklists/<subsystem>.md` lists checks as a triple:
+
+```
+### <id> <name>
+do:    <human action, in Discord-UI terms>
+prove: local → <sqlite query and/or stdout grep>
+       uat   → <pod-log grep>
+pass:  <exact expected observable>
+```
+
+`do:` describes the Discord UI well enough for a competent human to infer exact
+names/labels; it does not hardcode strings that drift. The `prove:`/`pass:` lines
+are grounded in code at the cited `file:line` — if code moves, re-ground before
+trusting them.

--- a/.claude/skills/qa-session/checklists/automod.md
+++ b/.claude/skills/qa-session/checklists/automod.md
@@ -1,0 +1,63 @@
+# Automod rule logging + check-requirements (#315 / #363)
+
+Grounding: `app/commands/report/automodRuleLog.ts`,
+`app/commands/report/modActionLogger.ts` (automod action path),
+`app/commands/checkRequirements.ts`.
+
+Prereq: bot role has **Manage Server** in the test guild (required to receive
+`AUTO_MODERATION_RULE_*` events). Do D1 first if unsure.
+
+Rule events are **not** persisted to SQLite — they post to the mod-log channel and
+emit a log line only. So proof is log + channel post (no DB).
+
+---
+
+## Batch A — rule lifecycle
+In Discord Server Settings → AutoMod, **create**, then **edit**, then **delete** a
+rule. Ping me after each (or after all three).
+
+### A1 create
+do:    create an automod rule
+prove: local → grep `'"service":"AutomodRuleLog"'` + `'"message":"Automod rule created"'` (info, with `ruleId`,`ruleName`,`guildId`); mod-log channel shows a "Automod rule created / **<name>**" post.
+       uat   → same log + channel post.
+pass:  create logged + posted.
+
+### A2 update
+do:    edit the rule
+prove: local → `"message":"Automod rule updated"` (:202); mod-log post "Automod rule updated" with a diff.
+       uat   → same.
+pass:  update logged + posted with diff.
+
+### A3 delete
+do:    delete the rule
+prove: local → `"message":"Automod rule deleted"` (:166); mod-log post with struck-through name.
+       uat   → same.
+pass:  delete logged + posted.
+
+---
+
+## Batch B — action execution (rule tripped) is independent
+Trip an existing automod rule (post content the rule blocks) from a fresh account.
+
+### B1 action logged separately from rule events
+do:    trip a rule
+prove: local → grep `'"service":"Automod"'` + `'"message":"Automod action executed"'` (with `userId`,`ruleName`,`matchedKeyword`); if it applied a timeout, the modActionLogger path also fires (see logging.md). Note: the channel post for an automod timeout reads "by AutoMod" while the `mod_actions` row stores `executor_id` NULL.
+       uat   → "Automod action executed" log present.
+pass:  rule-trip logs through the action path even when no rule lifecycle event occurred.
+
+---
+
+## Batch D — /check-requirements Manage Server surfacing (#363)
+Run `/check-requirements` with Manage Server granted, then revoke it and run again.
+
+### D1 granted → green
+do:    grant bot Manage Server, run /check-requirements
+prove: local → the embed line for the relevant permission shows 🟢; overall summary accent is green (`hasRequiredFailure=false`, `0x00cc00`, `:469`).
+       uat   → 🟢 line + green summary.
+pass:  granted permission shows green.
+
+### D2 revoked → optional, summary stays green
+do:    revoke Manage Server, run /check-requirements again
+prove: local → the line now shows 🔵 with an "(optional) — … disabled" detail (optional checks render blue, `icon()` `:456`); summary accent stays green because optional failures don't flip `hasRequiredFailure`.
+       uat   → 🔵 optional line; summary still green.
+pass:  revoked permission shows as optional (blue) and the overall summary remains green.

--- a/.claude/skills/qa-session/checklists/commands.md
+++ b/.claude/skills/qa-session/checklists/commands.md
@@ -1,0 +1,121 @@
+# Commands & setup: escalation, member apps, setup/honeypot/tickets/reactji, force-ban, modreport, track
+
+Grounding: `app/commands/escalate/*`, `app/discord/escalationResolver.ts`,
+`app/commands/memberApplications.ts`, `app/commands/setupHandlers.ts` +
+`app/helpers/setupAll.server.ts`, `setupHoneypot.ts`, `setupTickets.ts`,
+`setupReactjiChannel.ts`, `force-ban.ts`, `modreport.ts`, `track.ts`.
+Tables: `escalations`, `escalation_records`, `applications`, `honeypot_config`,
+`tickets_config`, `reactji_channeler_config`, `reported_messages`.
+
+Setup ordering gotcha (verify it's honored): channels/roles must be created
+**before** `@everyone` permissions are modified (`setupAll.server.ts`). A guild
+left with VIEW_CHANNELS denied but no member role = the failure mode.
+
+---
+
+## Batch A — guild setup (use a fresh test guild if possible)
+Run `/setup` and walk the flow to completion. Ping me.
+
+### A1 provisions channels/roles then perms
+do:    complete /setup
+prove: local → mod-log / deletion-log / honeypot / contact / apply channels exist under the logs category; if applications enabled, a Member role exists AND `@everyone` VIEW_CHANNELS is denied with the Member role granted — created in that order (channels first). DB: guild settings persisted (guild row + relevant config tables).
+       uat   → channels + roles present and consistent; no "locked out" state.
+pass:  setup provisions resources in safe order; no guild left view-denied without a member role.
+
+### A2 honeypot setup
+do:    run the honeypot setup command for a channel
+prove: local → `honeypot_config` has `(guild_id, channel_id)`; re-running is idempotent (ON CONFLICT DO NOTHING); warning message posted to the channel.
+       uat   → honeypot channel shows the warning post.
+pass:  honeypot configured, idempotent on re-run. (Enforcement is covered in spam.md Batch D.)
+
+### A3 tickets setup
+do:    run the tickets-channel command; then a user opens a ticket via the button
+prove: local → `tickets_config` row keyed by `message_id`; clicking the button opens a private thread named "<user> – <date>"; close buttons offer neutral/👍/👎.
+       uat   → ticket thread created on button click.
+pass:  ticket button provisions a private thread; close flow present.
+
+### A4 reactji setup
+do:    run setup-reactji-channel with an emoji + threshold
+prove: local → `reactji_channeler_config` upserts `(guild_id, emoji)` with `channel_id`/`threshold`; re-running with a new threshold updates the row.
+       uat   → config takes effect (forwarding tested in logging.md Batch D).
+pass:  reactji config created/updated by (guild, emoji).
+
+---
+
+## Batch B — escalation (escalate → vote → resolve)
+Prereq: `escalate` flag enabled for the guild. From a report thread, escalate a
+user; cast votes from a couple of accounts; confirm tally + resolution.
+
+DB:
+```sh
+sqlite3 ./mod-bot.sqlite3 "SELECT id,reported_user_id,voting_strategy,scheduled_for,resolution,resolved_at FROM escalations WHERE guild_id='<GUILD>' ORDER BY created_at DESC LIMIT 5;"
+sqlite3 ./mod-bot.sqlite3 "SELECT escalation_id,voter_id,vote FROM escalation_records ORDER BY voted_at DESC LIMIT 10;"
+```
+
+### B1 create + vote
+do:    escalate a user, then vote from 2 accounts
+prove: local → grep `"Created escalation"` then `"Vote recorded"` (with `totalVotes`,`leader`); `escalations` row + one `escalation_records` row per voter; vote message shows the tally; `scheduled_for` shrinks as votes arrive (`36 - 4*voteCount` h).
+       uat   → vote message updates with tally.
+pass:  escalation + votes recorded; tally and schedule update.
+
+### B2 vote toggle
+do:    click the same resolution again from one voter
+prove: local → grep `"Deleted existing vote"`; that voter's `escalation_records` row is removed.
+       uat   → tally decrements for that voter.
+pass:  re-clicking a resolution removes that vote.
+
+### B3 resolution
+do:    let it auto-resolve (or expedite), or test user-gone path by having the target leave
+prove: local → grep `"Auto-resolving escalation"` (or `"Resolving escalation - user gone"` → resolves as track); `escalations.resolved_at`/`resolution` set; ties broken by most-severe.
+       uat   → resolution action applied + posted.
+pass:  resolves to the winning resolution (track if user gone / no winner).
+
+---
+
+## Batch C — member applications
+Prereq: `member-applications` flag enabled + gate activated. From a fresh account,
+click apply, fill the modal, then approve from staff; repeat and deny another.
+
+DB:
+```sh
+sqlite3 ./mod-bot.sqlite3 "SELECT user_id,status,reviewed_by,resolved_at FROM applications WHERE guild_id='<GUILD>' ORDER BY created_at DESC LIMIT 5;"
+```
+
+### C1 apply → approve
+do:    submit application, staff approves
+prove: local → `applications` row pending → approved (`reviewed_by`,`resolved_at` set); applicant gets the member role + DM; mod-log updated.
+       uat   → approval grants role + DM.
+pass:  approval grants access and records reviewer.
+
+### C2 apply → deny
+do:    submit another, staff denies
+prove: local → row → denied; applicant DM'd and kicked.
+       uat   → denial DMs + removes applicant.
+pass:  denial DMs and removes.
+
+### C3 one-pending limit + auto-deny on leave
+do:    try a second pending app from the same user; separately, have a pending applicant leave
+prove: local → second submission blocked (one pending allowed); a departing pending applicant's row flips to denied (GuildMemberRemove handler).
+       uat   → second app blocked; departure resolves the app.
+pass:  single-pending enforced; departure auto-resolves.
+
+---
+
+## Batch D — single-shot commands
+### D1 force-ban
+do:    use the Force Ban user context command (needs Moderate Members)
+prove: local → grep `"Force ban command executed"` then `"User force banned successfully"`; user banned; ephemeral confirm. No DB row (audit-log only).
+       uat   → user banned, confirm shown.
+pass:  force-ban bans and confirms.
+
+### D2 modreport
+do:    run /modreport on a user with history (needs Manage Messages)
+prove: local → grep `"Modreport command executed"`; embed summarizes report count / channels / mod actions / 6-month sparkline. Read-only (no writes).
+       uat   → embed renders with history.
+pass:  modreport renders an accurate read-only summary.
+
+### D3 track
+do:    use the Track message context command (needs Manage Messages); then use the delete button
+prove: local → `reported_messages` row with `reason='track'` + a user thread; reply "Tracked <#thread>"; clicking delete removes the original message and sets `deleted_at` on the row (row kept).
+       uat   → thread created; delete removes message.
+pass:  track logs to a thread; delete marks (not removes) the row.

--- a/.claude/skills/qa-session/checklists/event-bus.md
+++ b/.claude/skills/qa-session/checklists/event-bus.md
@@ -1,0 +1,37 @@
+# Event-bus / gateway resilience (#334 / #360)
+
+Grounding: `app/discord/gateway.ts`, `app/discord/eventBus.ts`, `app/server.ts`
+(`:206-229`). Pipelines are forked with `Effect.forkDaemon` so they outlive the
+startup effect; the event bus is a process-lifetime `Queue` that buffers across a
+gateway reconnect. This is a resilience check, mostly observed in logs.
+
+Pipeline startup marker: grep `'"service":"Server"'` for the fork log
+(`"Interrupted old pipeline fibers"` precedes a fresh fork on reload).
+
+---
+
+## Batch A — survives reconnect / restart
+Trigger a gateway reconnect or a pod restart, then post a message that should drive
+a pipeline (e.g. a deletion or a normal message). Ping me.
+
+- **local:** restarting isn't ideal (dev hot-reloads); prefer forcing a reconnect,
+  or accept a deliberate dev-server restart if you must. After it's back, act.
+- **uat:** `kubectl -n staging rollout restart statefulset mod-bot-uat` (or wait for
+  a natural reconnect), then act once the pod is Ready.
+
+### A1 reconnect logged
+do:    cause reconnect / restart
+prove: local → grep `'"service":"Gateway"'` + `"Client reconnecting"` (or a fresh "Interrupted old pipeline fibers" on restart).
+       uat   → same Gateway reconnect log.
+pass:  reconnect/restart is logged.
+
+### A2 pipelines still consume afterward
+do:    after reconnect, post a normal message and delete a cached message
+prove: local → after the reconnect timestamp, grep shows fresh `'"service":"Automod"'` `"Message evaluated"` AND `'"service":"DeletionLogger"'` `"MessageDelete event data"` — i.e. events still flow through the same queue to the daemon pipelines.
+       uat   → same post-reconnect pipeline activity in logs.
+pass:  pipelines produce activity *after* the reconnect — they survived it.
+
+### A3 no duplicate/stuck fibers on reload (local only)
+do:    (local) make a trivial code edit to force HMR, then post a message
+prove: local → exactly one "Interrupted old pipeline fibers" + one fresh fork per reload; a single posted message yields a single "Message evaluated" (not N duplicates from leaked fibers).
+pass:  reload interrupts old fibers and forks once; no duplicate processing.

--- a/.claude/skills/qa-session/checklists/flags-and-web.md
+++ b/.claude/skills/qa-session/checklists/flags-and-web.md
@@ -1,0 +1,72 @@
+# Feature-flag gating (#355) + web / legal routes
+
+Grounding: `app/effects/featureFlags.ts`, `app/AppRuntime.ts` (premium-gate
+capture), `app/routes.ts` + `app/routes/*`, `app/legal/LegalPage.tsx`,
+`app/features/Admin`. Most web checks are HTTP+content and **you can do them
+yourself** — only flows needing a logged-in Discord identity need the human.
+
+Flag keys (`featureFlags.ts:7-17`): `mod-log`, `anon-report`, `escalate`,
+`ticketing`, `analytics`, `deletion-log`, `velocity-spam`, `member-applications`,
+`data-export`. Evaluated per `guild` group. **No staff bypass** — a disabled flag
+blocks everyone. PostHog unreachable ⇒ **fail-closed** (feature disabled + warn).
+
+---
+
+## Batch A — flag gating (Discord-side)
+With staff: pick a paid feature (e.g. `escalate`), toggle its PostHog flag off for
+the test guild, attempt to use it, then re-enable.
+
+### A1 disabled flag blocks the feature
+do:    disable the flag, try to use the feature
+prove: local → feature is blocked (e.g. escalate throws `FeatureDisabledError` reason `not_in_rollout`); PostHog gets a `"premium gate hit"` event for the guild. If PostHog is down instead, grep `"PostHog flag check failed, defaulting to disabled"` (warn) and confirm the feature is OFF (fail-closed), not on.
+       uat   → feature blocked; gate event captured.
+pass:  disabled (or unreachable) flag ⇒ feature off, equally for staff.
+
+### A2 enabled flag restores it
+do:    re-enable the flag, retry
+prove: local → feature works again.
+       uat   → feature works.
+pass:  re-enabling restores the feature.
+
+---
+
+## Batch B — public web routes (agent can do these solo)
+You can curl/Playwright these without the human. Verify HTTP 200 + key content.
+
+### B1 marketing pages
+do:    (agent) GET `/`, `/pricing`, `/features`
+prove: `/pricing` → 200, h1 "Free to run. $100 a year to decide together."; `/features` → 200, h1 "Everything Euno does"; `/` → 200 (logged-out landing) or redirect to `/app` if authed.
+pass:  all render with expected headings.
+
+### B2 legal pages (#367, bundled markdown)
+do:    (agent) GET `/terms`, `/privacy`
+prove: both → 200, real bundled content: ToS shows "Vitullo Consulting, LLC" + effective "June 16, 2026"; Privacy lists actual processors (Discord, Stripe, PostHog, Sentry, DigitalOcean) and real retention (~1h content cache, ~24h cache records). Rendered as prose HTML, not raw markdown.
+pass:  legal pages render grounded content, not a stub/error.
+
+### B3 robots.txt
+do:    (agent) GET `/robots.txt`
+prove: no route is defined in `app/routes.ts` → expect 404 / framework fallback. Record observed status.
+pass:  status recorded; flag if behavior differs from expectation (known sharp edge, not a fix here).
+
+---
+
+## Batch C — authenticated dashboard (needs a logged-in human)
+Human logs in via Discord OAuth.
+
+### C1 user dashboard
+do:    log in, open `/app`
+prove: local → 200; server cards render with 30-day sparklines, escalations/reports/actions, subscription badges.
+       uat   → dashboard renders for the user's guilds.
+pass:  dashboard renders per-guild stats.
+
+### C2 guild settings
+do:    open `/app/<guildId>/settings`
+prove: local → 200; mod-log channel + moderator role + restricted role selectors render and save.
+       uat   → settings save.
+pass:  settings form renders and persists.
+
+### C3 admin panel (staff identity only)
+do:    as a `@reactiflux.com` user, open `/app/admin`
+prove: local → 200; guild subscription list + per-guild PostHog flag values (expandable). A non-staff identity is denied.
+       uat   → admin list renders for staff; denied otherwise.
+pass:  admin gated to staff; flag values visible there (handy for cross-checking Batch A).

--- a/.claude/skills/qa-session/checklists/logging.md
+++ b/.claude/skills/qa-session/checklists/logging.md
@@ -1,0 +1,89 @@
+# Passive pipelines: mod-action logger, deletion logger, activity tracker, reactji
+
+Grounding: `app/commands/report/modActionLogger.ts` + `modActionLog.ts`,
+`app/discord/pipelines/deletionLogHandlers.ts`,
+`app/discord/pipelines/activityTrackerHandlers.ts`,
+`app/discord/pipelines/reactjiChannelerHandler.ts`.
+Tables: `mod_actions`, `message_cache`, `message_stats`, `reactji_channeler_config`.
+
+---
+
+## Batch A — mod-action logger (ban / unban / kick / timeout)
+From a staff account, perform a **manual** ban, then unban, then kick, then
+timeout against a throwaway test member. Ping me.
+
+DB:
+```sh
+sqlite3 ./mod-bot.sqlite3 "SELECT action_type,executor_username,reason,duration,created_at FROM mod_actions WHERE user_id='<USER>' AND guild_id='<GUILD>' ORDER BY created_at DESC;"
+```
+
+### A1 each action logs + posts + persists
+do:    manual ban, unban, kick, timeout
+prove: local → grep `'"service":"ModActionLogger"'` for `"Ban detected"`/`"Unban detected"`/`"Member removal detected"`/`"Timeout detected"`; mod-log channel shows one post per action; DB has one `mod_actions` row per action with the right `action_type` (timeout row also has `duration`).
+       uat   → log line + mod-log post per action.
+pass:  4 actions → 4 logs + 4 posts (+ rows locally). Self-actions by the bot are intentionally skipped (debug "Skipping self-…").
+
+### A2 one handler failure doesn't kill the pipeline
+do:    (observe across the batch) after any single action that errors, perform another normal action
+prove: local → the subsequent action still logs/persists — pipeline keeps consuming.
+       uat   → subsequent action still posts.
+pass:  a failure in one event doesn't stop later events.
+
+---
+
+## Batch B — deletion logger (cached vs uncached)
+Post a fresh message, then delete it (cached). Then delete an **old** message the
+bot never cached (uncached). Ping me.
+
+DB (cache is written on message create):
+```sh
+sqlite3 ./mod-bot.sqlite3 "SELECT message_id,user_id,content IS NOT NULL AS has_content,last_touched FROM message_cache WHERE guild_id='<GUILD>' ORDER BY last_touched DESC LIMIT 5;"
+```
+
+### B1 cached delete → content present
+do:    delete a recently-posted (cached) message
+prove: local → grep `'"service":"DeletionLogger"'` + `'"message":"MessageDelete event data"'` with `"hasCacheEntry":true`; deletion-log post quotes the message content; `message_cache` had the row.
+       uat   → deletion-log post includes the content.
+pass:  cached deletion logs with content.
+
+### B2 uncached delete → batched, content unknown
+do:    delete an old/uncached message
+prove: local → same event log with `"hasCacheEntry":false`; deletion-log shows a batched "N uncached message(s) deleted from #channel … we don't know the content or author" (batches within ~10s per channel).
+       uat   → uncached batch post present, no content.
+pass:  uncached deletion logs as count-only batch, no content claimed.
+
+---
+
+## Batch C — activity tracker (analytics)
+Prereq: the `analytics` flag must be **enabled** for the guild (else this pipeline
+no-ops with no logs — see flags-and-web.md). From a fresh account, post a message,
+edit it, add a reaction, remove it, delete it.
+
+DB:
+```sh
+sqlite3 ./mod-bot.sqlite3 "SELECT message_id,char_count,word_count,react_count FROM message_stats WHERE guild_id='<GUILD>' ORDER BY sent_at DESC LIMIT 5;"
+```
+
+### C1 message lifecycle writes stats
+do:    post → edit → react → unreact → delete
+prove: local → debug logs `"Message stats stored"` / `"…updated"` / `"…deleted"` (service ActivityTracker); DB row appears on post with `char_count`/`word_count`, `react_count` increments on react and decrements on unreact, row is removed on delete.
+       uat   → the debug logs appear in order (no DB).
+pass:  stats row tracks the message's lifecycle; react_count moves with reactions.
+
+### C2 gated off when flag disabled
+do:    (only if confirming the gate) disable `analytics`, repeat a post
+prove: local → no ActivityTracker logs, no new `message_stats` row.
+       uat   → no ActivityTracker logs.
+pass:  disabled flag → silent no-op.
+
+---
+
+## Batch D — reactji channeler
+Prereq: a reactji config exists (see setup in commands.md). React to a message
+with the configured emoji until the threshold count is hit.
+
+### D1 threshold reaction forwards
+do:    add the configured emoji reactions up to the exact threshold
+prove: local → grep `'"service":"ReactjiChanneler"'` + `"Forwarding message"` then `"Message forwarded successfully"`; the target channel receives the forwarded message plus a "Forwarded by @… reacting with <emoji>" summary.
+       uat   → forward + summary appear in the target channel.
+pass:  hitting the exact threshold forwards once with the reactor summary. (Trigger is `count === threshold`, so it fires exactly once.)

--- a/.claude/skills/qa-session/checklists/purge.md
+++ b/.claude/skills/qa-session/checklists/purge.md
@@ -1,0 +1,53 @@
+# Purge command (#364)
+
+Grounding: `app/commands/purgeMessages.ts`. No DB writes — purge is read-only;
+proof is Discord-observable + log lines (service `Commands`).
+
+Log markers (all info, with `guildId`, `moderatorUserId`, `targetUserId`):
+- invoked → `"Purge messages command invoked"` (:111)
+- dropdown changed → `"Purge messages duration selected"` (:182)
+- confirmed → `"Purge messages confirmed"` (:239)
+- done → `"Purge messages completed"` with `deletedCount` (:328)
+
+Gotcha to probe: per-channel scan wraps each channel in `try/catch` that **silently
+swallows** errors (`:321-324`) — a channel the bot can't read is skipped with no
+per-channel log, so `deletedCount` can under-count silently.
+
+---
+
+## Batch A — confirm-button flow on a real target
+Pick a target who **actually has recent messages**. Invoke the purge command on
+them (user context-menu). Ping me after the menu renders, again after confirming.
+
+### A1 renders with default + no accidental delete
+do:    open the command; observe the duration dropdown (defaults to **24h**) and a red/Danger "Delete messages" button; change the dropdown selection
+prove: local → grep `"Purge messages command invoked"`; on changing the dropdown, grep `"Purge messages duration selected"` and confirm NO `"Purge messages completed"` yet. Discord: nothing deleted.
+       uat   → same log sequence; no deletion.
+pass:  menu shows 24h default + Delete button; changing the selection does not delete.
+
+### A2 confirm → pending → count
+do:    click "Delete messages"
+prove: local → within ~1s the reply switches to a "Purging…" pending state and the controls disappear; grep `"Purge messages confirmed"` then `"Purge messages completed"` with `deletedCount`. Cross-check the count against what the target visibly had.
+       uat   → pending state shown; completed log carries `deletedCount`.
+pass:  pending state appears, controls removed, final `deletedCount` matches the visible messages purged.
+
+### A3 silent per-channel skip awareness
+do:    (same run) if the target had messages in a channel the bot can't read
+prove: local → note whether `deletedCount` is lower than the true total with no error surfaced (the swallowed `catch`). Record observed vs expected — this is a known sharp edge, not a regression to fix here.
+       uat   → same observation.
+pass:  finding recorded; flag if count under-counts silently.
+
+---
+
+## Batch B — edge cases
+### B1 zero-message target
+do:    purge a user who has no recent messages in range
+prove: local → completes with `deletedCount` 0; grep `"Purge messages completed"`; reply reads as "Deleted 0", not an error.
+       uat   → completed log with count 0.
+pass:  graceful "0 deleted", no error.
+
+### B2 permission gating
+do:    attempt to invoke the command as a user **without** Manage Messages
+prove: local → command is hidden or denied (Discord enforces `ManageMessages`, `:106`); no `"Purge messages command invoked"` log for that user.
+       uat   → command unavailable / denied.
+pass:  unprivileged user cannot invoke it.

--- a/.claude/skills/qa-session/checklists/spam.md
+++ b/.claude/skills/qa-session/checklists/spam.md
@@ -1,0 +1,98 @@
+# Spam pipeline (#359 / #361 / #308 / #353)
+
+Grounding: `app/features/spam/service.ts`, `app/features/spam/spamResponseHandler.ts`,
+`app/models/reportedMessages.ts`, `app/discord/pipelines/automod.ts`,
+`app/commands/report/userLog.ts`. Table: `reported_messages` (see `app/db.d.ts`).
+
+DB note — every message that reaches a verdict ≥ low writes a `reported_messages`
+row: key columns `reported_message_id`, `reported_user_id`, `guild_id`,
+`reason` (`'spam'`), `extra` (verdict summary), `log_message_id`, `deleted_at`.
+Unique index `idx_unique_message_reason_guild` on
+`(reported_message_id, reason, guild_id)`; inserts use `ON CONFLICT DO NOTHING`.
+
+Reusable local queries (swap IDs):
+```sh
+sqlite3 ./mod-bot.sqlite3 "SELECT reported_message_id,reason,extra,deleted_at,created_at FROM reported_messages WHERE reported_user_id='<USER>' AND guild_id='<GUILD>' ORDER BY created_at DESC LIMIT 10;"
+```
+
+---
+
+## Batch A — burst spam (the happy path)
+From a **fresh non-staff** account, post the same message 3+ times fast across two
+channels, then ping me.
+
+### A1 verdict reached
+do:    (covered by Batch A actions)
+prove: local → grep dev.log `'"service":"SpamResponse"'` + `'"message":"Spam verdict:'`; AND a row exists per query above with `extra` like `Score N (tier): …`
+       uat   → `kubectl -n staging logs … | grep '"service":"SpamResponse"' | grep 'Spam verdict:'`
+pass:  one verdict log with `tier` of medium/high and matching `score`; ≥1 `reported_messages` row.
+
+### A2 enforcement chain
+do:    (same burst)
+prove: local → in Discord: offending messages gone from the channels; target is timed out; if ≥3 high-tier reports, target was softban+unbanned (mod-log reply "Automatically removed <@…> for spam (last hour of messages also deleted)"). DB: matching rows have `deleted_at` set after cleanup.
+       uat   → mod-log channel shows the removal reply; logs show no `"Failed to delete spam message"` / `"Failed to timeout user"` / `"Failed to softban spammer"` (all `warn`, SpamResponse).
+pass:  messages removed + timeout applied; no enforcement-failure warnings.
+
+### A3 mod-thread report
+do:    (same burst)
+prove: local → a thread post appears in the mod-log area: header "detected as spam" with score/signal breakdown + a quoted copy of the message. DB row's `log_message_id`/`log_channel_id` are populated.
+       uat   → mod thread post present with the score breakdown.
+pass:  report posted with score/tier breakdown; `log_message_id` non-null.
+
+### A4 back-fill summary (idempotent)
+do:    (same burst — the earlier duplicates get back-filled)
+prove: local → grep `'"message":"Back-fill complete:'` (SpamResponse, info) → `N new, M already recorded`; NO `"Failed to back-fill prior duplicate into reported_messages"` (warn).
+       uat   → same greps on pod logs.
+pass:  one "Back-fill complete" line with sane counts; zero back-fill failures.
+
+---
+
+## Batch B — repeat offender (the #361 collision path)
+Wait out any cooldown, then trigger a **second** verdict for the **same** user
+(another burst). Ping me.
+
+### B1 no duplicate-insert failure
+do:    (second verdict for same user)
+prove: local → grep back-fill line again: prior messages now show as `already recorded`, not `new`; still zero `"Failed to back-fill…"` warnings. DB: no duplicate rows for the same `(reported_message_id,'spam',guild_id)`.
+       uat   → back-fill line shows `already recorded` count > 0, no failure warnings.
+pass:  collision handled silently as "already recorded"; if any failure *does* log, its context carries a structured sqlite `code`/`message` (not an opaque string).
+
+---
+
+## Batch C — forwarded-message spam
+Forward the same message repeatedly from a fresh account (Discord "Forward").
+
+### C1 forwarded content feeds the detector
+do:    forward identical content several times
+prove: local → verdict fires (as A1); the mod-thread report header notes "(forwarded)"; `getMessageContent` pulled the snapshot text (`app/helpers/discord.ts:309`).
+       uat   → verdict log present; report shows forwarded note.
+pass:  forwarded content is detected the same as inline content; report marks it forwarded.
+
+---
+
+## Batch D — honeypot
+Post in the honeypot channel — **once from a non-staff account, once from a mod
+account** (to confirm the exemption).
+
+### D1 non-staff post → enforced
+do:    non-staff posts in honeypot channel
+prove: local → softban executed immediately (honeypot tier = 100); user removed.
+       uat   → mod-log shows the honeypot removal.
+pass:  immediate softban on the non-staff post.
+
+### D2 mod post → exempt
+do:    mod posts in honeypot channel
+prove: local → grep `'"message":"Mod posted in honeypot channel, no action taken"'` (SpamDetection, debug); no enforcement.
+       uat   → same log line; no removal.
+pass:  mod post produces the exemption log and no action. (This is the "spam looks broken from a staff account" gotcha.)
+
+---
+
+## Batch E — non-spam control
+From a fresh account, post a few normal, distinct messages.
+
+### E1 no false positive
+do:    post normal varied messages
+prove: local → automod still evaluates them (`grep '"service":"Automod"' | grep '"message":"Message evaluated"'` shows `tier:"none"`), but NO "Spam verdict:" log and NO new `reported_messages` row for those message IDs.
+       uat   → no "Spam verdict:" logs for the control messages.
+pass:  pipeline saw the messages (tier none) and took no action; zero rows written.

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,11 @@ vite.config.ts*
 /playwright-report/
 /playwright/.cache/
 /.playwright-mcp/
-.claude/
+.claude/*
+!.claude/skills/
 
 # Brainstorming visual companion
 .superpowers/
+
+# QA session run logs (ephemeral, not committed)
+.claude/qa-runs/

--- a/app/commands/report/constructLog.ts
+++ b/app/commands/report/constructLog.ts
@@ -1,12 +1,12 @@
 import { formatDistanceToNowStrict } from "date-fns";
-import { type Message, type MessageCreateOptions } from "discord.js";
+import { type MessageCreateOptions } from "discord.js";
 import { Effect } from "effect";
 
 import { DiscordApiError } from "#~/effects/errors";
 import {
   constructDiscordLink,
-  isForwardedMessage,
   getMessageContent,
+  isForwardedMessage,
 } from "#~/helpers/discord";
 import { truncateMessage } from "#~/helpers/string";
 import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";

--- a/app/helpers/env.server.ts
+++ b/app/helpers/env.server.ts
@@ -19,15 +19,20 @@ const getEnv = (key: string, optional = false) => {
 };
 
 export const isProd = () => process.env.NODE_ENV === ENVIRONMENTS.production;
-console.log(
-  "Running as",
-  isProd() ? "PRODUCTION" : "TEST",
-  `environment: '${process.env.NODE_ENV}'`,
-);
-
-console.log("");
+if (process.env.NODE_ENV !== "test") {
+  console.log(
+    "Running as",
+    isProd() ? "PRODUCTION" : "TEST",
+    `environment: '${process.env.NODE_ENV}'`,
+  );
+  console.log("");
+}
 export const databaseUrl = getEnv("DATABASE_URL");
-export const sessionSecret = getEnv("SESSION_SECRET", true);
+export const sessionSecret =
+  getEnv("SESSION_SECRET", true) ||
+  // Tests force every env value to "", which leaves session cookies unsigned
+  // and triggers a react-router warning. A fixed dummy keeps them signed.
+  (process.env.NODE_ENV === "test" ? "test-session-secret" : "");
 
 export const emergencyWebhook = getEnv("EMERGENCY_WEBHOOK", true);
 export const applicationKey = getEnv("DISCORD_PUBLIC_KEY");
@@ -46,4 +51,3 @@ export const posthogHost = getEnv("POSTHOG_HOST", true);
 export const webBaseUrl = getEnv("WEB_BASE_URL", true);
 
 if (!ok) throw new Error("Environment misconfigured");
-console.log("");

--- a/app/helpers/sentry.server.ts
+++ b/app/helpers/sentry.server.ts
@@ -27,7 +27,7 @@ if (isValidDsn) {
 
   console.log("Sentry initialized:", sentryOptions);
   Sentry.init(sentryOptions);
-} else {
+} else if (process.env.NODE_ENV !== "test") {
   console.log("Sentry disabled: No valid DSN configured");
 }
 

--- a/app/models/session.server.ts
+++ b/app/models/session.server.ts
@@ -70,6 +70,7 @@ const {
   cookie: {
     name: "__session",
     sameSite: "lax",
+    secrets: [sessionSecret],
   },
   async createData(data, expires) {
     const result = await runTakeFirstOrThrow(


### PR DESCRIPTION
## Summary

Two changes on this branch:

### Test output cleanup + `__session` cookie signing (`57979bb`)
`npm run test` was noisy. This quiets it and fixes a real cookie gap surfaced along the way:
- Remove the only ESLint warning (unused `Message` import in `constructLog.ts`).
- Gate startup `console.log`s in `env.server.ts` / `sentry.server.ts` behind `NODE_ENV !== "test"`, and drop a stray trailing `console.log("")` that produced empty `stdout | <file>` blocks. Non-test logging is unchanged.
- **Sign the db-backed `__session` cookie** with `secrets: [sessionSecret]`, matching `__client-session` — closes a tamper gap that existed in production too.
- Fall back to a dummy `sessionSecret` in test (the test env forces every value to `""`), so the cookie is signed and react-router stops warning.

Remaining test output is one intentional line: the softban error-path test asserting `Effect.logError` fires.

### qa-session skill draft (`42ff6fd`)
Initial draft of the interactive human↔agent release-QA skill.

## ⚠️ Deploy note
Signing `__session` changes the cookie format, so **existing prod sessions are invalidated once on deploy** — users re-auth via Discord. No data loss. Worth flagging in release notes / RC QA.

## Test plan
- `npm run test` → 35 files / 354 tests pass; output clean apart from the intentional softban log.
- `npm run lint` and `npm run typecheck` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)