### PR TITLE
fix(spam): catch attachment re-upload spam + scale velocity scoring by magnitude

### DIFF
--- a/app/features/spam/contentAnalyzer.test.ts
+++ b/app/features/spam/contentAnalyzer.test.ts
@@ -1,5 +1,6 @@
 import {
   analyzeContent,
+  buildContentHash,
   buildEmbedBody,
   buildEmbedText,
   hasLinkInContentOrEmbeds,
@@ -148,4 +149,52 @@ test("hasLink is false when content has no http and embeds have no url", () => {
   const embeds = [{ url: null, title: "No link here", description: null }];
 
   expect(hasLinkInContentOrEmbeds(content, embeds)).toBe(false);
+});
+
+// ── buildContentHash tests ──
+
+describe("buildContentHash", () => {
+  test("re-upload stability: same text and same fingerprint produce identical hash", () => {
+    const fingerprint = "pic.png:12345:image/png";
+    const hash1 = buildContentHash("hello", "", [fingerprint]);
+    const hash2 = buildContentHash("hello", "", [fingerprint]);
+    expect(hash1).toBe(hash2);
+  });
+
+  test("different filename produces different hash", () => {
+    const hash1 = buildContentHash("hello", "", ["pic.png:12345:image/png"]);
+    const hash2 = buildContentHash("hello", "", ["pic2.png:12345:image/png"]);
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("different size produces different hash", () => {
+    const hash1 = buildContentHash("hello", "", ["pic.png:12345:image/png"]);
+    const hash2 = buildContentHash("hello", "", ["pic.png:99999:image/png"]);
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("different contentType produces different hash", () => {
+    const hash1 = buildContentHash("hello", "", ["pic.png:12345:image/png"]);
+    const hash2 = buildContentHash("hello", "", ["pic.png:12345:image/jpeg"]);
+    expect(hash1).not.toBe(hash2);
+  });
+
+  test("order independence: reversed attachment list hashes the same", () => {
+    const fps = ["a.png:1:image/png", "b.png:2:image/png"];
+    const hash1 = buildContentHash("hello", "", fps);
+    const hash2 = buildContentHash("hello", "", [...fps].reverse());
+    expect(hash1).toBe(hash2);
+  });
+
+  test("no attachments: empty array returns text-only hash (no ::attachments: suffix)", () => {
+    const hash = buildContentHash("hello world", "", []);
+    expect(hash).toBe("hello world");
+    expect(hash).not.toContain("::attachments:");
+  });
+
+  test("text normalization: differing case and whitespace produce the same base hash", () => {
+    const hash1 = buildContentHash("Hello World", "", []);
+    const hash2 = buildContentHash("  hello world  ", "", []);
+    expect(hash1).toBe(hash2);
+  });
 });

--- a/app/features/spam/contentAnalyzer.ts
+++ b/app/features/spam/contentAnalyzer.ts
@@ -104,17 +104,19 @@ export function buildEmbedBody(embeds: EmbedLike[]): string {
 
 /**
  * Build a content hash for duplicate detection.
- * Combines normalized message text, embed text, and attachment IDs.
+ * Combines normalized message text, embed text, and attachment fingerprints
+ * (filename + byte size + content type — stable across re-uploads, unlike the
+ * per-upload attachment ID).
  */
 export function buildContentHash(
   content: string,
   embedText: string,
-  attachmentIds: string[],
+  attachmentFingerprints: string[],
 ): string {
   const baseContent = [content.toLowerCase().trim(), embedText]
     .filter(Boolean)
     .join(" ");
-  const sortedIds = [...attachmentIds].sort().join(",");
+  const sortedIds = [...attachmentFingerprints].sort().join(",");
   return sortedIds ? `${baseContent}::attachments:${sortedIds}` : baseContent;
 }
 

--- a/app/features/spam/service.ts
+++ b/app/features/spam/service.ts
@@ -229,6 +229,7 @@ export const SpamDetectionServiceLive = Layer.effect(
             guildId,
             recentMessages,
             contentHash,
+            attachmentFingerprints.length,
           );
 
           const allSignals = [

--- a/app/features/spam/service.ts
+++ b/app/features/spam/service.ts
@@ -191,11 +191,13 @@ export const SpamDetectionServiceLive = Layer.effect(
           const hasLink = hasLinkInContentOrEmbeds(content, message.embeds);
 
           // Record in activity tracker
-          const attachmentIds = Array.from(message.attachments.keys());
+          const attachmentFingerprints = [...message.attachments.values()].map(
+            (a) => `${a.name}:${a.size}:${a.contentType ?? ""}`,
+          );
           const contentHash = buildContentHash(
             content,
             embedText,
-            attachmentIds,
+            attachmentFingerprints,
           );
           recordMessage(tracker, guildId, userId, {
             messageId: message.id,

--- a/app/features/spam/velocityAnalyzer.test.ts
+++ b/app/features/spam/velocityAnalyzer.test.ts
@@ -264,10 +264,12 @@ test("getPriorDuplicates respects a custom window", () => {
 // ── Scaled velocity signal tests ──
 
 describe("channel_hop_fast scaling", () => {
+  // Space messages 3000ms apart so all 15 fit inside the 60s window
+  // (furthest message: 15 * 3000 = 45000ms ago, well under 60s)
   function makeHopMessages(channelCount: number): RecentMessage[] {
     const now = Date.now();
     return Array.from({ length: channelCount }, (_, i) =>
-      makeMessage({ channelId: `ch-${i}`, timestamp: now - (i + 1) * 5000 }),
+      makeMessage({ channelId: `ch-${i}`, timestamp: now - (i + 1) * 3000 }),
     );
   }
 

--- a/app/features/spam/velocityAnalyzer.test.ts
+++ b/app/features/spam/velocityAnalyzer.test.ts
@@ -1,5 +1,9 @@
 import type { RecentMessage } from "./recentActivityTracker";
-import { analyzeVelocity, getPriorDuplicates } from "./velocityAnalyzer";
+import {
+  analyzeVelocity,
+  getPriorDuplicates,
+  VELOCITY_TUNING,
+} from "./velocityAnalyzer";
 
 const makeMessage = (
   overrides: Partial<RecentMessage> = {},
@@ -255,4 +259,243 @@ test("getPriorDuplicates respects a custom window", () => {
   const priors = getPriorDuplicates(messages, currentId, hash, 60000);
   expect(priors).toHaveLength(1);
   expect(priors[0].messageId).toBe("msg-2");
+});
+
+// ── Scaled velocity signal tests ──
+
+describe("channel_hop_fast scaling", () => {
+  function makeHopMessages(channelCount: number): RecentMessage[] {
+    const now = Date.now();
+    return Array.from({ length: channelCount }, (_, i) =>
+      makeMessage({ channelId: `ch-${i}`, timestamp: now - (i + 1) * 5000 }),
+    );
+  }
+
+  test("3 channels → base score (no bonus)", () => {
+    const signals = analyzeVelocity(makeHopMessages(3), "new content");
+    const s = signals.find((x) => x.name === "channel_hop_fast");
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(VELOCITY_TUNING.channelHopFast.base);
+  });
+
+  test("5 channels → base + 2", () => {
+    const signals = analyzeVelocity(makeHopMessages(5), "new content");
+    const s = signals.find((x) => x.name === "channel_hop_fast");
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(VELOCITY_TUNING.channelHopFast.base + 2);
+  });
+
+  test("11 channels → base + 8 (bonusCap)", () => {
+    const signals = analyzeVelocity(makeHopMessages(11), "new content");
+    const s = signals.find((x) => x.name === "channel_hop_fast");
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(
+      VELOCITY_TUNING.channelHopFast.base +
+        VELOCITY_TUNING.channelHopFast.bonusCap,
+    );
+  });
+
+  test("15 channels → capped at base + bonusCap", () => {
+    const signals = analyzeVelocity(makeHopMessages(15), "new content");
+    const s = signals.find((x) => x.name === "channel_hop_fast");
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(
+      VELOCITY_TUNING.channelHopFast.base +
+        VELOCITY_TUNING.channelHopFast.bonusCap,
+    );
+  });
+});
+
+describe("rapid_fire scaling", () => {
+  // Space messages 2s apart so all fit within the 30s window
+  function makeRapidMessages(count: number): RecentMessage[] {
+    const now = Date.now();
+    return Array.from({ length: count }, (_, i) =>
+      makeMessage({ contentHash: `msg-${i}`, timestamp: now - i * 2000 }),
+    );
+  }
+
+  test("5 msgs → base score (no bonus)", () => {
+    const signals = analyzeVelocity(makeRapidMessages(5), "new content");
+    const s = signals.find((x) => x.name === "rapid_fire");
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(VELOCITY_TUNING.rapidFire.base);
+  });
+
+  test("8 msgs → base + 3", () => {
+    const signals = analyzeVelocity(makeRapidMessages(8), "new content");
+    const s = signals.find((x) => x.name === "rapid_fire");
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(VELOCITY_TUNING.rapidFire.base + 3);
+  });
+
+  test("10 msgs → base + 5 (bonusCap)", () => {
+    const signals = analyzeVelocity(makeRapidMessages(10), "new content");
+    const s = signals.find((x) => x.name === "rapid_fire");
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(
+      VELOCITY_TUNING.rapidFire.base + VELOCITY_TUNING.rapidFire.bonusCap,
+    );
+  });
+
+  test("14 msgs → capped at base + bonusCap", () => {
+    const signals = analyzeVelocity(makeRapidMessages(14), "new content");
+    const s = signals.find((x) => x.name === "rapid_fire");
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(
+      VELOCITY_TUNING.rapidFire.base + VELOCITY_TUNING.rapidFire.bonusCap,
+    );
+  });
+});
+
+describe("channel_hop_slow scaling", () => {
+  // Make messages spread over 5 minutes (not 60s), so channelsIn60s < 3
+  function makeSlowHopMessages(channelCount: number): RecentMessage[] {
+    const now = Date.now();
+    return Array.from({ length: channelCount }, (_, i) =>
+      makeMessage({
+        channelId: `ch-${i}`,
+        // spread over ~4 minutes so they are within 5m but outside 60s
+        timestamp: now - 70000 - i * 15000,
+      }),
+    );
+  }
+
+  test("5 channels in 5m (slow) → base score", () => {
+    const signals = analyzeVelocity(makeSlowHopMessages(5), "new content");
+    const s = signals.find((x) => x.name === "channel_hop_slow");
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(VELOCITY_TUNING.channelHopSlow.base);
+  });
+
+  test("9 channels in 5m (slow) → base + 4 (capped)", () => {
+    const signals = analyzeVelocity(makeSlowHopMessages(9), "new content");
+    const s = signals.find((x) => x.name === "channel_hop_slow");
+    expect(s).toBeDefined();
+    expect(s!.score).toBe(
+      VELOCITY_TUNING.channelHopSlow.base +
+        VELOCITY_TUNING.channelHopSlow.bonusCap,
+    );
+  });
+});
+
+describe("attachment_burst signal", () => {
+  test("fires when a velocity signal is present (channel-hop + 2 attachments)", () => {
+    const now = Date.now();
+    const messages = [
+      makeMessage({ channelId: "ch-1", timestamp: now - 10000 }),
+      makeMessage({ channelId: "ch-2", timestamp: now - 5000 }),
+      makeMessage({ channelId: "ch-3", timestamp: now - 1000 }),
+    ];
+    const signals = analyzeVelocity(messages, "new content", 2);
+    expect(signals.find((s) => s.name === "channel_hop_fast")).toBeDefined();
+    const burst = signals.find((s) => s.name === "attachment_burst");
+    expect(burst).toBeDefined();
+    expect(burst!.score).toBe(2);
+  });
+
+  test("does NOT fire when no velocity signal is present (lone message with attachments)", () => {
+    const signals = analyzeVelocity([], "new content", 3);
+    expect(signals.find((s) => s.name === "attachment_burst")).toBeUndefined();
+  });
+
+  test("attachment_burst score is capped at bonusCap", () => {
+    const now = Date.now();
+    const messages = [
+      makeMessage({ channelId: "ch-1", timestamp: now - 10000 }),
+      makeMessage({ channelId: "ch-2", timestamp: now - 5000 }),
+      makeMessage({ channelId: "ch-3", timestamp: now - 1000 }),
+    ];
+    // 10 attachments, bonusCap is 4
+    const signals = analyzeVelocity(messages, "new content", 10);
+    const burst = signals.find((s) => s.name === "attachment_burst");
+    expect(burst).toBeDefined();
+    expect(burst!.score).toBe(VELOCITY_TUNING.attachmentBurst.bonusCap);
+  });
+
+  test("does NOT appear on cross_channel_spam path (early return)", () => {
+    const now = Date.now();
+    const hash = "spam content";
+    const messages = [
+      makeMessage({
+        contentHash: hash,
+        channelId: "ch-1",
+        timestamp: now - 10000,
+      }),
+      makeMessage({
+        contentHash: hash,
+        channelId: "ch-2",
+        timestamp: now - 20000,
+      }),
+      makeMessage({
+        contentHash: hash,
+        channelId: "ch-3",
+        timestamp: now - 30000,
+      }),
+    ];
+    // cross_channel_spam should fire and early-return — no attachment_burst
+    const signals = analyzeVelocity(messages, hash, 3);
+    expect(signals.find((s) => s.name === "cross_channel_spam")).toBeDefined();
+    expect(signals).toHaveLength(1);
+    expect(signals.find((s) => s.name === "attachment_burst")).toBeUndefined();
+  });
+});
+
+describe("scenario fixtures (velocity-only totals)", () => {
+  test("Scenario C: 15 channels/60s + 14 msgs/30s, 0 attachments → sum 20", () => {
+    const now = Date.now();
+    // 15 unique channels in 60s, varied content, 14 msgs in 30s
+    const messages = Array.from({ length: 14 }, (_, i) =>
+      makeMessage({
+        channelId: `ch-${i % 15}`,
+        contentHash: `unique-${i}`,
+        timestamp: now - (i + 1) * 2000, // within 30s
+      }),
+    );
+    // Add one more unique channel to reach 15 distinct (i%15 covers 0–13 = 14 channels already)
+    // With 14 msgs and channelId ch-0..ch-13, we have 14 channels; need 15
+    const extra = makeMessage({
+      channelId: "ch-14",
+      contentHash: "unique-extra",
+      timestamp: now - 1000,
+    });
+    const allMessages = [...messages, extra];
+    const signals = analyzeVelocity(allMessages, "new content", 0);
+    const hopFast = signals.find((s) => s.name === "channel_hop_fast");
+    const rapid = signals.find((s) => s.name === "rapid_fire");
+    expect(hopFast).toBeDefined();
+    expect(rapid).toBeDefined();
+    // channel_hop_fast: scaledScore(4, 15, 3, 1, 8) = 4 + min(12, 8) = 12
+    expect(hopFast!.score).toBe(12);
+    // rapid_fire: scaledScore(3, 15, 5, 1, 5) = 3 + min(10, 5) = 8
+    expect(rapid!.score).toBe(8);
+    const velocitySum = signals
+      .filter((s) => ["channel_hop_fast", "rapid_fire"].includes(s.name))
+      .reduce((acc, s) => acc + s.score, 0);
+    expect(velocitySum).toBe(20);
+  });
+
+  test("Scenario E: 5 channels/60s + 5 msgs/30s → velocity sum 9", () => {
+    const now = Date.now();
+    const messages = Array.from({ length: 5 }, (_, i) =>
+      makeMessage({
+        channelId: `ch-${i}`,
+        contentHash: `unique-${i}`,
+        timestamp: now - (i + 1) * 4000, // within 30s (i=4 → 20s ago)
+      }),
+    );
+    const signals = analyzeVelocity(messages, "new content", 0);
+    const hopFast = signals.find((s) => s.name === "channel_hop_fast");
+    const rapid = signals.find((s) => s.name === "rapid_fire");
+    expect(hopFast).toBeDefined();
+    expect(rapid).toBeDefined();
+    // channel_hop_fast: scaledScore(4, 5, 3, 1, 8) = 4 + 2 = 6
+    expect(hopFast!.score).toBe(6);
+    // rapid_fire: scaledScore(3, 5, 5, 1, 5) = 3 + 0 = 3
+    expect(rapid!.score).toBe(3);
+    const velocitySum = signals
+      .filter((s) => ["channel_hop_fast", "rapid_fire"].includes(s.name))
+      .reduce((acc, s) => acc + s.score, 0);
+    expect(velocitySum).toBe(9);
+  });
 });

--- a/app/features/spam/velocityAnalyzer.ts
+++ b/app/features/spam/velocityAnalyzer.ts
@@ -10,6 +10,24 @@ const ONE_MINUTE_MS = 60 * 1000;
 const FIVE_MINUTES_MS = 5 * ONE_MINUTE_MS;
 const THIRTY_SECONDS_MS = 30 * 1000;
 
+export const VELOCITY_TUNING = {
+  channelHopFast: { base: 4, threshold: 3, perUnit: 1, bonusCap: 8 }, // range 4–12
+  rapidFire: { base: 3, threshold: 5, perUnit: 1, bonusCap: 5 }, // range 3–8
+  channelHopSlow: { base: 3, threshold: 5, perUnit: 1, bonusCap: 4 }, // range 3–7
+  attachmentBurst: { perUnit: 1, bonusCap: 4 }, // 0–4
+} as const;
+
+/** base + min((count - threshold) * perUnit, bonusCap) — never below base. */
+function scaledScore(
+  base: number,
+  count: number,
+  threshold: number,
+  perUnit: number,
+  bonusCap: number,
+): number {
+  return base + Math.min(Math.max(count - threshold, 0) * perUnit, bonusCap);
+}
+
 /** Count unique channels used within a time window */
 function countChannelsInWindow(
   messages: RecentMessage[],
@@ -63,10 +81,12 @@ function countMessagesInWindow(
  * Analyze velocity signals from recent message history.
  * @param recentMessages - All recent messages for this user in this guild
  * @param currentContentHash - Content hash of the current message being checked
+ * @param attachmentCount - Number of attachments on the current message
  */
 export function analyzeVelocity(
   recentMessages: RecentMessage[],
   currentContentHash: string,
+  attachmentCount = 0,
 ): SpamSignal[] {
   const signals: SpamSignal[] = [];
   const now = Date.now();
@@ -99,7 +119,13 @@ export function analyzeVelocity(
   if (channelsIn60s >= 3) {
     signals.push({
       name: "channel_hop_fast",
-      score: 4,
+      score: scaledScore(
+        VELOCITY_TUNING.channelHopFast.base,
+        channelsIn60s,
+        VELOCITY_TUNING.channelHopFast.threshold,
+        VELOCITY_TUNING.channelHopFast.perUnit,
+        VELOCITY_TUNING.channelHopFast.bonusCap,
+      ),
       description: `${channelsIn60s} channels in 60 seconds`,
     });
   }
@@ -114,7 +140,13 @@ export function analyzeVelocity(
   if (channelsIn5m >= 5 && channelsIn60s < 3) {
     signals.push({
       name: "channel_hop_slow",
-      score: 3,
+      score: scaledScore(
+        VELOCITY_TUNING.channelHopSlow.base,
+        channelsIn5m,
+        VELOCITY_TUNING.channelHopSlow.threshold,
+        VELOCITY_TUNING.channelHopSlow.perUnit,
+        VELOCITY_TUNING.channelHopSlow.bonusCap,
+      ),
       description: `${channelsIn5m} channels in 5 minutes`,
     });
   }
@@ -143,11 +175,27 @@ export function analyzeVelocity(
   if (messagesIn30s >= 5) {
     signals.push({
       name: "rapid_fire",
-      score: 3,
+      score: scaledScore(
+        VELOCITY_TUNING.rapidFire.base,
+        messagesIn30s,
+        VELOCITY_TUNING.rapidFire.threshold,
+        VELOCITY_TUNING.rapidFire.perUnit,
+        VELOCITY_TUNING.rapidFire.bonusCap,
+      ),
       description: `${messagesIn30s} messages in 30 seconds`,
     });
   }
 
+  if (attachmentCount > 0 && signals.length > 0) {
+    signals.push({
+      name: "attachment_burst",
+      score: Math.min(
+        attachmentCount * VELOCITY_TUNING.attachmentBurst.perUnit,
+        VELOCITY_TUNING.attachmentBurst.bonusCap,
+      ),
+      description: `${attachmentCount} attachment(s) on flagged message`,
+    });
+  }
   return signals;
 }
 

--- a/app/features/spam/velocityGate.test.ts
+++ b/app/features/spam/velocityGate.test.ts
@@ -39,7 +39,7 @@ describe("gatedVelocitySignals", () => {
   test("returns analyzeVelocity output when the flag is enabled", async () => {
     const flags = makeFlags(true);
     const result = await Effect.runPromise(
-      gatedVelocitySignals(flags, "g1", messages, "h", { now: () => NOW }),
+      gatedVelocitySignals(flags, "g1", messages, "h", 0, { now: () => NOW }),
     );
     expect(result).toEqual(analyzeVelocity(messages, "h"));
   });
@@ -47,7 +47,7 @@ describe("gatedVelocitySignals", () => {
   test("returns [] when the flag is disabled", async () => {
     const flags = makeFlags(false);
     const result = await Effect.runPromise(
-      gatedVelocitySignals(flags, "g1", messages, "h", { now: () => NOW }),
+      gatedVelocitySignals(flags, "g1", messages, "h", 0, { now: () => NOW }),
     );
     expect(result).toEqual([]);
   });
@@ -56,13 +56,13 @@ describe("gatedVelocitySignals", () => {
     const calls = { n: 0 };
     const flags = makeFlags(true, calls);
     await Effect.runPromise(
-      gatedVelocitySignals(flags, "g1", messages, "h", {
+      gatedVelocitySignals(flags, "g1", messages, "h", 0, {
         now: () => NOW,
         ttlMs: 60_000,
       }),
     );
     await Effect.runPromise(
-      gatedVelocitySignals(flags, "g1", messages, "h", {
+      gatedVelocitySignals(flags, "g1", messages, "h", 0, {
         now: () => NOW + 30_000,
         ttlMs: 60_000,
       }),
@@ -74,13 +74,13 @@ describe("gatedVelocitySignals", () => {
     const calls = { n: 0 };
     const flags = makeFlags(true, calls);
     await Effect.runPromise(
-      gatedVelocitySignals(flags, "g1", messages, "h", {
+      gatedVelocitySignals(flags, "g1", messages, "h", 0, {
         now: () => NOW,
         ttlMs: 60_000,
       }),
     );
     await Effect.runPromise(
-      gatedVelocitySignals(flags, "g1", messages, "h", {
+      gatedVelocitySignals(flags, "g1", messages, "h", 0, {
         now: () => NOW + 61_000,
         ttlMs: 60_000,
       }),
@@ -92,11 +92,78 @@ describe("gatedVelocitySignals", () => {
     const calls = { n: 0 };
     const flags = makeFlags(true, calls);
     await Effect.runPromise(
-      gatedVelocitySignals(flags, "g1", messages, "h", { now: () => NOW }),
+      gatedVelocitySignals(flags, "g1", messages, "h", 0, { now: () => NOW }),
     );
     await Effect.runPromise(
-      gatedVelocitySignals(flags, "g2", messages, "h", { now: () => NOW }),
+      gatedVelocitySignals(flags, "g2", messages, "h", 0, { now: () => NOW }),
     );
     expect(calls.n).toBe(2);
+  });
+
+  test("forwards attachmentCount — channel-hop + attachments yields attachment_burst", async () => {
+    const flags = makeFlags(true);
+    const now = Date.now();
+    // 3 different channels in 60s triggers channel_hop_fast
+    const hopMessages = [
+      {
+        messageId: "a",
+        channelId: "ch-1",
+        contentHash: "x",
+        timestamp: now - 10000,
+        hasLink: false,
+      },
+      {
+        messageId: "b",
+        channelId: "ch-2",
+        contentHash: "x",
+        timestamp: now - 5000,
+        hasLink: false,
+      },
+      {
+        messageId: "c",
+        channelId: "ch-3",
+        contentHash: "x",
+        timestamp: now - 1000,
+        hasLink: false,
+      },
+    ];
+    const result = await Effect.runPromise(
+      gatedVelocitySignals(flags, "g1", hopMessages, "new-content", 2),
+    );
+    expect(result.find((s) => s.name === "channel_hop_fast")).toBeDefined();
+    expect(result.find((s) => s.name === "attachment_burst")).toBeDefined();
+    expect(result.find((s) => s.name === "attachment_burst")!.score).toBe(2);
+  });
+
+  test("gate-disabled returns [] even with attachments and velocity-triggering messages", async () => {
+    const flags = makeFlags(false);
+    const now = Date.now();
+    const hopMessages = [
+      {
+        messageId: "a",
+        channelId: "ch-1",
+        contentHash: "x",
+        timestamp: now - 10000,
+        hasLink: false,
+      },
+      {
+        messageId: "b",
+        channelId: "ch-2",
+        contentHash: "x",
+        timestamp: now - 5000,
+        hasLink: false,
+      },
+      {
+        messageId: "c",
+        channelId: "ch-3",
+        contentHash: "x",
+        timestamp: now - 1000,
+        hasLink: false,
+      },
+    ];
+    const result = await Effect.runPromise(
+      gatedVelocitySignals(flags, "g1", hopMessages, "new-content", 3),
+    );
+    expect(result).toEqual([]);
   });
 });

--- a/app/features/spam/velocityGate.test.ts
+++ b/app/features/spam/velocityGate.test.ts
@@ -102,33 +102,35 @@ describe("gatedVelocitySignals", () => {
 
   test("forwards attachmentCount — channel-hop + attachments yields attachment_burst", async () => {
     const flags = makeFlags(true);
-    const now = Date.now();
+    const testNow = Date.now();
     // 3 different channels in 60s triggers channel_hop_fast
     const hopMessages = [
       {
         messageId: "a",
         channelId: "ch-1",
         contentHash: "x",
-        timestamp: now - 10000,
+        timestamp: testNow - 10000,
         hasLink: false,
       },
       {
         messageId: "b",
         channelId: "ch-2",
         contentHash: "x",
-        timestamp: now - 5000,
+        timestamp: testNow - 5000,
         hasLink: false,
       },
       {
         messageId: "c",
         channelId: "ch-3",
         contentHash: "x",
-        timestamp: now - 1000,
+        timestamp: testNow - 1000,
         hasLink: false,
       },
     ];
     const result = await Effect.runPromise(
-      gatedVelocitySignals(flags, "g1", hopMessages, "new-content", 2),
+      gatedVelocitySignals(flags, "g1", hopMessages, "new-content", 2, {
+        now: () => testNow,
+      }),
     );
     expect(result.find((s) => s.name === "channel_hop_fast")).toBeDefined();
     expect(result.find((s) => s.name === "attachment_burst")).toBeDefined();
@@ -137,32 +139,34 @@ describe("gatedVelocitySignals", () => {
 
   test("gate-disabled returns [] even with attachments and velocity-triggering messages", async () => {
     const flags = makeFlags(false);
-    const now = Date.now();
+    const testNow = Date.now();
     const hopMessages = [
       {
         messageId: "a",
         channelId: "ch-1",
         contentHash: "x",
-        timestamp: now - 10000,
+        timestamp: testNow - 10000,
         hasLink: false,
       },
       {
         messageId: "b",
         channelId: "ch-2",
         contentHash: "x",
-        timestamp: now - 5000,
+        timestamp: testNow - 5000,
         hasLink: false,
       },
       {
         messageId: "c",
         channelId: "ch-3",
         contentHash: "x",
-        timestamp: now - 1000,
+        timestamp: testNow - 1000,
         hasLink: false,
       },
     ];
     const result = await Effect.runPromise(
-      gatedVelocitySignals(flags, "g1", hopMessages, "new-content", 3),
+      gatedVelocitySignals(flags, "g1", hopMessages, "new-content", 3, {
+        now: () => testNow,
+      }),
     );
     expect(result).toEqual([]);
   });

--- a/app/features/spam/velocityGate.ts
+++ b/app/features/spam/velocityGate.ts
@@ -28,6 +28,7 @@ export const gatedVelocitySignals = (
   guildId: string,
   recentMessages: Parameters<typeof analyzeVelocity>[0],
   contentHash: string,
+  attachmentCount = 0,
   opts: GateOpts = {},
 ) =>
   Effect.gen(function* () {
@@ -55,5 +56,7 @@ export const gatedVelocitySignals = (
       );
     }
 
-    return enabled ? analyzeVelocity(recentMessages, contentHash) : [];
+    return enabled
+      ? analyzeVelocity(recentMessages, contentHash, attachmentCount)
+      : [];
   });


### PR DESCRIPTION
## Why

A spammer (`smartharry_49425`) hit one guild across 15 channels for ~15 minutes (~300 spam verdicts) but every verdict stayed pinned at `tier: low, score: 7` — log-only, no removal. They were only stopped when they tripped a honeypot channel. Two independent gaps let this happen:

1. **The duplicate detector was defeated by attachments.** `buildContentHash` fingerprinted attachments on `message.attachments.keys()` — the per-upload snowflake **ID**, which is unique every upload. The spammer re-uploaded the *same files* (matching filenames + byte sizes, per the logs), but each got a fresh ID → different hash → the `cross_channel_spam` combo detector (+15 → instant `high`) never fired.
2. **Velocity scoring was flat.** `channel_hop_fast` (+4) and `rapid_fire` (+3) are fixed constants that don't scale, so 15 channels scored the same `7` as 5 — permanently `low`, never reaching `medium`/`high`.

## What

**Part A — stable attachment fingerprint** (`buildContentHash` / `service.ts`)
Fingerprint attachments by `name:size:contentType` instead of the per-upload ID, so identical re-uploaded files hash identically and `cross_channel_spam` fires.

**Part B — magnitude-aware velocity scoring** (`velocityAnalyzer.ts`)
Count-based signals now scale `base + min((count − threshold)·perUnit, cap)` via an exported `VELOCITY_TUNING` table:

| Signal | Was | Now (range) |
|---|---|---|
| `channel_hop_fast` | +4 | 4–12 |
| `rapid_fire` | +3 | 3–8 |
| `channel_hop_slow` | +3 | 3–7 |
| `attachment_burst` *(new)* | — | 0–4 (+1/attachment, only when another velocity signal fired; never on the `cross_channel_spam` early-return path) |

`cross_channel_spam` (+15) and `duplicate_messages` (+5), the tiers, and the response handler are unchanged. `attachmentCount` threads `service.ts → gatedVelocitySignals → analyzeVelocity`.

### Effect on the incident
The 15-channel/varied-content burst now scores `channel_hop_fast 12 + rapid_fire 8 = 20` → `high` (timeout + the 3-report auto-kick/softban path) instead of a permanent `7 = low`. Identical-file re-upload floods now trip `cross_channel_spam` at the 3rd channel.

## Testing
- 104 spam tests pass (`vitest run app/features/spam/`); typecheck clean.
- New `buildContentHash` tests (re-upload stability, name/size/type differentiation, order-independence, no-attachment path).
- Velocity scaling tests at threshold/mid/cap for each signal; `attachment_burst` gating (fires only with another signal, never on the cross_channel path); end-to-end forwarding through the gate; design-doc scenarios asserted directly.

## Follow-ups (deferred, non-blocking)
- The `buildContentHash` re-upload unit test is structurally trivial; the real regression lives at the `service.ts` call-site — worth a service-layer test.
- `analyzeVelocity` uses internal `Date.now()` (no clock injection); the `rapid_fire` 14-msg fixture has ~2s of window margin.
- `a.name` is nullable in some discord.js typings — could mirror the `contentType ?? ""` handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)