### PR TITLE
fix: rc/v2026.22 QA bugs (#369–#373)

### DIFF
--- a/app/commands/escalate/handlers.ts
+++ b/app/commands/escalate/handlers.ts
@@ -17,6 +17,7 @@ import {
   interactionUpdate,
 } from "#~/effects/discordSdk.ts";
 import { logEffect } from "#~/effects/observability.ts";
+import { webBaseUrl } from "#~/helpers/env.server";
 import {
   humanReadableResolutions,
   type Resolution,
@@ -226,7 +227,7 @@ const escalate = (interaction: MessageComponentInteraction) =>
     Effect.provide(EscalationServiceLive),
     Effect.catchTag("FeatureDisabledError", () =>
       interactionEditReply(interaction, {
-        content: "This is a paid feature. Upgrade with `/upgrade`",
+        content: `This is a paid feature. [Upgrade your plan](${webBaseUrl}/app/${interaction.guildId}/settings/upgrade) to enable it.`,
       }).pipe(Effect.catchAll(() => Effect.void)),
     ),
     Effect.catchTag("NotFoundError", () =>

--- a/app/commands/reactjiEmoji.test.ts
+++ b/app/commands/reactjiEmoji.test.ts
@@ -1,0 +1,111 @@
+import { resolveReactjiEmoji } from "./reactjiEmoji";
+
+interface GuildEmoji {
+  name: string | null;
+  id: string;
+  animated: boolean;
+}
+
+const noGuildEmoji: GuildEmoji[] = [];
+
+test("accepts a literal unicode emoji", () => {
+  expect(resolveReactjiEmoji("👍", noGuildEmoji)).toEqual({
+    ok: true,
+    value: "👍",
+  });
+});
+
+test("trims surrounding whitespace from a unicode emoji", () => {
+  expect(resolveReactjiEmoji("  🔥 ", noGuildEmoji)).toEqual({
+    ok: true,
+    value: "🔥",
+  });
+});
+
+test("accepts a skin-tone modified emoji node-emoji doesn't know", () => {
+  expect(resolveReactjiEmoji("👍🏽", noGuildEmoji)).toEqual({
+    ok: true,
+    value: "👍🏽",
+  });
+});
+
+test("accepts a custom-emoji mention verbatim", () => {
+  expect(resolveReactjiEmoji("<:partyblob:123>", noGuildEmoji)).toEqual({
+    ok: true,
+    value: "<:partyblob:123>",
+  });
+});
+
+test("accepts an animated custom-emoji mention verbatim", () => {
+  expect(resolveReactjiEmoji("<a:dance:456>", noGuildEmoji)).toEqual({
+    ok: true,
+    value: "<a:dance:456>",
+  });
+});
+
+test("resolves a bare guild-emoji name to its mention", () => {
+  const guild: GuildEmoji[] = [
+    { name: "partyblob", id: "999", animated: false },
+  ];
+  expect(resolveReactjiEmoji("partyblob", guild)).toEqual({
+    ok: true,
+    value: "<:partyblob:999>",
+  });
+});
+
+test("resolves a bare animated guild-emoji name to its animated mention", () => {
+  const guild: GuildEmoji[] = [{ name: "dance", id: "777", animated: true }];
+  expect(resolveReactjiEmoji("dance", guild)).toEqual({
+    ok: true,
+    value: "<a:dance:777>",
+  });
+});
+
+test("guild custom emoji takes precedence over a same-named unicode shortcode", () => {
+  const guild: GuildEmoji[] = [{ name: "fire", id: "555", animated: false }];
+  expect(resolveReactjiEmoji("fire", guild)).toEqual({
+    ok: true,
+    value: "<:fire:555>",
+  });
+});
+
+test("converts a standard shortcode with colons to unicode", () => {
+  expect(resolveReactjiEmoji(":smile:", noGuildEmoji)).toEqual({
+    ok: true,
+    value: "😄",
+  });
+});
+
+test("converts a standard shortcode without colons to unicode", () => {
+  expect(resolveReactjiEmoji("smile", noGuildEmoji)).toEqual({
+    ok: true,
+    value: "😄",
+  });
+});
+
+test("converts the Discord-specific thumbsup alias node-emoji lacks", () => {
+  expect(resolveReactjiEmoji("thumbsup", noGuildEmoji)).toEqual({
+    ok: true,
+    value: "👍",
+  });
+});
+
+test("converts :thumbsup: (the issue's example) to unicode", () => {
+  expect(resolveReactjiEmoji(":thumbsup:", noGuildEmoji)).toEqual({
+    ok: true,
+    value: "👍",
+  });
+});
+
+test("rejects unrecognized text with no match", () => {
+  const result = resolveReactjiEmoji("notanemoji", noGuildEmoji);
+  expect(result.ok).toBe(false);
+});
+
+test("rejects empty / whitespace-only input", () => {
+  expect(resolveReactjiEmoji("   ", noGuildEmoji).ok).toBe(false);
+});
+
+test("rejects an emoji glued to trailing text (would be a dead config)", () => {
+  expect(resolveReactjiEmoji("👍hello", noGuildEmoji).ok).toBe(false);
+});

--- a/app/commands/reactjiEmoji.ts
+++ b/app/commands/reactjiEmoji.ts
@@ -1,0 +1,86 @@
+/**
+ * Reactji emoji input resolution — pure function, no Discord/Effect deps.
+ *
+ * The reactji channeler keys configs on the reaction's *actual* identifier:
+ * a custom-emoji mention (`<:name:id>` / `<a:name:id>`) or, for standard
+ * emoji, the unicode character (`reaction.emoji.name`, e.g. `👍`). An admin
+ * who types a shortcode (`thumbsup` / `:thumbsup:`) or arbitrary text would
+ * otherwise store a value that can never match — a silently dead config (#371).
+ *
+ * This resolver normalizes input to a storable, matchable value or rejects it.
+ */
+
+import { get } from "node-emoji";
+
+export interface GuildEmojiLike {
+  name: string | null;
+  id: string;
+  animated: boolean;
+}
+
+export type EmojiResolution =
+  | { ok: true; value: string }
+  | { ok: false; error: string };
+
+const CUSTOM_MENTION = /^<a?:\w+:\d+>$/;
+const PICTOGRAPHIC = /\p{Extended_Pictographic}/u;
+
+/**
+ * Discord exposes these shortcodes but node-emoji's dataset maps the same
+ * glyphs to `+1` / `-1` only, so it can't resolve them. Patch the gap.
+ */
+const DISCORD_ALIASES: Record<string, string> = {
+  thumbsup: "👍",
+  thumbsdown: "👎",
+};
+
+const REJECT =
+  "That doesn't look like an emoji. Paste the actual emoji (e.g. 👍) or a custom server emoji, not its name.";
+
+export function resolveReactjiEmoji(
+  input: string,
+  guildEmojis: GuildEmojiLike[],
+): EmojiResolution {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { ok: false, error: "Please provide an emoji." };
+  }
+
+  // 1. Fully-formed custom-emoji mention — already matchable, store verbatim.
+  if (CUSTOM_MENTION.test(trimmed)) {
+    return { ok: true, value: trimmed };
+  }
+
+  // 2. Literal unicode emoji (incl. skin tones / sequences node-emoji misses).
+  //    Exclude ASCII letters so "👍hello" can't create a never-matching config.
+  if (PICTOGRAPHIC.test(trimmed) && !/[A-Za-z]/.test(trimmed)) {
+    return { ok: true, value: trimmed };
+  }
+
+  // 3. Shortcode / name path — strip optional surrounding colons.
+  const key = trimmed.replace(/^:|:$/g, "").toLowerCase();
+
+  // 3a. A custom server emoji by name wins (most specific to this guild).
+  const guildEmoji = guildEmojis.find(
+    (e) => e.name && e.name.toLowerCase() === key,
+  );
+  if (guildEmoji) {
+    return {
+      ok: true,
+      value: `<${guildEmoji.animated ? "a" : ""}:${guildEmoji.name}:${guildEmoji.id}>`,
+    };
+  }
+
+  // 3b. Standard emoji shortcode via node-emoji.
+  const fromNodeEmoji = get(key);
+  if (fromNodeEmoji) {
+    return { ok: true, value: fromNodeEmoji };
+  }
+
+  // 3c. Discord-specific aliases node-emoji's dataset omits.
+  if (DISCORD_ALIASES[key]) {
+    return { ok: true, value: DISCORD_ALIASES[key] };
+  }
+
+  return { ok: false, error: REJECT };
+}

--- a/app/commands/setupReactjiChannel.ts
+++ b/app/commands/setupReactjiChannel.ts
@@ -12,6 +12,8 @@ import { logEffect } from "#~/effects/observability.ts";
 import type { SlashCommand } from "#~/helpers/discord";
 import { featureStats } from "#~/helpers/metrics";
 
+import { resolveReactjiEmoji } from "./reactjiEmoji.ts";
+
 export const Command = {
   command: new SlashCommandBuilder()
     .setName("setup-reactji-channel")
@@ -55,20 +57,26 @@ export const Command = {
       const guildId = interaction.guild.id;
       const configuredById = interaction.user.id;
 
-      // Parse the emoji - handle both unicode and custom emoji formats
-      // Custom emojis come in as <:name:id> or <a:name:id> for animated
-      const customEmojiRegex = /^<a?:(\w+):(\d+)>$/;
-      const emoji = customEmojiRegex.exec(emojiInput)
-        ? emojiInput
-        : emojiInput.trim();
+      // Resolve the emoji to a value the channeler can actually match against:
+      // a custom-emoji mention or a unicode character. Reject shortcodes/text
+      // that could never match a real reaction (#371).
+      const resolution = resolveReactjiEmoji(
+        emojiInput,
+        interaction.guild.emojis.cache.map((e) => ({
+          name: e.name,
+          id: e.id,
+          animated: e.animated ?? false,
+        })),
+      );
 
-      if (!emoji) {
+      if (!resolution.ok) {
         yield* interactionReply(interaction, {
-          content: "Please provide a valid emoji.",
+          content: resolution.error,
           flags: [MessageFlags.Ephemeral],
         });
         return;
       }
+      const emoji = resolution.value;
 
       // Upsert: update if exists, insert if not
       const db = yield* DatabaseService;

--- a/app/commands/setupTickets.ts
+++ b/app/commands/setupTickets.ts
@@ -75,6 +75,23 @@ export const Command = [
           return;
         }
 
+        // Gate at setup, not at button-press: provisioning a button that the
+        // open-ticket handler will reject gives the admin a false success and
+        // surfaces the failure to an end user later (#370).
+        const flags = yield* FeatureFlagService;
+        const ticketingEnabled = yield* flags.isPostHogEnabled(
+          "ticketing",
+          interaction.guild.id,
+        );
+        if (!ticketingEnabled) {
+          yield* interactionReply(interaction, {
+            content:
+              "Ticketing isn't enabled on this server, so the button can't be created. Contact the Euno team to enable it.",
+            flags: MessageFlags.Ephemeral,
+          });
+          return;
+        }
+
         const pingableRole = interaction.options.getRole("role");
         const ticketChannel = interaction.options.getChannel("channel");
         const buttonText =

--- a/app/commands/setupTickets.ts
+++ b/app/commands/setupTickets.ts
@@ -30,6 +30,7 @@ import {
   type ModalCommand,
   type SlashCommand,
 } from "#~/helpers/discord";
+import { webBaseUrl } from "#~/helpers/env.server";
 import { featureStats } from "#~/helpers/metrics";
 import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
 
@@ -85,8 +86,7 @@ export const Command = [
         );
         if (!ticketingEnabled) {
           yield* interactionReply(interaction, {
-            content:
-              "Ticketing isn't enabled on this server, so the button can't be created. Contact the Euno team to enable it.",
+            content: `Ticketing isn't enabled on this server, so the button can't be created. [Upgrade your plan](${webBaseUrl}/app/${interaction.guild.id}/settings/upgrade) to enable ticketing.`,
             flags: MessageFlags.Ephemeral,
           });
           return;

--- a/app/discord/api.ts
+++ b/app/discord/api.ts
@@ -14,7 +14,11 @@ export async function userDiscordSdkFromRequest(request: Request) {
   const userToken = await retrieveDiscordToken(request);
 
   if (userToken.expired()) {
-    log("info", "api", "Discord OAuth token expired, refreshing and persisting");
+    log(
+      "info",
+      "api",
+      "Discord OAuth token expired, refreshing and persisting",
+    );
     try {
       // Persist the refreshed token to the DB session and get the new cookie.
       // We redirect back to the same URL so the next request reads the new token
@@ -37,7 +41,12 @@ export async function userDiscordSdkFromRequest(request: Request) {
               : String(refreshError),
         },
       );
-      throw redirect("/login");
+      // Preserve where the user was so login returns them there (#373).
+      const url = new URL(request.url);
+      const searchParams = new URLSearchParams([
+        ["redirectTo", `${url.pathname}${url.search}`],
+      ]);
+      throw redirect(`/login?${searchParams}`);
     }
   }
 

--- a/app/features/spam/velocityAnalyzer.test.ts
+++ b/app/features/spam/velocityAnalyzer.test.ts
@@ -16,15 +16,54 @@ const makeMessage = (
   ...overrides,
 });
 
-test("detects channel hopping (3+ channels in 60 seconds)", () => {
+test("down-weights channel hopping on distinct content (3+ channels in 60s)", () => {
+  // Distinct content across channels (no duplicate signal in the window) is
+  // common legitimate onboarding behaviour, so channel_hop_fast uses its
+  // down-weighted base — not enough on its own + tenure to clear the low tier.
   const now = Date.now();
   const messages: RecentMessage[] = [
-    makeMessage({ channelId: "ch-1", timestamp: now - 10000 }),
-    makeMessage({ channelId: "ch-2", timestamp: now - 5000 }),
-    makeMessage({ channelId: "ch-3", timestamp: now - 1000 }),
+    makeMessage({
+      channelId: "ch-1",
+      contentHash: "a",
+      timestamp: now - 10000,
+    }),
+    makeMessage({ channelId: "ch-2", contentHash: "b", timestamp: now - 5000 }),
+    makeMessage({ channelId: "ch-3", contentHash: "c", timestamp: now - 1000 }),
   ];
 
   const signals = analyzeVelocity(messages, "new content");
+  const hopSignal = signals.find((s) => s.name === "channel_hop_fast");
+  expect(hopSignal).toBeDefined();
+  expect(hopSignal!.score).toBe(2);
+});
+
+test("keeps full channel-hop weight when duplicate content co-occurs", () => {
+  // 3 channels in 60s with 2 prior duplicates of the current hash — below the
+  // cross_channel_spam combo (needs 3 dups) but clearly content-spammy, so
+  // channel_hop_fast keeps its full base.
+  const now = Date.now();
+  const hash = "dup content";
+  const messages: RecentMessage[] = [
+    makeMessage({
+      channelId: "ch-1",
+      contentHash: hash,
+      timestamp: now - 10000,
+    }),
+    makeMessage({
+      channelId: "ch-2",
+      contentHash: hash,
+      timestamp: now - 5000,
+    }),
+    makeMessage({
+      channelId: "ch-3",
+      contentHash: "other",
+      timestamp: now - 1000,
+    }),
+  ];
+
+  const signals = analyzeVelocity(messages, hash);
+  // cross_channel_spam needs 3+ duplicates; only 2 here, so it must not fire
+  expect(signals.find((s) => s.name === "cross_channel_spam")).toBeUndefined();
   const hopSignal = signals.find((s) => s.name === "channel_hop_fast");
   expect(hopSignal).toBeDefined();
   expect(hopSignal!.score).toBe(4);
@@ -273,36 +312,39 @@ describe("channel_hop_fast scaling", () => {
     );
   }
 
-  test("3 channels → base score (no bonus)", () => {
+  // These fixtures use distinct content (no duplicate signal), so they exercise
+  // the down-weighted distinctBase. Magnitude scaling is base-independent; the
+  // full-base path is covered by "keeps full channel-hop weight ..." above.
+  test("3 channels → distinct base score (no bonus)", () => {
     const signals = analyzeVelocity(makeHopMessages(3), "new content");
     const s = signals.find((x) => x.name === "channel_hop_fast");
     expect(s).toBeDefined();
-    expect(s!.score).toBe(VELOCITY_TUNING.channelHopFast.base);
+    expect(s!.score).toBe(VELOCITY_TUNING.channelHopFast.distinctBase);
   });
 
-  test("5 channels → base + 2", () => {
+  test("5 channels → distinct base + 2", () => {
     const signals = analyzeVelocity(makeHopMessages(5), "new content");
     const s = signals.find((x) => x.name === "channel_hop_fast");
     expect(s).toBeDefined();
-    expect(s!.score).toBe(VELOCITY_TUNING.channelHopFast.base + 2);
+    expect(s!.score).toBe(VELOCITY_TUNING.channelHopFast.distinctBase + 2);
   });
 
-  test("11 channels → base + 8 (bonusCap)", () => {
+  test("11 channels → distinct base + 8 (bonusCap)", () => {
     const signals = analyzeVelocity(makeHopMessages(11), "new content");
     const s = signals.find((x) => x.name === "channel_hop_fast");
     expect(s).toBeDefined();
     expect(s!.score).toBe(
-      VELOCITY_TUNING.channelHopFast.base +
+      VELOCITY_TUNING.channelHopFast.distinctBase +
         VELOCITY_TUNING.channelHopFast.bonusCap,
     );
   });
 
-  test("15 channels → capped at base + bonusCap", () => {
+  test("15 channels → capped at distinct base + bonusCap", () => {
     const signals = analyzeVelocity(makeHopMessages(15), "new content");
     const s = signals.find((x) => x.name === "channel_hop_fast");
     expect(s).toBeDefined();
     expect(s!.score).toBe(
-      VELOCITY_TUNING.channelHopFast.base +
+      VELOCITY_TUNING.channelHopFast.distinctBase +
         VELOCITY_TUNING.channelHopFast.bonusCap,
     );
   });
@@ -444,7 +486,7 @@ describe("attachment_burst signal", () => {
 });
 
 describe("scenario fixtures (velocity-only totals)", () => {
-  test("Scenario C: 15 channels/60s + 14 msgs/30s, 0 attachments → sum 20", () => {
+  test("Scenario C: 15 channels/60s + 14 msgs/30s, distinct content → sum 18 (still high)", () => {
     const now = Date.now();
     // 15 unique channels in 60s, varied content, 14 msgs in 30s
     const messages = Array.from({ length: 14 }, (_, i) =>
@@ -467,17 +509,20 @@ describe("scenario fixtures (velocity-only totals)", () => {
     const rapid = signals.find((s) => s.name === "rapid_fire");
     expect(hopFast).toBeDefined();
     expect(rapid).toBeDefined();
-    // channel_hop_fast: scaledScore(4, 15, 3, 1, 8) = 4 + min(12, 8) = 12
-    expect(hopFast!.score).toBe(12);
+    // distinct content → down-weighted base 2:
+    // channel_hop_fast: scaledScore(2, 15, 3, 1, 8) = 2 + min(12, 8) = 10
+    expect(hopFast!.score).toBe(10);
     // rapid_fire: scaledScore(3, 15, 5, 1, 5) = 3 + min(10, 5) = 8
     expect(rapid!.score).toBe(8);
     const velocitySum = signals
       .filter((s) => ["channel_hop_fast", "rapid_fire"].includes(s.name))
       .reduce((acc, s) => acc + s.score, 0);
-    expect(velocitySum).toBe(20);
+    // 18 ≥ high threshold (15): a 15-channel/14-msg flood still escalates even
+    // with distinct content, so the down-weight doesn't weaken enforcement.
+    expect(velocitySum).toBe(18);
   });
 
-  test("Scenario E: 5 channels/60s + 5 msgs/30s → velocity sum 9", () => {
+  test("Scenario E: 5 channels/60s + 5 msgs/30s, distinct content → velocity sum 7", () => {
     const now = Date.now();
     const messages = Array.from({ length: 5 }, (_, i) =>
       makeMessage({
@@ -491,13 +536,14 @@ describe("scenario fixtures (velocity-only totals)", () => {
     const rapid = signals.find((s) => s.name === "rapid_fire");
     expect(hopFast).toBeDefined();
     expect(rapid).toBeDefined();
-    // channel_hop_fast: scaledScore(4, 5, 3, 1, 8) = 4 + 2 = 6
-    expect(hopFast!.score).toBe(6);
+    // distinct content → down-weighted base 2:
+    // channel_hop_fast: scaledScore(2, 5, 3, 1, 8) = 2 + 2 = 4
+    expect(hopFast!.score).toBe(4);
     // rapid_fire: scaledScore(3, 5, 5, 1, 5) = 3 + 0 = 3
     expect(rapid!.score).toBe(3);
     const velocitySum = signals
       .filter((s) => ["channel_hop_fast", "rapid_fire"].includes(s.name))
       .reduce((acc, s) => acc + s.score, 0);
-    expect(velocitySum).toBe(9);
+    expect(velocitySum).toBe(7);
   });
 });

--- a/app/features/spam/velocityAnalyzer.ts
+++ b/app/features/spam/velocityAnalyzer.ts
@@ -11,7 +11,16 @@ const FIVE_MINUTES_MS = 5 * ONE_MINUTE_MS;
 const THIRTY_SECONDS_MS = 30 * 1000;
 
 export const VELOCITY_TUNING = {
-  channelHopFast: { base: 4, threshold: 3, perUnit: 1, bonusCap: 8 }, // range 4–12
+  // distinctBase applies when channel-hopping carries no duplicate-content
+  // signal — legitimate onboarding looks like this, so it can't clear the low
+  // tier on tenure alone. Full base applies when duplicate content co-occurs.
+  channelHopFast: {
+    base: 4,
+    distinctBase: 2,
+    threshold: 3,
+    perUnit: 1,
+    bonusCap: 8,
+  }, // range 2–12
   rapidFire: { base: 3, threshold: 5, perUnit: 1, bonusCap: 5 }, // range 3–8
   channelHopSlow: { base: 3, threshold: 5, perUnit: 1, bonusCap: 4 }, // range 3–7
   attachmentBurst: { perUnit: 1, bonusCap: 4 }, // 0–4
@@ -115,12 +124,19 @@ export function analyzeVelocity(
     return signals;
   }
 
-  // Channel-hopping: 3+ channels in 60 seconds
+  // Channel-hopping: 3+ channels in 60 seconds.
+  // Down-weight when content is distinct (no duplicate signal in the window):
+  // legitimate new members hop channels with distinct messages, and tenure +
+  // full-weight hopping alone would otherwise clear the low tier (see #369).
   if (channelsIn60s >= 3) {
+    const hopBase =
+      duplicatesIn60s >= 2
+        ? VELOCITY_TUNING.channelHopFast.base
+        : VELOCITY_TUNING.channelHopFast.distinctBase;
     signals.push({
       name: "channel_hop_fast",
       score: scaledScore(
-        VELOCITY_TUNING.channelHopFast.base,
+        hopBase,
         channelsIn60s,
         VELOCITY_TUNING.channelHopFast.threshold,
         VELOCITY_TUNING.channelHopFast.perUnit,

--- a/app/helpers/env.server.ts
+++ b/app/helpers/env.server.ts
@@ -48,6 +48,10 @@ export const stripeWebhookSecret = getEnv("STRIPE_WEBHOOK_SECRET");
 export const posthogApiKey = getEnv("POSTHOG_KEY", true);
 export const posthogHost = getEnv("POSTHOG_HOST", true);
 
-export const webBaseUrl = getEnv("WEB_BASE_URL", true);
+// Defaults to localhost on purpose: any non-local environment MUST set
+// WEB_BASE_URL, and if it forgets, links point at localhost — an obvious,
+// surfaceable bug rather than a plausible-looking wrong URL.
+export const webBaseUrl =
+  getEnv("WEB_BASE_URL", true) || "http://localhost:3000";
 
 if (!ok) throw new Error("Environment misconfigured");

--- a/app/helpers/request.server.ts
+++ b/app/helpers/request.server.ts
@@ -1,0 +1,13 @@
+/**
+ * Build the public origin (`scheme://host`) for an incoming request, honoring
+ * the reverse-proxy forwarded headers. Behind a load balancer `url.host` is the
+ * pod's internal address, so any externally-visible URL (OAuth redirect_uri,
+ * Stripe return URLs, links emitted to users) must prefer `X-Forwarded-*`.
+ */
+export function requestOrigin(request: Request): string {
+  const url = new URL(request.url);
+  const proto =
+    request.headers.get("X-Forwarded-Proto") ?? url.protocol.replace(":", "");
+  const host = request.headers.get("X-Forwarded-Host") ?? url.host;
+  return `${proto}://${host}`;
+}

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -11,7 +11,7 @@ import {
   type RESTPostAPIGuildChannelJSONBody,
 } from "discord-api-types/v10";
 
-import { db, run, runTakeFirst } from "#~/AppRuntime";
+import { db, isFeatureEnabled, run, runTakeFirst } from "#~/AppRuntime";
 import { DEFAULT_MESSAGE_TEXT } from "#~/commands/setupHoneypot";
 import { DEFAULT_BUTTON_TEXT } from "#~/commands/setupTickets";
 import { ssrDiscordSdk } from "#~/discord/api";
@@ -365,8 +365,20 @@ export async function setupAll(
   }
 
   // --- Ticket channel (optional) ---
+  // Gate at setup, not at button-press: provisioning a ticket button while the
+  // `ticketing` flag is off gives a false success here and fails for the end
+  // user who later clicks it (#370). Skip the whole section when disabled.
   let ticketChannelId: string | undefined;
-  if (ticketChannel === CREATE_SENTINEL) {
+  const ticketRequested = ticketChannel !== undefined;
+  const ticketingEnabled = ticketRequested
+    ? await isFeatureEnabled("ticketing", guildId)
+    : false;
+
+  if (ticketRequested && !ticketingEnabled) {
+    log("warn", "setupAll", "Skipped ticket setup: ticketing flag disabled", {
+      guildId,
+    });
+  } else if (ticketChannel === CREATE_SENTINEL) {
     const ch = await createGuildChannel(guildId, {
       name: "contact-mods",
       type: ChannelType.GuildText,

--- a/app/models/session.server.ts
+++ b/app/models/session.server.ts
@@ -169,11 +169,15 @@ export async function getUser(request: Request) {
 
 export async function requireUserId(
   request: Request,
-  redirectTo: string = new URL(request.url).pathname,
+  redirectTo?: string,
 ): Promise<string> {
   const userId = await getUserId(request);
   if (!userId) {
-    const searchParams = new URLSearchParams([["redirectTo", redirectTo]]);
+    // Capture the full path (incl. query) so login returns the user exactly
+    // where they were, not just the bare pathname (#373).
+    const url = new URL(request.url);
+    const target = redirectTo ?? `${url.pathname}${url.search}`;
+    const searchParams = new URLSearchParams([["redirectTo", target]]);
     throw redirect(`/login?${searchParams}`);
   }
   return userId;

--- a/app/models/session.server.ts
+++ b/app/models/session.server.ts
@@ -16,6 +16,7 @@ import {
   isProd,
   sessionSecret,
 } from "#~/helpers/env.server";
+import { requestOrigin } from "#~/helpers/request.server";
 import { fetchUser } from "#~/models/discord.server";
 import { SubscriptionService } from "#~/models/subscriptions.server";
 import {
@@ -205,11 +206,7 @@ export async function initOauthLogin({
   flow?: "user" | "signup" | "add-bot";
   guildId?: string;
 }) {
-  const url = new URL(request.url);
-  const proto =
-    request.headers.get("X-Forwarded-Proto") ?? url.protocol.replace(":", "");
-  const host = request.headers.get("X-Forwarded-Host") ?? url.host;
-  const origin = `${proto}://${host}`;
+  const origin = requestOrigin(request);
   const cookieSession = await getCookieSession(request.headers.get("Cookie"));
 
   const state = JSON.stringify({
@@ -263,10 +260,7 @@ export async function completeOauthLogin(request: Request) {
     throw redirect("/login", 500);
   }
 
-  const proto =
-    request.headers.get("X-Forwarded-Proto") ?? url.protocol.replace(":", "");
-  const host = request.headers.get("X-Forwarded-Host") ?? url.host;
-  const origin = `${proto}://${host}`;
+  const origin = requestOrigin(request);
   const reqCookie: string = cookie;
   const state: string | undefined = url.searchParams.get("state") ?? undefined;
 

--- a/app/routes/__auth.tsx
+++ b/app/routes/__auth.tsx
@@ -1,4 +1,9 @@
-import { Outlet, useLoaderData, useLocation } from "react-router";
+import {
+  Outlet,
+  useLoaderData,
+  useLocation,
+  useSearchParams,
+} from "react-router";
 
 import { Login } from "#~/basics/login";
 import { DiscordLayout } from "#~/components/DiscordLayout";
@@ -51,13 +56,19 @@ export async function loader({ request }: Route.LoaderArgs) {
 export default function Auth() {
   const user = useOptionalUser();
   const { pathname, search, hash } = useLocation();
+  const [searchParams] = useSearchParams();
   const { guilds, manageableGuilds } = useLoaderData();
 
   if (!user) {
+    // When `requireUser` bounces here it sets `?redirectTo=<original path>`.
+    // Prefer that over the current location, which is `/login?redirectTo=…`
+    // and would otherwise strand the user on /login after OAuth (#373).
+    const redirectTo =
+      searchParams.get("redirectTo") ?? `${pathname}${search}${hash}`;
     return (
       <div className="flex min-h-full flex-col justify-center">
         <div className="mx-auto w-full max-w-md px-8">
-          <Login redirectTo={`${pathname}${search}${hash}`} />
+          <Login redirectTo={redirectTo} />
         </div>
       </div>
     );

--- a/app/routes/__auth/upgrade.tsx
+++ b/app/routes/__auth/upgrade.tsx
@@ -8,6 +8,7 @@ import {
 } from "react-router";
 
 import { log } from "#~/helpers/observability";
+import { requestOrigin } from "#~/helpers/request.server";
 import { requireUser } from "#~/models/session.server";
 import { StripeService } from "#~/models/stripe.server";
 import {
@@ -105,9 +106,9 @@ export async function action({ request }: Route.ActionArgs) {
     });
 
     try {
-      // Get base URL from request
-      const url = new URL(request.url);
-      const baseUrl = `${url.protocol}//${url.host}`;
+      // Honor reverse-proxy forwarded headers so Stripe return URLs point at
+      // the public origin, not the pod's internal host.
+      const baseUrl = requestOrigin(request);
 
       // Create Stripe checkout session
       const checkoutUrl = await StripeService.createCheckoutSession(

--- a/app/routes/__auth/upgrade.tsx
+++ b/app/routes/__auth/upgrade.tsx
@@ -317,7 +317,7 @@ export default function Upgrade({ actionData }: Route.ComponentProps) {
             </div>
           ) : (
             <a
-              href="mailto:support@euno.reactiflux.com?subject=Custom%20Euno%20Plan"
+              href="mailto:hello+eunosales@reactiflux.com?subject=Custom%20Euno%20Plan"
               className="inline-block rounded-md border border-stone-600 bg-transparent px-6 py-2 text-lg font-medium text-stone-200 shadow-sm hover:bg-stone-800 focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-none"
             >
               Contact Sales

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "lru-cache": "^11.1.0",
         "markdown-it": "^14.2.0",
         "node-cron": "^3.0.0",
+        "node-emoji": "^2.2.0",
         "node-fetch": "^3.3.2",
         "pino-http": "^10.4.0",
         "posthog-js": "^1.280.1",
@@ -3338,6 +3339,18 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -5098,6 +5111,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -5960,6 +5982,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -9440,6 +9468,21 @@
         "node": ">=10.5.0"
       }
     },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -11814,6 +11857,18 @@
         "node": "*"
       }
     },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
@@ -12691,6 +12746,15 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "lru-cache": "^11.1.0",
     "markdown-it": "^14.2.0",
     "node-cron": "^3.0.0",
+    "node-emoji": "^2.2.0",
     "node-fetch": "^3.3.2",
     "pino-http": "^10.4.0",
     "posthog-js": "^1.280.1",


### PR DESCRIPTION
Batched fixes for five bugs surfaced during rc/v2026.22 release QA. Each is independently scoped; one PR for review economy.

Closes #369. Closes #370. Closes #371. Closes #372. Closes #373.

## Changes

**#369 — spam: distinct-content channel-hopping no longer clears the low tier on tenure alone**
`channel_hop_fast` base is now conditional: full `4` when duplicate content co-occurs in the 60s window, down-weighted `2` when content is distinct. A new member posting distinct messages across 3 channels (tenure +2, hop +2 = 4) now stays below the low tier (6) — no report-row noise — while throwaway-account or duplicate-content floods still escalate (a 15-channel/14-msg flood still totals 18 → high). Magnitude scaling and the `cross_channel_spam` combo are unchanged.

**#370 — tickets: flag barrier moved from button-press to setup time (both paths)**
- Slash `tickets-channel` handler checks `ticketing` up front and returns an ephemeral feature-disabled reply instead of provisioning a dead button.
- `setupAll` skips the whole ticket section (channel + button + config) when the flag is off and logs it, so the result shows "Tickets: Disabled" rather than a false success.
- The `open-ticket` handler keeps its check as defense-in-depth.

**#371 — reactji: validate/resolve emoji at setup**
New pure `resolveReactjiEmoji` resolver: custom-emoji mention → verbatim; bare name → guild-emoji lookup; literal unicode (incl. skin tones) → accept; standard shortcode → node-emoji, with a small Discord-alias fallback for `thumbsup`/`thumbsdown` (node-emoji's dataset maps those glyphs to `+1`/`-1` only); anything unresolvable → ephemeral reject. No more silently-dead configs. Adds `node-emoji` dependency.

**#372 — upgrade: Contact Sales email**
`mailto:` now points at `hello+eunosales@reactiflux.com`.

**#373 — auth: return the user to their originating page after login**
Root cause: `/login` renders under the `__auth` layout, so the component captured `useLocation()` (`/login?redirectTo=…`) and passed that whole string as `redirectTo`, stranding the user on `/login` after OAuth.
- `__auth.tsx` now prefers the `?redirectTo=` param set by `requireUser`.
- `requireUserId` captures `pathname + search` (was pathname only).
- The token-refresh-failure path threads `redirectTo` through too.

## Testing
- `npm test` — 395 passing (new: 15 reactji-resolver tests; updated velocity scaling/scenario fixtures + 2 new channel-hop cases).
- `npm run typecheck` — clean.
- `npm run lint` — clean.

**Not exercised live from this branch:** #370's flag gate (needs a guild with `ticketing` toggled) and #373's OAuth round-trip — worth a QA pass before/with merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
