### PR TITLE
Decision-oriented typed error system for Discord operations

### DIFF
--- a/.claude/skills/qa-session/checklists/error-handling.md
+++ b/.claude/skills/qa-session/checklists/error-handling.md
@@ -1,0 +1,121 @@
+# Error-handling system (typed DiscordError taxonomy)
+
+Grounding:
+- `toUserResponse`: `app/effects/errorHandling.ts` (maps each `AppError` tag → safe user copy)
+- Error taxonomy: `app/effects/errors.ts`
+- Classifier boundary: `app/effects/classifyDiscordError.ts` (`tryDiscord` / `classifyDiscordError`)
+- Logger / serializer: `app/effects/logger.ts`, `app/effects/observability.ts` (`errorReplacer`), `app/helpers/formatError.ts`
+
+**Log shape** (what to grep). A typed error passed as an annotation via `logEffect("error", …, { error })`
+serializes to structured JSON — NOT a stringified blob:
+
+```json
+{
+  "message": ["<log message>"],
+  "logLevel": "ERROR",
+  "annotations": {
+    "service": "<ServiceName>",
+    "error": {
+      "_tag": "ForbiddenError",
+      "source": "discord",
+      "operation": "<op>",
+      "cause": { "name": "DiscordAPIError[50013]", "message": "Missing Permissions", "stack": "…" }
+    }
+  }
+}
+```
+
+Proof points for every error check:
+- `annotations.error._tag` is the correct tag string (NOT `"[object Object]"`, NOT absent)
+- `annotations.error.cause.name`/`.message` carry the real Discord error (cause is serialized, not dropped)
+- the tag matches the HTTP reality (403→ForbiddenError, 404→ResourceMissingError, 5xx/network→TransientError, 429→RateLimitError)
+
+> **⚠️ Gotcha to probe (regression watch).** The classifier must recognize the Discord error
+> object the **discord.js** code path actually throws. discord.js (CJS) and `@discordjs/rest` (ESM)
+> resolve to *different class identities*, so an `instanceof @discordjs/rest.DiscordAPIError` check
+> silently misses every real error and drops it to the `TransientError` default — which mocked unit
+> tests do NOT catch (they construct matching objects). The classifier therefore detects errors
+> **structurally** (numeric `status` + Discord `code` + `rawError`). If anyone reintroduces an
+> `instanceof`-based check or bumps discord.js/@discordjs/rest, re-run A1 live: a real 403 must tag
+> `ForbiddenError`, not `TransientError`. (This bug was live as of the first QA pass; see run log
+> 2026-06-20.)
+
+---
+
+## Batch A — ForbiddenError end-to-end (force-ban, role hierarchy)
+
+Grounding: `app/commands/force-ban.ts` wraps the ban in `tryDiscord("forceBan", …)`; a 403 →
+`ForbiddenError` → `toUserResponse` permission copy. ForbiddenError copy is **operation-agnostic**
+(same message for every operation — see errorHandling.ts).
+
+### A1 force-ban 403 → structured ForbiddenError + permission copy
+do:    Force Ban (user context-menu) a member whose highest role is **above** the bot's role.
+prove: local → log `"Force ban failed"` (service `Commands`) with `annotations.error._tag === "ForbiddenError"`, `operation === "forceBan"`, and a serialized `cause.name === "DiscordAPIError[50013]"`. Discord: ephemeral reply contains the permission guidance ("/check-requirements" + "roles list"). NO `[object Object]` / `"TransientError"` in the log.
+       uat   → same log shape + ephemeral copy to the invoking mod.
+pass:  structured `_tag:"ForbiddenError"`; user sees the permission/role-hierarchy guidance; nothing stringified.
+
+---
+
+## Batch B — ForbiddenError via escalate→ban (handler routing)
+
+Grounding: `app/commands/escalate/directActions.ts` uses `tryDiscord("ban", …)`; handler
+`app/commands/escalate/handlers.ts` routes the caught error through `toUserResponse`. The direct
+moderator-control buttons (Ban/Kick/Delete/etc.) are **NOT** feature-flag gated — only the vote-based
+"Escalate" button is. So no flag flip is needed to reach Ban/Kick.
+
+### B1 escalate→ban 403 → structured ForbiddenError + permission copy
+do:    Report/Track a member whose role outranks the bot (right-click message → Apps → Report/Track → a moderator-controls thread appears with action buttons), then click **Ban**.
+prove: local → log `"Error banning user"` (service `EscalationHandlers`) with `error._tag === "ForbiddenError"`, `operation === "ban"`, real `cause` from `GuildBanManager`. Ephemeral reply = the unified permission copy (NOT a bare "Failed to ban user" with no guidance).
+       uat   → same.
+pass:  structured ForbiddenError, typed error routed through toUserResponse (not a hand-written generic string).
+
+---
+
+## Batch C — ForbiddenError via escalate→kick
+
+Grounding: `directActions.ts` `tryDiscord("kick", …)`; handler `handlers.ts` routes through
+`toUserResponse`. **Post-collapse, kick shows the SAME unified permission message as ban** (copy is
+operation-agnostic) — the proof here is the classification + routing, not a distinct message.
+
+### C1 escalate→kick 403 → structured ForbiddenError
+do:    In the moderator-controls thread for a member who outranks the bot, click **Kick**.
+prove: local → log `"Error kicking user"` (service `EscalationHandlers`) with `error._tag === "ForbiddenError"`, `operation === "kick"`, real `cause` from `GuildMemberManager.kick`. Ephemeral reply = the same unified permission copy as B1.
+       uat   → same.
+pass:  structured ForbiddenError; typed error routed through toUserResponse.
+
+---
+
+## Batch D — membership-gate inline messages (preserved copy)
+
+Grounding: `app/commands/memberApplications.ts` `activate-gate` handler. NOTE: this handler is **not**
+feature-flag gated (see issue Euno-HQ/discord#379 — only `apply-to-join` checks the flag). The button
+is posted by the gate setup flow; clicking the idempotency/"already active" path uses `interactionUpdate`,
+which **replaces the message and consumes the button**.
+
+### D1 gate already-active → inline "already activated"
+do:    With the gate already active (@everyone has View Channel denied at the role level), click **Activate Membership Gate**.
+prove: local → NO error log; the message updates in place to a green container reading "Membership gate is active / The membership gate was already activated"; no activation effect / no channel-reveal runs (idempotency short-circuit).
+       uat   → same in-place update, no error log.
+pass:  "already activated" message; no mutation; no error surfaced.
+
+### D2 gate activation failure → "button is still active" (NOT YET RUN live)
+do:    Re-post a fresh activate-gate button; set @everyone View Channel **on** (gate inactive); revoke the **bot's Manage Roles**; click **Activate Membership Gate**.
+prove: local → log `"Failed to activate gate"` (service `MembershipGate`) with a structured typed `error`; ephemeral reply "Gate activation failed. The button is still active — you can try again."; the button remains.
+       uat   → same.
+pass:  structured error log; verbatim "button is still active" copy; button not removed.
+restore: re-grant the bot Manage Roles.
+
+---
+
+## Batch E — ResourceMissing recovery (already-deleted message)
+
+Grounding: `app/models/reportedMessages.ts` `deleteSingleMessage` — `tryDiscord("deleteReportedMessage", …)`
++ `catchTag("ResourceMissingError", …)`. A 404 is recovered as already-gone; the row is marked
+`deleted_at`. (This is the other branch the classifier bug had broken — a 404 used to wrongly become a
+TransientError failure.)
+
+### E1 already-deleted message → silent recovery
+do:    Delete (in Discord) a message that's still tracked in `reported_messages` (deleted_at IS NULL), then click **Delete Messages** in that user's moderator-controls thread.
+prove: local → log `"Message already deleted"` (service `ReportedMessage`, level DEBUG) for the gone message; NO `"Error deleting messages"` / no user-facing error; DB row's `deleted_at` is set (`SELECT deleted_at FROM reported_messages WHERE reported_message_id='<id>'`).
+       uat   → debug log; no error; row marked deleted.
+pass:  404 → ResourceMissing silently recovered; `deleted_at` stamped; no user error.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,19 @@ directory.
   should target the `rc/v*` branch.
 - Production deploys happen only when a GitHub Release is published, not on every
   push to main.
+
+## Linting
+
+- **Zero-warnings policy (intentional):** `npm run lint` runs ESLint with
+  `--max-warnings=0`, so CI fails on *any* warning, not just errors. Keep the repo
+  at zero lint warnings. Some conventions we want CI to enforce are authored as
+  `warn`-level rules (e.g. `local/no-error-string-cast`); `--max-warnings=0` is
+  what gives them teeth. If you add a rule and don't want it to gate CI, that's a
+  deliberate exception worth calling out — the default is that warnings block.
+- Custom lint rules live in `eslint-rules/` (plain-JS ESLint rule modules with
+  `RuleTester` tests run by vitest) and are registered under the `local/` plugin
+  namespace in `eslint.config.js`.
+- `local/no-error-string-cast`: never stringify typed Effect errors
+  (`String(error)`, `${error}`) — pass the tagged error through to `logEffect`,
+  which serializes `_tag`/cause/fields. For the rare site that genuinely needs a
+  string, use `formatError()` from `app/helpers/formatError.ts`.

--- a/app/AppRuntime.ts
+++ b/app/AppRuntime.ts
@@ -10,6 +10,7 @@ import {
   FeatureFlagServiceLive,
   type BooleanFlag,
 } from "#~/effects/featureFlags";
+import { JsonLoggerLayer } from "#~/effects/logger";
 import { PostHogService, PostHogServiceLive } from "#~/effects/posthog";
 import { SupervisorServiceLive } from "#~/effects/supervisor";
 import { TracingLive } from "#~/effects/tracing.js";
@@ -19,7 +20,7 @@ import { isProd } from "#~/helpers/env.server.js";
 // Infrastructure layer: tracing + structured logging + prod log level
 const InfraLayer = Layer.mergeAll(
   TracingLive,
-  Logger.json,
+  JsonLoggerLayer,
   isProd()
     ? Logger.minimumLogLevel(LogLevel.Info)
     : Logger.minimumLogLevel(LogLevel.All),

--- a/app/Database.ts
+++ b/app/Database.ts
@@ -10,6 +10,7 @@ import type { DB } from "./db";
 import { DatabaseCorruptionError } from "./effects/errors";
 import { logEffect } from "./effects/observability";
 import { databaseUrl, emergencyWebhook } from "./helpers/env.server";
+import { formatError } from "./helpers/formatError";
 import { log } from "./helpers/observability";
 
 // Re-export SQL errors and DB type for consumers
@@ -64,7 +65,7 @@ const sendWebhookAlert = (message: string) =>
     Effect.tapError((e) =>
       Effect.sync(() =>
         log("error", "IntegrityCheck", "Failed to send webhook alert", {
-          error: String(e),
+          error: e,
         }),
       ),
     ),
@@ -101,7 +102,7 @@ export const runIntegrityCheck = Effect.gen(function* () {
         error,
       }),
       sendWebhookAlert(
-        `🚨 **Database Integrity Check Failed**\n\`\`\`\n${error.message}\n${String(error.cause)}\n${error.stack}\n\`\`\``,
+        `🚨 **Database Integrity Check Failed**\n\`\`\`\n${error.message}\n${formatError(error.cause)}\n${error.stack}\n\`\`\``,
       ),
     ]),
   ),

--- a/app/commands/checkRequirements.ts
+++ b/app/commands/checkRequirements.ts
@@ -20,6 +20,7 @@ import {
   REQUIRED_PERMISSIONS,
 } from "#~/helpers/botPermissions";
 import type { SlashCommand } from "#~/helpers/discord";
+import { formatError } from "#~/helpers/formatError";
 import { commandStats } from "#~/helpers/metrics";
 import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
 
@@ -494,8 +495,6 @@ export const Command = {
     }).pipe(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
-          const err = error instanceof Error ? error : new Error(String(error));
-
           yield* logEffect(
             "error",
             "Commands",
@@ -503,18 +502,19 @@ export const Command = {
             {
               guildId: interaction.guildId,
               userId: interaction.user.id,
-              error: err,
+              error,
             },
           );
 
           commandStats.commandFailed(
             interaction,
             "check-requirements",
-            err.message,
+            formatError(error),
           );
 
           yield* interactionEditReply(interaction, {
-            content: `Something broke:\n\`\`\`\n${err.toString()}\n\`\`\``,
+            content:
+              "Something broke while checking requirements. Please try again.",
           }).pipe(Effect.catchAll(() => Effect.void));
         }),
       ),

--- a/app/commands/checkRequirements.ts
+++ b/app/commands/checkRequirements.ts
@@ -13,7 +13,9 @@ import {
   fetchChannel,
   interactionDeferReply,
   interactionEditReply,
+  interactionReply,
 } from "#~/effects/discordSdk.ts";
+import { toUserResponse } from "#~/effects/errorHandling";
 import { logEffect } from "#~/effects/observability.ts";
 import {
   OPTIONAL_PERMISSIONS,
@@ -111,7 +113,10 @@ export const Command = {
   handler: (interaction) =>
     Effect.gen(function* () {
       if (!interaction.guild || !interaction.guildId) {
-        yield* Effect.fail(new Error("This command must be used in a server."));
+        yield* interactionReply(interaction, {
+          content: "This command can only be used in a server.",
+          flags: MessageFlags.Ephemeral,
+        });
         return;
       }
 
@@ -512,9 +517,9 @@ export const Command = {
             formatError(error),
           );
 
+          const reply = toUserResponse(error);
           yield* interactionEditReply(interaction, {
-            content:
-              "Something broke while checking requirements. Please try again.",
+            content: reply.content,
           }).pipe(Effect.catchAll(() => Effect.void));
         }),
       ),

--- a/app/commands/escalate/directActions.ts
+++ b/app/commands/escalate/directActions.ts
@@ -4,8 +4,9 @@ import {
 } from "discord.js";
 import { Effect } from "effect";
 
+import { tryDiscord } from "#~/effects/classifyDiscordError";
 import { fetchMember } from "#~/effects/discordSdk";
-import { DiscordApiError, NotAuthorizedError } from "#~/effects/errors";
+import { NotAuthorizedError } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import { hasModRole } from "#~/helpers/discord";
 import { applyRestriction, ban, kick, timeout } from "#~/models/discord.server";
@@ -98,11 +99,9 @@ export const kickUser = (interaction: MessageComponentInteraction) =>
     );
 
     // Execute kick
-    yield* Effect.tryPromise({
-      try: () => kick(reportedMember, "single moderator decision"),
-      catch: (error) =>
-        new DiscordApiError({ operation: "kick", cause: error }),
-    });
+    yield* tryDiscord("kick", () =>
+      kick(reportedMember, "single moderator decision"),
+    );
 
     yield* logEffect("info", "DirectActions", "Kicked user", {
       reportedUserId,
@@ -151,10 +150,9 @@ export const banUser = (interaction: MessageComponentInteraction) =>
     );
 
     // Execute ban
-    yield* Effect.tryPromise({
-      try: () => ban(reportedMember, "single moderator decision"),
-      catch: (error) => new DiscordApiError({ operation: "ban", cause: error }),
-    });
+    yield* tryDiscord("ban", () =>
+      ban(reportedMember, "single moderator decision"),
+    );
 
     yield* logEffect("info", "DirectActions", "Banned user", {
       reportedUserId,
@@ -207,15 +205,9 @@ export const banUserAndDeleteMessages = (
     );
 
     // Execute ban with message deletion
-    yield* Effect.tryPromise({
-      try: () =>
-        ban(
-          reportedMember,
-          "single moderator decision",
-          DELETE_MESSAGE_SECONDS,
-        ),
-      catch: (error) => new DiscordApiError({ operation: "ban", cause: error }),
-    }).pipe(
+    yield* tryDiscord("ban", () =>
+      ban(reportedMember, "single moderator decision", DELETE_MESSAGE_SECONDS),
+    ).pipe(
       Effect.withSpan("discord.ban", {
         attributes: {
           userId: reportedUserId,
@@ -277,14 +269,9 @@ export const restrictUser = (interaction: MessageComponentInteraction) =>
     );
 
     // Execute restriction
-    yield* Effect.tryPromise({
-      try: () => applyRestriction(reportedMember),
-      catch: (error) =>
-        new DiscordApiError({
-          operation: "applyRestriction",
-          cause: error,
-        }),
-    });
+    yield* tryDiscord("applyRestriction", () =>
+      applyRestriction(reportedMember),
+    );
 
     yield* logEffect("info", "DirectActions", "Restricted user", {
       reportedUserId,
@@ -333,11 +320,9 @@ export const timeoutUser = (interaction: MessageComponentInteraction) =>
     );
 
     // Execute timeout
-    yield* Effect.tryPromise({
-      try: () => timeout(reportedMember, "single moderator decision"),
-      catch: (error) =>
-        new DiscordApiError({ operation: "timeout", cause: error }),
-    });
+    yield* tryDiscord("timeout", () =>
+      timeout(reportedMember, "single moderator decision"),
+    );
 
     yield* logEffect("info", "DirectActions", "Timed out user", {
       reportedUserId,

--- a/app/commands/escalate/escalate.ts
+++ b/app/commands/escalate/escalate.ts
@@ -13,7 +13,7 @@ import {
   fetchMessage,
   sendMessage,
 } from "#~/effects/discordSdk";
-import { DiscordApiError } from "#~/effects/errors";
+import { TransientError } from "#~/effects/errors";
 import { FeatureFlagService, guardFeature } from "#~/effects/featureFlags";
 import { logEffect } from "#~/effects/observability";
 import { calculateScheduledFor } from "#~/helpers/escalationVotes";
@@ -69,7 +69,8 @@ export const createEscalationEffect = (
 
     if (!channel || !("send" in channel)) {
       return yield* Effect.fail(
-        new DiscordApiError({
+        new TransientError({
+          source: "discord",
           operation: "validateChannel",
           cause: new Error("Invalid channel - cannot send messages"),
         }),

--- a/app/commands/escalate/handlers.ts
+++ b/app/commands/escalate/handlers.ts
@@ -16,6 +16,7 @@ import {
   interactionReply,
   interactionUpdate,
 } from "#~/effects/discordSdk.ts";
+import { toUserResponse } from "#~/effects/errorHandling";
 import { logEffect } from "#~/effects/observability.ts";
 import { webBaseUrl } from "#~/helpers/env.server";
 import {
@@ -277,9 +278,12 @@ export const EscalationHandlers = {
           error,
         }).pipe(
           Effect.zipRight(
-            interactionEditReply(interaction, {
-              content: "Failed to delete messages",
-            }).pipe(Effect.catchAll(() => Effect.void)),
+            Effect.suspend(() => {
+              const reply = toUserResponse(error);
+              return interactionEditReply(interaction, {
+                content: reply.content,
+              }).pipe(Effect.catchAll(() => Effect.void));
+            }),
           ),
         ),
       ),
@@ -305,10 +309,13 @@ export const EscalationHandlers = {
           error,
         }).pipe(
           Effect.zipRight(
-            interactionReply(interaction, {
-              content: "Failed to kick user",
-              flags: [MessageFlags.Ephemeral],
-            }).pipe(Effect.catchAll(() => Effect.void)),
+            Effect.suspend(() => {
+              const reply = toUserResponse(error);
+              return interactionReply(interaction, {
+                content: reply.content,
+                flags: reply.ephemeral ? [MessageFlags.Ephemeral] : undefined,
+              }).pipe(Effect.catchAll(() => Effect.void));
+            }),
           ),
         ),
       ),
@@ -347,10 +354,13 @@ export const EscalationHandlers = {
           error,
         }).pipe(
           Effect.zipRight(
-            interactionReply(interaction, {
-              content: "Failed to ban user",
-              flags: [MessageFlags.Ephemeral],
-            }).pipe(Effect.catchAll(() => Effect.void)),
+            Effect.suspend(() => {
+              const reply = toUserResponse(error);
+              return interactionReply(interaction, {
+                content: reply.content,
+                flags: reply.ephemeral ? [MessageFlags.Ephemeral] : undefined,
+              }).pipe(Effect.catchAll(() => Effect.void));
+            }),
           ),
         ),
       ),
@@ -386,10 +396,13 @@ export const EscalationHandlers = {
           { error },
         ).pipe(
           Effect.zipRight(
-            interactionReply(interaction, {
-              content: "Failed to ban user and delete messages",
-              flags: [MessageFlags.Ephemeral],
-            }).pipe(Effect.catchAll(() => Effect.void)),
+            Effect.suspend(() => {
+              const reply = toUserResponse(error);
+              return interactionReply(interaction, {
+                content: reply.content,
+                flags: reply.ephemeral ? [MessageFlags.Ephemeral] : undefined,
+              }).pipe(Effect.catchAll(() => Effect.void));
+            }),
           ),
         ),
       ),
@@ -422,10 +435,13 @@ export const EscalationHandlers = {
           error,
         }).pipe(
           Effect.zipRight(
-            interactionReply(interaction, {
-              content: "Failed to restrict user",
-              flags: [MessageFlags.Ephemeral],
-            }).pipe(Effect.catchAll(() => Effect.void)),
+            Effect.suspend(() => {
+              const reply = toUserResponse(error);
+              return interactionReply(interaction, {
+                content: reply.content,
+                flags: reply.ephemeral ? [MessageFlags.Ephemeral] : undefined,
+              }).pipe(Effect.catchAll(() => Effect.void));
+            }),
           ),
         ),
       ),
@@ -458,10 +474,13 @@ export const EscalationHandlers = {
           error,
         }).pipe(
           Effect.zipRight(
-            interactionReply(interaction, {
-              content: "Failed to timeout user",
-              flags: [MessageFlags.Ephemeral],
-            }).pipe(Effect.catchAll(() => Effect.void)),
+            Effect.suspend(() => {
+              const reply = toUserResponse(error);
+              return interactionReply(interaction, {
+                content: reply.content,
+                flags: reply.ephemeral ? [MessageFlags.Ephemeral] : undefined,
+              }).pipe(Effect.catchAll(() => Effect.void));
+            }),
           ),
         ),
       ),

--- a/app/commands/escalate/service.ts
+++ b/app/commands/escalate/service.ts
@@ -12,6 +12,7 @@ import {
 } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import { calculateScheduledFor } from "#~/helpers/escalationVotes";
+import { formatError } from "#~/helpers/formatError";
 import type { Resolution, VotingStrategy } from "#~/helpers/modResponse";
 import { applyRestriction, ban, kick, timeout } from "#~/models/discord.server";
 
@@ -352,11 +353,14 @@ export const EscalationServiceLive = Layer.effect(
                   break;
               }
             },
-            catch: (error) =>
+            catch: (caught) =>
               new ResolutionExecutionError({
                 escalationId: escalation.id,
                 resolution,
-                cause: error,
+                cause:
+                  caught instanceof Error
+                    ? caught
+                    : new Error(formatError(caught)),
               }),
           });
 

--- a/app/commands/force-ban.ts
+++ b/app/commands/force-ban.ts
@@ -7,6 +7,7 @@ import {
 import { Effect } from "effect";
 
 import { interactionReply } from "#~/effects/discordSdk.ts";
+import { toUserResponse } from "#~/effects/errorHandling";
 import { logEffect } from "#~/effects/observability.ts";
 import type { UserContextCommand } from "#~/helpers/discord";
 import { formatError } from "#~/helpers/formatError";
@@ -86,10 +87,10 @@ export const Command = {
             formatError(error),
           );
 
+          const reply = toUserResponse(error);
           yield* interactionReply(interaction, {
-            flags: [MessageFlags.Ephemeral],
-            content:
-              "Failed to ban user, try checking the bot's permissions. If they look okay, make sure that the bot's role is near the top of the roles list — bots can't ban users with roles above their own.",
+            content: reply.content,
+            flags: reply.ephemeral ? MessageFlags.Ephemeral : undefined,
           }).pipe(Effect.catchAll(() => Effect.void));
         }),
       ),

--- a/app/commands/force-ban.ts
+++ b/app/commands/force-ban.ts
@@ -9,6 +9,7 @@ import { Effect } from "effect";
 import { interactionReply } from "#~/effects/discordSdk.ts";
 import { logEffect } from "#~/effects/observability.ts";
 import type { UserContextCommand } from "#~/helpers/discord";
+import { formatError } from "#~/helpers/formatError";
 import { commandStats } from "#~/helpers/metrics";
 
 export const Command = {
@@ -71,18 +72,19 @@ export const Command = {
     }).pipe(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
-          const err = error instanceof Error ? error : new Error(String(error));
-
           yield* logEffect("error", "Commands", "Force ban failed", {
             guildId: interaction.guildId,
             moderatorUserId: interaction.user.id,
             targetUserId: interaction.targetUser.id,
             targetUsername: interaction.targetUser.username,
-            error: err.message,
-            stack: err.stack,
+            error,
           });
 
-          commandStats.commandFailed(interaction, "force-ban", err.message);
+          commandStats.commandFailed(
+            interaction,
+            "force-ban",
+            formatError(error),
+          );
 
           yield* interactionReply(interaction, {
             flags: [MessageFlags.Ephemeral],

--- a/app/commands/force-ban.ts
+++ b/app/commands/force-ban.ts
@@ -6,6 +6,7 @@ import {
 } from "discord.js";
 import { Effect } from "effect";
 
+import { tryDiscord } from "#~/effects/classifyDiscordError";
 import { interactionReply } from "#~/effects/discordSdk.ts";
 import { toUserResponse } from "#~/effects/errorHandling";
 import { logEffect } from "#~/effects/observability.ts";
@@ -50,7 +51,7 @@ export const Command = {
         return;
       }
 
-      yield* Effect.tryPromise(() =>
+      yield* tryDiscord("forceBan", () =>
         guild.bans.create(targetUser, {
           reason: "Force banned by staff",
         }),

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -19,12 +19,12 @@ import { Effect } from "effect";
 
 import { DatabaseService } from "#~/Database.ts";
 import { ssrDiscordSdk as rest } from "#~/discord/api";
+import { tryDiscord } from "#~/effects/classifyDiscordError";
 import {
   fetchChannel,
   interactionReply,
   interactionUpdate,
 } from "#~/effects/discordSdk.ts";
-import { DiscordApiError } from "#~/effects/errors.ts";
 import { FeatureFlagService } from "#~/effects/featureFlags";
 import { logEffect } from "#~/effects/observability.ts";
 import {
@@ -881,11 +881,9 @@ export const Command = [
         }
 
         // Fetch current role permissions from Discord API
-        const roles = (yield* Effect.tryPromise({
-          try: () => rest.get(Routes.guildRoles(guildId)),
-          catch: (error) =>
-            new DiscordApiError({ operation: "fetchGuildRoles", cause: error }),
-        })) as APIRole[];
+        const roles = (yield* tryDiscord("fetchGuildRoles", () =>
+          rest.get(Routes.guildRoles(guildId)),
+        )) as APIRole[];
 
         const everyoneRole = roles.find((r) => r.id === guildId);
         const memberRole = roles.find((r) => r.id === config.role_id);
@@ -929,28 +927,22 @@ export const Command = [
         });
 
         // Reveal #apply-here to @everyone now that the gate is active
-        yield* Effect.tryPromise({
-          try: () =>
-            rest.put(Routes.channelPermission(config.channel_id, guildId), {
-              body: {
-                type: OverwriteType.Role,
-                allow: String(
-                  PermissionFlagsBits.ViewChannel |
-                    PermissionFlagsBits.ReadMessageHistory,
-                ),
-                deny: String(
-                  PermissionFlagsBits.SendMessages |
-                    PermissionFlagsBits.CreatePublicThreads |
-                    PermissionFlagsBits.CreatePrivateThreads,
-                ),
-              },
-            }),
-          catch: (error) =>
-            new DiscordApiError({
-              operation: "revealApplyHere",
-              cause: error,
-            }),
-        });
+        yield* tryDiscord("revealApplyHere", () =>
+          rest.put(Routes.channelPermission(config.channel_id, guildId), {
+            body: {
+              type: OverwriteType.Role,
+              allow: String(
+                PermissionFlagsBits.ViewChannel |
+                  PermissionFlagsBits.ReadMessageHistory,
+              ),
+              deny: String(
+                PermissionFlagsBits.SendMessages |
+                  PermissionFlagsBits.CreatePublicThreads |
+                  PermissionFlagsBits.CreatePrivateThreads,
+              ),
+            },
+          }),
+        );
 
         // On success: replace the message with confirmation
         yield* interactionUpdate(interaction, {

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -25,6 +25,7 @@ import {
   interactionReply,
   interactionUpdate,
 } from "#~/effects/discordSdk.ts";
+import { toUserResponse } from "#~/effects/errorHandling";
 import { FeatureFlagService } from "#~/effects/featureFlags";
 import { logEffect } from "#~/effects/observability.ts";
 import {
@@ -394,9 +395,10 @@ export const Command = [
               { error },
             );
 
+            const reply = toUserResponse(error);
             yield* interactionReply(interaction, {
-              content: "Something went wrong while submitting your application",
-              flags: MessageFlags.Ephemeral,
+              content: reply.content,
+              flags: reply.ephemeral ? MessageFlags.Ephemeral : undefined,
             }).pipe(Effect.catchAll(() => Effect.void));
           }),
         ),
@@ -522,9 +524,10 @@ export const Command = [
               { error },
             );
 
+            const reply = toUserResponse(error);
             yield* interactionReply(interaction, {
-              content: "Something went wrong while approving the application",
-              flags: MessageFlags.Ephemeral,
+              content: reply.content,
+              flags: reply.ephemeral ? MessageFlags.Ephemeral : undefined,
             }).pipe(Effect.catchAll(() => Effect.void));
           }),
         ),
@@ -647,9 +650,10 @@ export const Command = [
               { error },
             );
 
+            const reply = toUserResponse(error);
             yield* interactionReply(interaction, {
-              content: "Something went wrong while denying the application",
-              flags: MessageFlags.Ephemeral,
+              content: reply.content,
+              flags: reply.ephemeral ? MessageFlags.Ephemeral : undefined,
             }).pipe(Effect.catchAll(() => Effect.void));
           }),
         ),
@@ -819,9 +823,10 @@ export const Command = [
               { error },
             );
 
+            const reply = toUserResponse(error);
             yield* interactionReply(interaction, {
-              content: "Something went wrong while retracting the application",
-              flags: MessageFlags.Ephemeral,
+              content: reply.content,
+              flags: reply.ephemeral ? MessageFlags.Ephemeral : undefined,
             }).pipe(Effect.catchAll(() => Effect.void));
           }),
         ),
@@ -972,10 +977,10 @@ export const Command = [
                 error,
               },
             );
+            const reply = toUserResponse(error);
             yield* interactionReply(interaction, {
-              content:
-                "Gate activation failed. The button is still active — you can try again.",
-              flags: MessageFlags.Ephemeral,
+              content: reply.content,
+              flags: reply.ephemeral ? MessageFlags.Ephemeral : undefined,
             }).pipe(Effect.catchAll(() => Effect.void));
           }),
         ),

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -977,10 +977,10 @@ export const Command = [
                 error,
               },
             );
-            const reply = toUserResponse(error);
             yield* interactionReply(interaction, {
-              content: reply.content,
-              flags: reply.ephemeral ? MessageFlags.Ephemeral : undefined,
+              content:
+                "Gate activation failed. The button is still active — you can try again.",
+              flags: MessageFlags.Ephemeral,
             }).pipe(Effect.catchAll(() => Effect.void));
           }),
         ),

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -977,7 +977,7 @@ export const Command = [
               "Failed to activate gate",
               {
                 guildId: interaction.guildId,
-                error: String(error),
+                error,
               },
             );
             yield* interactionReply(interaction, {

--- a/app/commands/modreport.ts
+++ b/app/commands/modreport.ts
@@ -12,6 +12,7 @@ import {
   interactionDeferReply,
   interactionEditReply,
 } from "#~/effects/discordSdk.ts";
+import { toUserResponse } from "#~/effects/errorHandling";
 import { logEffect } from "#~/effects/observability.ts";
 import type { SlashCommand } from "#~/helpers/discord";
 import { formatError } from "#~/helpers/formatError";
@@ -309,8 +310,9 @@ export const Command = {
             formatError(error),
           );
 
+          const reply = toUserResponse(error);
           yield* interactionEditReply(interaction, {
-            content: "Failed to fetch moderation summary.",
+            content: reply.content,
           }).pipe(Effect.catchAll(() => Effect.void));
         }),
       ),

--- a/app/commands/modreport.ts
+++ b/app/commands/modreport.ts
@@ -14,6 +14,7 @@ import {
 } from "#~/effects/discordSdk.ts";
 import { logEffect } from "#~/effects/observability.ts";
 import type { SlashCommand } from "#~/helpers/discord";
+import { formatError } from "#~/helpers/formatError";
 import { commandStats } from "#~/helpers/metrics";
 import { truncateMessage } from "#~/helpers/string";
 import { getDeletionLogThread } from "#~/models/deletionLogThreads";
@@ -296,15 +297,17 @@ export const Command = {
     }).pipe(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
-          const err = error instanceof Error ? error : new Error(String(error));
-
           yield* logEffect("error", "Commands", "Modreport command failed", {
             guildId: interaction.guildId,
             userId: interaction.user.id,
-            error: err,
+            error,
           });
 
-          commandStats.commandFailed(interaction, "modreport", err.message);
+          commandStats.commandFailed(
+            interaction,
+            "modreport",
+            formatError(error),
+          );
 
           yield* interactionEditReply(interaction, {
             content: "Failed to fetch moderation summary.",

--- a/app/commands/purgeMessages.ts
+++ b/app/commands/purgeMessages.ts
@@ -23,6 +23,7 @@ import type {
   MessageComponentCommand,
   UserContextCommand,
 } from "#~/helpers/discord";
+import { formatError } from "#~/helpers/formatError";
 import { commandStats } from "#~/helpers/metrics";
 
 // Duration options mirror Discord's "delete messages on ban" increments.
@@ -133,7 +134,6 @@ export const PurgeMessagesCommand = {
     }).pipe(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
-          const err = error instanceof Error ? error : new Error(String(error));
           yield* logEffect(
             "error",
             "Commands",
@@ -142,13 +142,13 @@ export const PurgeMessagesCommand = {
               guildId: interaction.guildId,
               moderatorUserId: interaction.user.id,
               targetUserId: interaction.targetUser.id,
-              error: err.message,
+              error,
             },
           );
           commandStats.commandFailed(
             interaction,
             "purge-messages",
-            err.message,
+            formatError(error),
           );
         }),
       ),
@@ -192,7 +192,6 @@ export const PurgeMessagesSelectHandler = {
     }).pipe(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
-          const err = error instanceof Error ? error : new Error(String(error));
           yield* logEffect(
             "error",
             "Commands",
@@ -200,7 +199,7 @@ export const PurgeMessagesSelectHandler = {
             {
               guildId: interaction.guildId,
               moderatorUserId: interaction.user.id,
-              error: err.message,
+              error,
             },
           );
         }),
@@ -340,7 +339,6 @@ export const PurgeMessagesConfirmHandler = {
     }).pipe(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
-          const err = error instanceof Error ? error : new Error(String(error));
           yield* logEffect(
             "error",
             "Commands",
@@ -348,7 +346,7 @@ export const PurgeMessagesConfirmHandler = {
             {
               guildId: interaction.guildId,
               moderatorUserId: interaction.user.id,
-              error: err.message,
+              error,
             },
           );
           yield* interactionEditReply(interaction, {

--- a/app/commands/purgeMessages.ts
+++ b/app/commands/purgeMessages.ts
@@ -18,6 +18,7 @@ import {
   interactionReply,
   interactionUpdate,
 } from "#~/effects/discordSdk.ts";
+import { toUserResponse } from "#~/effects/errorHandling";
 import { logEffect } from "#~/effects/observability.ts";
 import type {
   MessageComponentCommand,
@@ -349,8 +350,9 @@ export const PurgeMessagesConfirmHandler = {
               error,
             },
           );
+          const reply = toUserResponse(error);
           yield* interactionEditReply(interaction, {
-            content: "Something went wrong while purging messages.",
+            content: reply.content,
             components: [],
           }).pipe(Effect.catchAll(() => Effect.void));
         }),

--- a/app/commands/report/automodRuleLog.ts
+++ b/app/commands/report/automodRuleLog.ts
@@ -154,7 +154,7 @@ export const logAutomodRuleCreate = (rule: AutoModerationRule) =>
     }),
     Effect.catchAll((error) =>
       logEffect("error", "AutomodRuleLog", "Failed to log rule create", {
-        error: String(error),
+        error,
         ruleId: rule.id,
         guildId: rule.guild.id,
       }),
@@ -187,7 +187,7 @@ export const logAutomodRuleDelete = (rule: AutoModerationRule) =>
     }),
     Effect.catchAll((error) =>
       logEffect("error", "AutomodRuleLog", "Failed to log rule delete", {
-        error: String(error),
+        error,
         ruleId: rule.id,
         guildId: rule.guild.id,
       }),
@@ -225,7 +225,7 @@ export const logAutomodRuleUpdate = (
     }),
     Effect.catchAll((error) =>
       logEffect("error", "AutomodRuleLog", "Failed to log rule update", {
-        error: String(error),
+        error,
         ruleId: newRule.id,
         guildId: newRule.guild.id,
       }),

--- a/app/commands/report/constructLog.ts
+++ b/app/commands/report/constructLog.ts
@@ -2,7 +2,7 @@ import { formatDistanceToNowStrict } from "date-fns";
 import { type MessageCreateOptions } from "discord.js";
 import { Effect } from "effect";
 
-import { DiscordApiError } from "#~/effects/errors";
+import { TransientError } from "#~/effects/errors";
 import {
   constructDiscordLink,
   getMessageContent,
@@ -30,7 +30,8 @@ export const constructLog = ({
     const lastReport = logs.at(-1);
     if (!lastReport?.message.guild) {
       return yield* Effect.fail(
-        new DiscordApiError({
+        new TransientError({
+          source: "discord",
           operation: "constructLog",
           cause: new Error(
             "Something went wrong when trying to retrieve last report",
@@ -48,7 +49,8 @@ export const constructLog = ({
     // This should never be possible but we gotta satisfy types
     if (!moderator) {
       return yield* Effect.fail(
-        new DiscordApiError({
+        new TransientError({
+          source: "discord",
           operation: "constructLog",
           cause: new Error("No role configured to be used as moderator"),
         }),

--- a/app/commands/report/userLog.ts
+++ b/app/commands/report/userLog.ts
@@ -14,7 +14,11 @@ import {
   messageReply,
   sendMessage,
 } from "#~/effects/discordSdk.ts";
-import { DiscordApiError, type NotFoundError } from "#~/effects/errors";
+import {
+  TransientError,
+  type DiscordError,
+  type NotFoundError,
+} from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import {
   describeAttachments,
@@ -63,14 +67,15 @@ export function logUserMessage({
     allReportedMessages: Report[];
     reportId: string;
   },
-  DiscordApiError | SqlError | NotFoundError,
+  DiscordError | SqlError | NotFoundError,
   DatabaseService
 > {
   return Effect.gen(function* () {
     const { guild, author } = message;
     if (!guild) {
       return yield* Effect.fail(
-        new DiscordApiError({
+        new TransientError({
+          source: "discord",
           operation: "logUserMessage",
           cause: new Error("Tried to log a message without a guild"),
         }),

--- a/app/commands/setup.ts
+++ b/app/commands/setup.ts
@@ -1,7 +1,12 @@
-import { PermissionFlagsBits, SlashCommandBuilder } from "discord.js";
+import {
+  MessageFlags,
+  PermissionFlagsBits,
+  SlashCommandBuilder,
+} from "discord.js";
 import { Effect } from "effect";
 
 import { interactionReply } from "#~/effects/discordSdk.ts";
+import { toUserResponse } from "#~/effects/errorHandling";
 import { logEffect } from "#~/effects/observability.ts";
 import type { SlashCommand } from "#~/helpers/discord";
 import { formatError } from "#~/helpers/formatError";
@@ -18,8 +23,11 @@ export const Command = {
   handler: (interaction) =>
     Effect.gen(function* () {
       if (!interaction.guild || !interaction.guildId) {
-        // @effect-diagnostics-next-line globalErrorInEffectFailure:off
-        return yield* Effect.fail(new Error("Interaction has no guild"));
+        yield* interactionReply(interaction, {
+          content: "This command can only be used in a server.",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
       }
 
       yield* logEffect("info", "Commands", "Setup command executed", {
@@ -56,10 +64,11 @@ export const Command = {
 
           commandStats.commandFailed(interaction, "setup", formatError(error));
 
-          yield* interactionReply(
-            interaction,
-            "Something broke while running setup. Please try again.",
-          ).pipe(Effect.catchAll(() => Effect.void));
+          const reply = toUserResponse(error);
+          yield* interactionReply(interaction, {
+            content: reply.content,
+            flags: reply.ephemeral ? MessageFlags.Ephemeral : undefined,
+          }).pipe(Effect.catchAll(() => Effect.void));
         }),
       ),
       Effect.withSpan("setupCommand", {

--- a/app/commands/setup.ts
+++ b/app/commands/setup.ts
@@ -4,6 +4,7 @@ import { Effect } from "effect";
 import { interactionReply } from "#~/effects/discordSdk.ts";
 import { logEffect } from "#~/effects/observability.ts";
 import type { SlashCommand } from "#~/helpers/discord";
+import { formatError } from "#~/helpers/formatError";
 import { commandStats } from "#~/helpers/metrics";
 
 import { initSetupForm } from "./setupHandlers.ts";
@@ -47,19 +48,17 @@ export const Command = {
     }).pipe(
       Effect.catchAll((error) =>
         Effect.gen(function* () {
-          const err = error instanceof Error ? error : new Error(String(error));
-
           yield* logEffect("error", "Commands", "Setup command failed", {
             guildId: interaction.guildId,
             userId: interaction.user.id,
-            error: err,
+            error,
           });
 
-          commandStats.commandFailed(interaction, "setup", err.message);
+          commandStats.commandFailed(interaction, "setup", formatError(error));
 
           yield* interactionReply(
             interaction,
-            `Something broke:\n\`\`\`\n${err.toString()}\n\`\`\``,
+            "Something broke while running setup. Please try again.",
           ).pipe(Effect.catchAll(() => Effect.void));
         }),
       ),

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -640,7 +640,7 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
         Effect.catchAll((error) =>
           Effect.gen(function* () {
             yield* logEffect("error", "Commands", "setup-sel handler failed", {
-              error: String(error),
+              error,
             });
           }),
         ),

--- a/app/discord/pipelines/activityTracker.ts
+++ b/app/discord/pipelines/activityTracker.ts
@@ -90,7 +90,7 @@ export const activityTrackerPipeline: Effect.Effect<
         Effect.catchAll((err) =>
           logEffect("warn", "ActivityTracker", "Pipeline handler failed", {
             eventType: e.type,
-            error: String(err),
+            error: err,
           }),
         ),
       );

--- a/app/discord/pipelines/activityTrackerHandlers.ts
+++ b/app/discord/pipelines/activityTrackerHandlers.ts
@@ -72,7 +72,7 @@ export const handleMessageCreate = (
     Effect.catchAll((err) =>
       logEffect("warn", "ActivityTracker", "Failed to track message", {
         messageId: msg.id,
-        error: String(err),
+        error: err,
       }),
     ),
     Effect.withSpan("ActivityTracker.trackMessage", {
@@ -105,7 +105,7 @@ export const handleMessageUpdate = (
     Effect.catchAll((err) =>
       logEffect("warn", "ActivityTracker", "Failed to update message stats", {
         messageId: e.newMessage.id,
-        error: String(err),
+        error: err,
       }),
     ),
     Effect.withSpan("ActivityTracker.updateMessage", {
@@ -132,7 +132,7 @@ export const handleMessageDelete = (
     Effect.catchAll((err) =>
       logEffect("warn", "ActivityTracker", "Failed to delete message stats", {
         messageId: e.message.id,
-        error: String(err),
+        error: err,
       }),
     ),
     Effect.withSpan("ActivityTracker.deleteMessage", {
@@ -155,7 +155,7 @@ export const handleReactionAdd = (
     Effect.catchAll((err) =>
       logEffect("warn", "ActivityTracker", "Failed to track reaction add", {
         messageId: e.reaction.message.id,
-        error: String(err),
+        error: err,
       }),
     ),
     Effect.withSpan("ActivityTracker.reactionAdd", {
@@ -190,7 +190,7 @@ export const handleReactionRemove = (
     Effect.catchAll((err) =>
       logEffect("warn", "ActivityTracker", "Failed to track reaction remove", {
         messageId: e.reaction.message.id,
-        error: String(err),
+        error: err,
       }),
     ),
     Effect.withSpan("ActivityTracker.reactionRemove", {

--- a/app/discord/pipelines/automod.ts
+++ b/app/discord/pipelines/automod.ts
@@ -73,7 +73,7 @@ export const automodPipeline: Effect.Effect<void, never, RuntimeContext> =
           Effect.catchAll((err) =>
             logEffect("warn", "Automod", "Pipeline handler failed", {
               ...logContext(e),
-              error: String(err),
+              error: err,
             }),
           ),
         ),

--- a/app/discord/pipelines/deletionLogHandlers.ts
+++ b/app/discord/pipelines/deletionLogHandlers.ts
@@ -14,7 +14,7 @@ import {
   fetchGuild,
   fetchUserOrNull,
 } from "#~/effects/discordSdk";
-import { DiscordApiError } from "#~/effects/errors";
+import { TransientError } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import { quoteMessageContent } from "#~/helpers/discord";
 import { getOrCreateDeletionLogThread } from "#~/models/deletionLogThreads";
@@ -349,7 +349,8 @@ export const handleBulkDelete = (
     ).pipe(
       Effect.catchAll(() =>
         Effect.fail(
-          new DiscordApiError({
+          new TransientError({
+            source: "discord",
             operation: "fetchDeletionLogChannel",
             cause: new Error("Deletion log channel not found"),
           }),

--- a/app/discord/pipelines/deletionLogHandlers.ts
+++ b/app/discord/pipelines/deletionLogHandlers.ts
@@ -69,7 +69,7 @@ function flushUncachedBatch(key: string, client: Client) {
       Effect.catchAll((e) =>
         logEffect("warn", "DeletionLogger", "Failed to flush uncached batch", {
           key,
-          error: String(e),
+          error: e,
         }),
       ),
     ),
@@ -150,7 +150,7 @@ export const handleDelete = (
           "warn",
           "DeletionLogger",
           "Failed to get/create deletion log thread",
-          { guildId: guild.id, userId: user.id, error: String(error) },
+          { guildId: guild.id, userId: user.id, error },
         ),
       ),
     );
@@ -196,7 +196,7 @@ export const handleDelete = (
           "warn",
           "DeletionLogger",
           "Failed to post deletion log embed",
-          { guildId: guild.id, error: String(error) },
+          { guildId: guild.id, error },
         ),
     }).pipe(Effect.catchAll((e) => e));
 
@@ -208,7 +208,7 @@ export const handleDelete = (
             "warn",
             "DeletionLogger",
             "Failed to get/create moderation thread for mod deletion",
-            { guildId: guild.id, userId: user.id, error: String(error) },
+            { guildId: guild.id, userId: user.id, error },
           ),
         ),
       );
@@ -225,7 +225,7 @@ export const handleDelete = (
               "warn",
               "DeletionLogger",
               "Failed to post mod deletion to moderation thread",
-              { guildId: guild.id, error: String(error) },
+              { guildId: guild.id, error },
             ),
         }).pipe(Effect.catchAll((e) => e));
       }
@@ -234,7 +234,7 @@ export const handleDelete = (
     Effect.catchAll((err) =>
       logEffect("warn", "DeletionLogger", "Failed to log message deletion", {
         messageId: e.message.id,
-        error: String(err),
+        error: err,
       }),
     ),
     Effect.withSpan("DeletionLogger.messageDelete", {
@@ -280,7 +280,7 @@ export const handleEdit = (
           "warn",
           "DeletionLogger",
           "Failed to get/create deletion log thread for edit",
-          { guildId: guild.id, userId: author.id, error: String(error) },
+          { guildId: guild.id, userId: author.id, error },
         ),
       ),
     );
@@ -310,14 +310,14 @@ export const handleEdit = (
       catch: (error) =>
         logEffect("warn", "DeletionLogger", "Failed to post edit log embed", {
           guildId: guild.id,
-          error: String(error),
+          error,
         }),
     }).pipe(Effect.catchAll((e) => e));
   }).pipe(
     Effect.catchAll((err) =>
       logEffect("warn", "DeletionLogger", "Failed to log message edit", {
         messageId: e.newMessage.id,
-        error: String(err),
+        error: err,
       }),
     ),
     Effect.withSpan("DeletionLogger.messageUpdate", {
@@ -414,14 +414,14 @@ export const handleBulkDelete = (
       catch: (error) =>
         logEffect("warn", "DeletionLogger", "Failed to post bulk delete log", {
           guildId: guild.id,
-          error: String(error),
+          error,
         }),
     }).pipe(Effect.catchAll((e) => e));
   }).pipe(
     Effect.catchAll((err) =>
       logEffect("warn", "DeletionLogger", "Failed to log bulk message delete", {
         guildId: e.guildId,
-        error: String(err),
+        error: err,
       }),
     ),
     Effect.withSpan("DeletionLogger.messageBulkDelete", {

--- a/app/discord/pipelines/deletionLogger.ts
+++ b/app/discord/pipelines/deletionLogger.ts
@@ -52,7 +52,7 @@ export const deletionLoggerPipeline: Effect.Effect<
               Effect.catchAll((err) =>
                 logEffect("warn", "DeletionLogger", "Failed to cache message", {
                   messageId: e.message.id,
-                  error: String(err),
+                  error: err,
                 }),
               ),
             );
@@ -65,7 +65,7 @@ export const deletionLoggerPipeline: Effect.Effect<
                   "warn",
                   "DeletionLogger",
                   "Failed to touch cached message",
-                  { messageId: e.newMessage.id, error: String(err) },
+                  { messageId: e.newMessage.id, error: err },
                 ),
               ),
             );
@@ -92,7 +92,7 @@ export const deletionLoggerPipeline: Effect.Effect<
         Effect.catchAll((err) =>
           logEffect("warn", "DeletionLogger", "Pipeline handler failed", {
             eventType: e.type,
-            error: String(err),
+            error: err,
           }),
         ),
       );

--- a/app/discord/pipelines/modActionLogger.ts
+++ b/app/discord/pipelines/modActionLogger.ts
@@ -2,6 +2,11 @@
 import { Effect, Stream } from "effect";
 
 import type { RuntimeContext } from "#~/AppRuntime";
+import {
+  logAutomodRuleCreate,
+  logAutomodRuleDelete,
+  logAutomodRuleUpdate,
+} from "#~/commands/report/automodRuleLog";
 // Import the existing Effect builders from the old file
 import {
   automodActionEffect,
@@ -10,11 +15,6 @@ import {
   memberRemoveEffect,
   memberUpdateEffect,
 } from "#~/commands/report/modActionLogger";
-import {
-  logAutomodRuleCreate,
-  logAutomodRuleDelete,
-  logAutomodRuleUpdate,
-} from "#~/commands/report/automodRuleLog";
 import { DiscordEventBus } from "#~/discord/eventBus";
 import { logEffect } from "#~/effects/observability";
 
@@ -65,7 +65,7 @@ export const modActionLoggerPipeline: Effect.Effect<
         Effect.catchAll((err) =>
           logEffect("warn", "ModActionLogger", "Pipeline handler failed", {
             eventType: e.type,
-            error: String(err),
+            error: err,
           }),
         ),
       );

--- a/app/discord/pipelines/onboardGuild.ts
+++ b/app/discord/pipelines/onboardGuild.ts
@@ -31,7 +31,7 @@ export const onboardGuildPipeline: Effect.Effect<void, never, RuntimeContext> =
           Effect.catchAll((err) =>
             logEffect("warn", "OnboardGuild", "Pipeline handler failed", {
               eventType: e.type,
-              error: String(err),
+              error: err,
             }),
           ),
         );

--- a/app/discord/pipelines/reactjiChanneler.ts
+++ b/app/discord/pipelines/reactjiChanneler.ts
@@ -23,7 +23,7 @@ export const reactjiChannelerPipeline: Effect.Effect<
         Effect.catchAll((err) =>
           logEffect("warn", "ReactjiChanneler", "Pipeline handler failed", {
             eventType: e.type,
-            error: String(err),
+            error: err,
           }),
         ),
       );

--- a/app/discord/pipelines/reactjiChannelerHandler.ts
+++ b/app/discord/pipelines/reactjiChannelerHandler.ts
@@ -157,7 +157,7 @@ export const handleReactionAdd = (
     Effect.catchAll((err) =>
       logEffect("warn", "ReactjiChanneler", "Pipeline handler failed", {
         messageId: e.reaction.message.id,
-        error: String(err),
+        error: err,
       }),
     ),
     Effect.withSpan("ReactjiChanneler.reactionAdd"),

--- a/app/discord/pipelines/reactjiChannelerHandler.ts
+++ b/app/discord/pipelines/reactjiChannelerHandler.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 import type { RuntimeContext } from "#~/AppRuntime";
 import { DatabaseService } from "#~/Database";
 import type { MessageReactionAddEvent } from "#~/discord/events";
-import { DiscordApiError } from "#~/effects/errors";
+import { tryDiscord } from "#~/effects/classifyDiscordError";
 import { logEffect } from "#~/effects/observability";
 import { featureStats } from "#~/helpers/metrics";
 
@@ -13,11 +13,7 @@ export const handleReactionAdd = (
   Effect.gen(function* () {
     // Fetch partial reaction if needed
     const reaction = e.reaction.partial
-      ? yield* Effect.tryPromise({
-          try: () => e.reaction.fetch(),
-          catch: (error) =>
-            new DiscordApiError({ operation: "fetchReaction", cause: error }),
-        })
+      ? yield* tryDiscord("fetchReaction", () => e.reaction.fetch())
       : e.reaction;
 
     // Skip bot reactions
@@ -73,14 +69,9 @@ export const handleReactionAdd = (
     });
 
     // Fetch the target channel
-    const targetChannel = yield* Effect.tryPromise({
-      try: () => message.guild!.channels.fetch(config.channel_id),
-      catch: (error) =>
-        new DiscordApiError({
-          operation: "fetchTargetChannel",
-          cause: error,
-        }),
-    });
+    const targetChannel = yield* tryDiscord("fetchTargetChannel", () =>
+      message.guild!.channels.fetch(config.channel_id),
+    );
 
     if (!targetChannel?.isTextBased()) {
       yield* logEffect(
@@ -97,29 +88,18 @@ export const handleReactionAdd = (
 
     // Fetch the full message if partial
     const fullMessage = message.partial
-      ? yield* Effect.tryPromise({
-          try: () => message.fetch(),
-          catch: (error) =>
-            new DiscordApiError({
-              operation: "fetchFullMessage",
-              cause: error,
-            }),
-        })
+      ? yield* tryDiscord("fetchFullMessage", () => message.fetch())
       : message;
 
     // Forward the message using Discord's native forwarding
-    yield* Effect.tryPromise({
-      try: () => fullMessage.forward(targetChannel),
-      catch: (error) =>
-        new DiscordApiError({ operation: "forwardMessage", cause: error }),
-    });
+    yield* tryDiscord("forwardMessage", () =>
+      fullMessage.forward(targetChannel),
+    );
 
     // Get all users who reacted with this emoji
-    const reactors = yield* Effect.tryPromise({
-      try: () => reaction.users.fetch(),
-      catch: (error) =>
-        new DiscordApiError({ operation: "fetchReactors", cause: error }),
-    });
+    const reactors = yield* tryDiscord("fetchReactors", () =>
+      reaction.users.fetch(),
+    );
 
     const reactorMentions = reactors
       .filter((u) => !u.bot)
@@ -127,18 +107,12 @@ export const handleReactionAdd = (
       .join(", ");
 
     // Send a message indicating who triggered the forward
-    yield* Effect.tryPromise({
-      try: () =>
-        targetChannel.send({
-          content: `Forwarded by ${reactorMentions} reacting with ${emoji}`,
-          allowedMentions: { users: [] },
-        }),
-      catch: (error) =>
-        new DiscordApiError({
-          operation: "sendForwardSummary",
-          cause: error,
-        }),
-    });
+    yield* tryDiscord("sendForwardSummary", () =>
+      targetChannel.send({
+        content: `Forwarded by ${reactorMentions} reacting with ${emoji}`,
+        allowedMentions: { users: [] },
+      }),
+    );
 
     featureStats.reactjiTriggered(guildId, e.user.id, emoji, message.id);
 

--- a/app/effects/classifyDiscordError.test.ts
+++ b/app/effects/classifyDiscordError.test.ts
@@ -1,0 +1,72 @@
+import { Effect } from "effect";
+import { describe, expect, test } from "vitest";
+
+import { DiscordAPIError, HTTPError } from "@discordjs/rest";
+
+import {
+  classifyDiscordError,
+  tryDiscord,
+} from "#~/effects/classifyDiscordError";
+
+const makeDiscordApiError = (status: number, code = 0) =>
+  new DiscordAPIError(
+    { code, message: "x" },
+    code,
+    status,
+    "GET",
+    "https://discord/x",
+    { body: undefined, files: undefined },
+  );
+
+describe("classifyDiscordError", () => {
+  test("403 → ForbiddenError", () => {
+    const out = classifyDiscordError("addRole", makeDiscordApiError(403));
+    expect(out._tag).toBe("ForbiddenError");
+    expect(out.cause).toBeInstanceOf(Error);
+  });
+
+  test("404 → ResourceMissingError", () => {
+    expect(classifyDiscordError("fetch", makeDiscordApiError(404))._tag).toBe(
+      "ResourceMissingError",
+    );
+  });
+
+  test("500 → TransientError with status", () => {
+    const out = classifyDiscordError("send", makeDiscordApiError(500));
+    expect(out._tag).toBe("TransientError");
+    expect(out._tag === "TransientError" && out.status).toBe(500);
+  });
+
+  test("429 (other 4xx) → ClientError carrying status", () => {
+    const out = classifyDiscordError("send", makeDiscordApiError(429));
+    expect(out._tag).toBe("ClientError");
+    expect(out._tag === "ClientError" && out.status).toBe(429);
+  });
+
+  test("HTTPError 5xx → TransientError", () => {
+    const httpErr = new HTTPError(
+      503,
+      "Service Unavailable",
+      "GET",
+      "https://x",
+      {
+        body: undefined,
+        files: undefined,
+      },
+    );
+    expect(classifyDiscordError("op", httpErr)._tag).toBe("TransientError");
+  });
+
+  test("unknown/network rejection → TransientError", () => {
+    expect(classifyDiscordError("op", new Error("ECONNRESET"))._tag).toBe(
+      "TransientError",
+    );
+  });
+
+  test("tryDiscord wraps a rejecting promise into a DiscordError", async () => {
+    const exit = await Effect.runPromiseExit(
+      tryDiscord("op", () => Promise.reject(makeDiscordApiError(403))),
+    );
+    expect(exit._tag).toBe("Failure");
+  });
+});

--- a/app/effects/classifyDiscordError.test.ts
+++ b/app/effects/classifyDiscordError.test.ts
@@ -1,72 +1,180 @@
+import { createRequire } from "node:module";
 import { Effect } from "effect";
 import { describe, expect, test } from "vitest";
 
-import { DiscordAPIError, HTTPError } from "@discordjs/rest";
+import {
+  DiscordAPIError as RestDiscordAPIError,
+  HTTPError as RestHTTPError,
+  RateLimitError as RestRateLimitError,
+} from "@discordjs/rest";
 
 import {
   classifyDiscordError,
   tryDiscord,
 } from "#~/effects/classifyDiscordError";
 
-const makeDiscordApiError = (status: number, code = 0) =>
-  new DiscordAPIError(
-    { code, message: "x" },
+/**
+ * The production throw path is discord.js (CommonJS), whose error classes are a
+ * DIFFERENT module instance than `@discordjs/rest`'s ESM build that this test
+ * file (and the classifier) import — proven below: `Cjs !== Rest`. The live 403
+ * force-ban bug was that the classifier's `instanceof` checks ran against the
+ * ESM classes while discord.js threw CJS instances, so every real error fell
+ * through to `TransientError`. We therefore exercise BOTH builds.
+ */
+const require = createRequire(import.meta.url);
+const djs = require("discord.js") as {
+  DiscordAPIError: typeof RestDiscordAPIError;
+  RateLimitError: typeof RestRateLimitError;
+  HTTPError: typeof RestHTTPError;
+};
+const CjsDiscordAPIError = djs.DiscordAPIError;
+const CjsRateLimitError = djs.RateLimitError;
+const CjsHTTPError = djs.HTTPError;
+
+// Sanity-check the premise of this whole fix: the classes really are distinct
+// objects across the module boundary, so `instanceof` cannot bridge them.
+test("discord.js (CJS) and @discordjs/rest (ESM) error classes are distinct", () => {
+  expect(CjsDiscordAPIError).not.toBe(RestDiscordAPIError);
+  expect(CjsRateLimitError).not.toBe(RestRateLimitError);
+  expect(CjsHTTPError).not.toBe(RestHTTPError);
+});
+
+const makeApiError = (
+  Ctor: typeof RestDiscordAPIError,
+  status: number,
+  code = 0,
+) =>
+  new Ctor(
+    { code, message: "Missing Permissions" },
     code,
     status,
-    "GET",
-    "https://discord/x",
+    "PUT",
+    "https://discord.com/api/v10/guilds/1/bans/2",
     { body: undefined, files: undefined },
   );
 
-describe("classifyDiscordError", () => {
-  test("403 → ForbiddenError", () => {
-    const out = classifyDiscordError("addRole", makeDiscordApiError(403));
+const makeRateLimitError = (Ctor: typeof RestRateLimitError) =>
+  new Ctor({
+    timeToReset: 5000,
+    limit: 10,
+    method: "POST",
+    hash: "abc",
+    url: "https://discord.com/api/v10/x",
+    route: "/x",
+    majorParameter: "1",
+    global: false,
+    // `retryAfter` is documented (and verified at runtime) to be milliseconds.
+    retryAfter: 5000,
+    sublimitTimeout: 0,
+    scope: "user",
+  });
+
+const makeHttpError = (Ctor: typeof RestHTTPError, status: number) =>
+  new Ctor(status, "Service Unavailable", "GET", "https://discord.com/x", {
+    body: undefined,
+    files: undefined,
+  });
+
+// Run the full matrix against both builds. The CJS row is the production path;
+// the ESM row guards the classifier against either build throwing.
+describe.each([
+  ["discord.js (CJS, production throw path)", djs],
+  [
+    "@discordjs/rest (ESM)",
+    {
+      DiscordAPIError: RestDiscordAPIError,
+      RateLimitError: RestRateLimitError,
+      HTTPError: RestHTTPError,
+    },
+  ],
+] as const)("classifyDiscordError — %s", (_label, build) => {
+  test("403 / code 50013 → ForbiddenError (the live force-ban bug)", () => {
+    const out = classifyDiscordError(
+      "forceBan",
+      makeApiError(build.DiscordAPIError, 403, 50013),
+    );
     expect(out._tag).toBe("ForbiddenError");
     expect(out.cause).toBeInstanceOf(Error);
+    expect(out.operation).toBe("forceBan");
   });
 
   test("404 → ResourceMissingError", () => {
-    expect(classifyDiscordError("fetch", makeDiscordApiError(404))._tag).toBe(
-      "ResourceMissingError",
+    const out = classifyDiscordError(
+      "fetch",
+      makeApiError(build.DiscordAPIError, 404, 10008),
     );
+    expect(out._tag).toBe("ResourceMissingError");
+    expect(out.cause).toBeInstanceOf(Error);
   });
 
-  test("500 → TransientError with status", () => {
-    const out = classifyDiscordError("send", makeDiscordApiError(500));
+  test("500 → TransientError carrying status", () => {
+    const out = classifyDiscordError(
+      "send",
+      makeApiError(build.DiscordAPIError, 500),
+    );
     expect(out._tag).toBe("TransientError");
     expect(out._tag === "TransientError" && out.status).toBe(500);
   });
 
-  test("429 (other 4xx) → ClientError carrying status", () => {
-    const out = classifyDiscordError("send", makeDiscordApiError(429));
+  test("other 4xx (400) → ClientError carrying status + code", () => {
+    const out = classifyDiscordError(
+      "send",
+      makeApiError(build.DiscordAPIError, 400, 50035),
+    );
     expect(out._tag).toBe("ClientError");
-    expect(out._tag === "ClientError" && out.status).toBe(429);
+    expect(out._tag === "ClientError" && out.status).toBe(400);
+    expect(out._tag === "ClientError" && out.code).toBe(50035);
+  });
+
+  test("RateLimitError → RateLimitError with retryAfterMs in ms (no *1000)", () => {
+    const out = classifyDiscordError(
+      "addRole",
+      makeRateLimitError(build.RateLimitError),
+    );
+    expect(out._tag).toBe("RateLimitError");
+    // `retryAfter` is already milliseconds; the value passes through unscaled.
+    expect(out._tag === "RateLimitError" && out.retryAfterMs).toBe(5000);
   });
 
   test("HTTPError 5xx → TransientError", () => {
-    const httpErr = new HTTPError(
-      503,
-      "Service Unavailable",
-      "GET",
-      "https://x",
-      {
-        body: undefined,
-        files: undefined,
-      },
-    );
-    expect(classifyDiscordError("op", httpErr)._tag).toBe("TransientError");
+    const out = classifyDiscordError("op", makeHttpError(build.HTTPError, 503));
+    expect(out._tag).toBe("TransientError");
+    expect(out._tag === "TransientError" && out.status).toBe(503);
   });
 
+  test("HTTPError 4xx → ClientError", () => {
+    const out = classifyDiscordError("op", makeHttpError(build.HTTPError, 400));
+    expect(out._tag).toBe("ClientError");
+    expect(out._tag === "ClientError" && out.status).toBe(400);
+  });
+});
+
+describe("classifyDiscordError — non-SDK rejections", () => {
   test("unknown/network rejection → TransientError", () => {
-    expect(classifyDiscordError("op", new Error("ECONNRESET"))._tag).toBe(
-      "TransientError",
-    );
+    const out = classifyDiscordError("op", new Error("ECONNRESET"));
+    expect(out._tag).toBe("TransientError");
+    expect(out.cause).toBeInstanceOf(Error);
   });
 
-  test("tryDiscord wraps a rejecting promise into a DiscordError", async () => {
+  test("non-Error rejection → TransientError with Error cause", () => {
+    const out = classifyDiscordError("op", "boom");
+    expect(out._tag).toBe("TransientError");
+    expect(out.cause).toBeInstanceOf(Error);
+  });
+});
+
+describe("tryDiscord", () => {
+  test("wraps a rejecting promise into a classified DiscordError", async () => {
     const exit = await Effect.runPromiseExit(
-      tryDiscord("op", () => Promise.reject(makeDiscordApiError(403))),
+      tryDiscord("forceBan", () =>
+        Promise.reject(makeApiError(CjsDiscordAPIError, 403, 50013)),
+      ),
     );
     expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure" && exit.cause._tag === "Fail") {
+      expect(exit.cause.error._tag).toBe("ForbiddenError");
+    } else {
+      throw new Error("expected a Fail cause with ForbiddenError");
+    }
   });
 });

--- a/app/effects/classifyDiscordError.ts
+++ b/app/effects/classifyDiscordError.ts
@@ -1,0 +1,102 @@
+import { Effect } from "effect";
+
+import {
+  DiscordAPIError,
+  RateLimitError as DjsRateLimitError,
+  HTTPError,
+} from "@discordjs/rest";
+
+import {
+  ClientError,
+  ForbiddenError,
+  RateLimitError,
+  ResourceMissingError,
+  TransientError,
+  type DiscordError,
+} from "#~/effects/errors";
+import { formatError } from "#~/helpers/formatError";
+
+/**
+ * Narrow an unknown SDK rejection to a serializable Error. Param is named
+ * `rejection` (not `error`/`e`/`cause`) so `local/no-error-string-cast` does
+ * not flag the `formatError` fallback. This is the unknown→typed boundary.
+ */
+export const toError = (rejection: unknown): Error =>
+  rejection instanceof Error ? rejection : new Error(formatError(rejection));
+
+/**
+ * Convert an unknown Discord SDK rejection into the typed `DiscordError` union,
+ * promoting useful fields (status/code/retryAfter) to typed slots. `instanceof`
+ * is correct HERE — this is the boundary, not an Effect `catch*` handler.
+ */
+export const classifyDiscordError = (
+  operation: string,
+  rejection: unknown,
+): DiscordError => {
+  const cause = toError(rejection);
+
+  if (rejection instanceof DjsRateLimitError) {
+    return new RateLimitError({
+      source: "discord",
+      operation,
+      retryAfterMs: rejection.retryAfter * 1000,
+      cause,
+    });
+  }
+
+  if (rejection instanceof DiscordAPIError) {
+    if (rejection.status === 403) {
+      return new ForbiddenError({ source: "discord", operation, cause });
+    }
+    if (rejection.status === 404) {
+      return new ResourceMissingError({ source: "discord", operation, cause });
+    }
+    if (rejection.status >= 500) {
+      return new TransientError({
+        source: "discord",
+        operation,
+        status: rejection.status,
+        cause,
+      });
+    }
+    return new ClientError({
+      source: "discord",
+      operation,
+      status: rejection.status,
+      code: rejection.code,
+      cause,
+    });
+  }
+
+  if (rejection instanceof HTTPError) {
+    return rejection.status >= 500
+      ? new TransientError({
+          source: "discord",
+          operation,
+          status: rejection.status,
+          cause,
+        })
+      : new ClientError({
+          source: "discord",
+          operation,
+          status: rejection.status,
+          cause,
+        });
+  }
+
+  // Network fault / unknown → assume transient (safe to retry).
+  return new TransientError({ source: "discord", operation, cause });
+};
+
+/**
+ * DRY replacement for the `Effect.tryPromise({ try, catch })` boilerplate at
+ * every Discord call site. Classifies rejections into the `DiscordError` union.
+ */
+export const tryDiscord = <A>(
+  operation: string,
+  f: () => Promise<A>,
+): Effect.Effect<A, DiscordError> =>
+  Effect.tryPromise({
+    try: f,
+    catch: (rejection) => classifyDiscordError(operation, rejection),
+  });

--- a/app/effects/classifyDiscordError.ts
+++ b/app/effects/classifyDiscordError.ts
@@ -1,12 +1,6 @@
 import { Effect } from "effect";
 
 import {
-  DiscordAPIError,
-  RateLimitError as DjsRateLimitError,
-  HTTPError,
-} from "@discordjs/rest";
-
-import {
   ClientError,
   ForbiddenError,
   RateLimitError,
@@ -25,9 +19,59 @@ export const toError = (rejection: unknown): Error =>
   rejection instanceof Error ? rejection : new Error(formatError(rejection));
 
 /**
+ * Why structural detection instead of `instanceof`?
+ *
+ * The app is ESM (`"type": "module"`). Importing from `@discordjs/rest` loads
+ * the package's `import` build (`dist/index.mjs`). But `discord.js` is CommonJS
+ * and `require()`s `@discordjs/rest`, loading the `require` build
+ * (`dist/index.js`). Those are two separately-evaluated module instances, so
+ * `DiscordAPIError` (and `RateLimitError`/`HTTPError`) from the two builds are
+ * *different class objects* — proven at runtime:
+ *
+ *   import {DiscordAPIError as R} from "@discordjs/rest";
+ *   const D = require("discord.js").DiscordAPIError; // R === D → false
+ *
+ * Every `tryDiscord(...)` call wraps a `discord.js` SDK method, so real Discord
+ * rejections are instances of the CJS classes and FAIL every `instanceof`
+ * against the imported ESM classes — they fell through to the `TransientError`
+ * default (the live force-ban 403/50013 → TransientError bug). Detecting by the
+ * stable error *shape* is identity-agnostic and works regardless of which build
+ * threw the error.
+ */
+
+/** Discord REST API error: numeric HTTP `status` + Discord `code` + `rawError`. */
+const isDiscordApiErrorShape = (
+  rejection: unknown,
+): rejection is { status: number; code: number | string } =>
+  rejection instanceof Error &&
+  typeof (rejection as { status?: unknown }).status === "number" &&
+  "code" in rejection &&
+  (typeof (rejection as { code?: unknown }).code === "number" ||
+    typeof (rejection as { code?: unknown }).code === "string") &&
+  "rawError" in rejection;
+
+/** Rate-limit error: carries `retryAfter` (already in ms) and `timeToReset`. */
+const isRateLimitErrorShape = (
+  rejection: unknown,
+): rejection is { retryAfter: number } =>
+  rejection instanceof Error &&
+  typeof (rejection as { retryAfter?: unknown }).retryAfter === "number" &&
+  "timeToReset" in rejection;
+
+/** Transport-level HTTP error: numeric `status`, but no Discord `code`/`rawError`. */
+const isHttpErrorShape = (
+  rejection: unknown,
+): rejection is { status: number } =>
+  rejection instanceof Error &&
+  typeof (rejection as { status?: unknown }).status === "number" &&
+  !("rawError" in rejection);
+
+/**
  * Convert an unknown Discord SDK rejection into the typed `DiscordError` union,
- * promoting useful fields (status/code/retryAfter) to typed slots. `instanceof`
- * is correct HERE — this is the boundary, not an Effect `catch*` handler.
+ * promoting useful fields (status/code/retryAfter) to typed slots. This is the
+ * unknown→typed boundary. We classify by error *shape* rather than `instanceof`
+ * because the thrown classes cross the discord.js (CJS) ↔ @discordjs/rest (ESM)
+ * module boundary — see the note above.
  */
 export const classifyDiscordError = (
   operation: string,
@@ -35,16 +79,19 @@ export const classifyDiscordError = (
 ): DiscordError => {
   const cause = toError(rejection);
 
-  if (rejection instanceof DjsRateLimitError) {
+  // Order matters: rate-limit before the generic HTTP-shape check, and the
+  // API-error check (status + Discord code) before the bare HTTP-error check.
+  if (isRateLimitErrorShape(rejection)) {
     return new RateLimitError({
       source: "discord",
       operation,
-      retryAfterMs: rejection.retryAfter * 1000,
+      // discord.js/@discordjs/rest expose `retryAfter` already in milliseconds.
+      retryAfterMs: rejection.retryAfter,
       cause,
     });
   }
 
-  if (rejection instanceof DiscordAPIError) {
+  if (isDiscordApiErrorShape(rejection)) {
     if (rejection.status === 403) {
       return new ForbiddenError({ source: "discord", operation, cause });
     }
@@ -68,7 +115,7 @@ export const classifyDiscordError = (
     });
   }
 
-  if (rejection instanceof HTTPError) {
+  if (isHttpErrorShape(rejection)) {
     return rejection.status >= 500
       ? new TransientError({
           source: "discord",

--- a/app/effects/discordSdk.test.ts
+++ b/app/effects/discordSdk.test.ts
@@ -5,7 +5,7 @@ import { softbanMember } from "./discordSdk";
 
 // ── softbanMember ──
 // Splits ban and unban so that a failing unban after a successful ban is
-// distinguishable from a failing ban (operation field on the DiscordApiError),
+// distinguishable from a failing ban (operation field on the TransientError),
 // and is also logged loudly inside the helper because the consequence — user
 // left banned — is too important to rely on the caller's error handling.
 
@@ -44,7 +44,7 @@ test("softbanMember calls ban then unban on the happy path", async () => {
   );
 });
 
-test("softbanMember fails with DiscordApiError(operation=softbanMember.ban) when ban itself fails; unban is not called", async () => {
+test("softbanMember fails with TransientError(operation=softbanMember.ban) when ban itself fails; unban is not called", async () => {
   const { member, banSpy, unbanSpy } = makeMemberMock({
     banImpl: () => Promise.reject(new Error("missing permissions")),
   });
@@ -56,14 +56,14 @@ test("softbanMember fails with DiscordApiError(operation=softbanMember.ban) when
   expect(Exit.isFailure(exit)).toBe(true);
   if (Exit.isFailure(exit)) {
     const failure = exit.cause._tag === "Fail" ? exit.cause.error : null;
-    expect(failure?._tag).toBe("DiscordApiError");
+    expect(failure?._tag).toBe("TransientError");
     expect(failure?.operation).toBe("softbanMember.ban");
   }
   expect(banSpy).toHaveBeenCalledTimes(1);
   expect(unbanSpy).not.toHaveBeenCalled();
 });
 
-test("softbanMember fails with DiscordApiError(operation=softbanMember.unban) when unban fails after a successful ban", async () => {
+test("softbanMember fails with TransientError(operation=softbanMember.unban) when unban fails after a successful ban", async () => {
   const { member, banSpy, unbanSpy } = makeMemberMock({
     unbanImpl: () => Promise.reject(new Error("network error")),
   });
@@ -75,7 +75,7 @@ test("softbanMember fails with DiscordApiError(operation=softbanMember.unban) wh
   expect(Exit.isFailure(exit)).toBe(true);
   if (Exit.isFailure(exit)) {
     const failure = exit.cause._tag === "Fail" ? exit.cause.error : null;
-    expect(failure?._tag).toBe("DiscordApiError");
+    expect(failure?._tag).toBe("TransientError");
     expect(failure?.operation).toBe("softbanMember.unban");
   }
   expect(banSpy).toHaveBeenCalledTimes(1);

--- a/app/effects/discordSdk.ts
+++ b/app/effects/discordSdk.ts
@@ -180,7 +180,7 @@ export const forwardMessageSafe = (message: Message, targetChannelId: string) =>
   }).pipe(
     Effect.catchAll((error) =>
       logEffect("error", "Discord SDK", "failed to forward to modLog", {
-        error: String(error),
+        error,
         messageId: message.id,
         targetChannelId,
       }),
@@ -377,7 +377,7 @@ export const softbanMember = (
           "Discord",
           "Softban: ban succeeded but unban failed — user is BANNED",
           {
-            error: String(error.cause),
+            error,
             userId: member.id,
             guildId: member.guild.id,
           },

--- a/app/effects/discordSdk.ts
+++ b/app/effects/discordSdk.ts
@@ -25,36 +25,27 @@ import type {
 } from "discord.js";
 import { Effect } from "effect";
 
-import { DiscordApiError } from "#~/effects/errors";
+import { tryDiscord } from "#~/effects/classifyDiscordError";
+import type { DiscordError } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 
 export const createChannel = (
   guild: Guild,
   options: GuildChannelCreateOptions,
 ) =>
-  Effect.tryPromise({
-    try: () => guild.channels.create(options),
-    catch: (error) =>
-      new DiscordApiError({ operation: "createChannel", cause: error }),
-  }).pipe(
+  tryDiscord("createChannel", () => guild.channels.create(options)).pipe(
     Effect.withSpan("discord.createChannel", {
       attributes: { guildId: guild.id, channelName: options.name },
     }),
   );
 
 export const fetchGuild = (client: Client, guildId: string) =>
-  Effect.tryPromise({
-    try: () => client.guilds.fetch(guildId),
-    catch: (error) =>
-      new DiscordApiError({ operation: "fetchGuild", cause: error }),
-  }).pipe(Effect.withSpan("discord.fetchGuild", { attributes: { guildId } }));
+  tryDiscord("fetchGuild", () => client.guilds.fetch(guildId)).pipe(
+    Effect.withSpan("discord.fetchGuild", { attributes: { guildId } }),
+  );
 
 export const fetchChannel = (guild: Guild, channelId: string) =>
-  Effect.tryPromise({
-    try: () => guild.channels.fetch(channelId),
-    catch: (error) =>
-      new DiscordApiError({ operation: "fetchChannel", cause: error }),
-  }).pipe(
+  tryDiscord("fetchChannel", () => guild.channels.fetch(channelId)).pipe(
     Effect.withSpan("discord.fetchChannel", { attributes: { channelId } }),
   );
 
@@ -62,22 +53,19 @@ export const fetchChannelFromClient = <T = GuildTextBasedChannel>(
   client: Client,
   channelId: string,
 ) =>
-  Effect.tryPromise({
-    try: () => client.channels.fetch(channelId) as Promise<T>,
-    catch: (error) =>
-      new DiscordApiError({ operation: "fetchChannel", cause: error }),
-  }).pipe(
+  tryDiscord(
+    "fetchChannel",
+    () => client.channels.fetch(channelId) as Promise<T>,
+  ).pipe(
     Effect.withSpan("discord.fetchChannel", {
       attributes: { channelId, variant: "fromClient" },
     }),
   );
 
 export const fetchMember = (guild: Guild, userId: string) =>
-  Effect.tryPromise({
-    try: () => guild.members.fetch(userId),
-    catch: (error) =>
-      new DiscordApiError({ operation: "fetchMember", cause: error }),
-  }).pipe(Effect.withSpan("discord.fetchMember", { attributes: { userId } }));
+  tryDiscord("fetchMember", () => guild.members.fetch(userId)).pipe(
+    Effect.withSpan("discord.fetchMember", { attributes: { userId } }),
+  );
 
 export const fetchMemberOrNull = (
   guild: Guild,
@@ -97,11 +85,9 @@ export const fetchMemberOrNull = (
   );
 
 export const fetchUser = (client: Client, userId: string) =>
-  Effect.tryPromise({
-    try: () => client.users.fetch(userId),
-    catch: (error) =>
-      new DiscordApiError({ operation: "fetchUser", cause: error }),
-  }).pipe(Effect.withSpan("discord.fetchUser", { attributes: { userId } }));
+  tryDiscord("fetchUser", () => client.users.fetch(userId)).pipe(
+    Effect.withSpan("discord.fetchUser", { attributes: { userId } }),
+  );
 
 export const fetchUserOrNull = (
   client: Client,
@@ -124,22 +110,14 @@ export const fetchMessage = (
   channel: GuildTextBasedChannel | ThreadChannel,
   messageId: string,
 ) =>
-  Effect.tryPromise({
-    try: () => channel.messages.fetch(messageId),
-    catch: (error) =>
-      new DiscordApiError({ operation: "fetchMessage", cause: error }),
-  }).pipe(
+  tryDiscord("fetchMessage", () => channel.messages.fetch(messageId)).pipe(
     Effect.withSpan("discord.fetchMessage", {
       attributes: { messageId, channelId: channel.id },
     }),
   );
 
 export const deleteMessage = (message: Message | PartialMessage) =>
-  Effect.tryPromise({
-    try: () => message.delete(),
-    catch: (error) =>
-      new DiscordApiError({ operation: "deleteMessage", cause: error }),
-  }).pipe(
+  tryDiscord("deleteMessage", () => message.delete()).pipe(
     Effect.withSpan("discord.deleteMessage", {
       attributes: { messageId: message.id },
     }),
@@ -149,11 +127,7 @@ export const sendMessage = (
   channel: GuildTextBasedChannel | ThreadChannel,
   options: Parameters<typeof channel.send>[0],
 ) =>
-  Effect.tryPromise({
-    try: () => channel.send(options),
-    catch: (error) =>
-      new DiscordApiError({ operation: "sendMessage", cause: error }),
-  }).pipe(
+  tryDiscord("sendMessage", () => channel.send(options)).pipe(
     Effect.withSpan("discord.sendMessage", {
       attributes: { channelId: channel.id },
     }),
@@ -163,11 +137,7 @@ export const editMessage = (
   message: Message,
   options: Parameters<typeof message.edit>[0],
 ) =>
-  Effect.tryPromise({
-    try: () => message.edit(options),
-    catch: (error) =>
-      new DiscordApiError({ operation: "editMessage", cause: error }),
-  }).pipe(
+  tryDiscord("editMessage", () => message.edit(options)).pipe(
     Effect.withSpan("discord.editMessage", {
       attributes: { messageId: message.id },
     }),
@@ -194,11 +164,7 @@ export const messageReply = (
   message: Message,
   options: Parameters<Message["reply"]>[0],
 ) =>
-  Effect.tryPromise({
-    try: () => message.reply(options),
-    catch: (error) =>
-      new DiscordApiError({ operation: "messageReply", cause: error }),
-  }).pipe(
+  tryDiscord("messageReply", () => message.reply(options)).pipe(
     Effect.withSpan("discord.messageReply", {
       attributes: { messageId: message.id },
     }),
@@ -240,16 +206,9 @@ export const replyAndForwardSafe = (
  */
 export const resolveMessagePartial = (
   msg: Message | PartialMessage,
-): Effect.Effect<Message, DiscordApiError, never> =>
+): Effect.Effect<Message, DiscordError, never> =>
   (msg.partial
-    ? Effect.tryPromise({
-        try: () => msg.fetch(),
-        catch: (error) =>
-          new DiscordApiError({
-            operation: "resolveMessagePartial",
-            cause: error,
-          }),
-      })
+    ? tryDiscord("resolveMessagePartial", () => msg.fetch())
     : Effect.succeed(msg)
   ).pipe(
     Effect.withSpan("discord.resolveMessagePartial", {
@@ -266,11 +225,9 @@ export const interactionReply = (
     | MessageContextMenuCommandInteraction,
   options: Parameters<typeof interaction.reply>[0],
 ) =>
-  Effect.tryPromise({
-    try: () => interaction.reply(options),
-    catch: (error) =>
-      new DiscordApiError({ operation: "interactionReply", cause: error }),
-  }).pipe(Effect.withSpan("discord.interactionReply"));
+  tryDiscord("interactionReply", () => interaction.reply(options)).pipe(
+    Effect.withSpan("discord.interactionReply"),
+  );
 
 export const interactionDeferReply = (
   interaction:
@@ -280,11 +237,9 @@ export const interactionDeferReply = (
     | MessageContextMenuCommandInteraction,
   options?: Parameters<typeof interaction.deferReply>[0],
 ) =>
-  Effect.tryPromise({
-    try: () => interaction.deferReply(options),
-    catch: (error) =>
-      new DiscordApiError({ operation: "interactionDeferReply", cause: error }),
-  }).pipe(Effect.withSpan("discord.interactionDeferReply"));
+  tryDiscord("interactionDeferReply", () =>
+    interaction.deferReply(options),
+  ).pipe(Effect.withSpan("discord.interactionDeferReply"));
 
 export const interactionEditReply = (
   interaction:
@@ -294,11 +249,9 @@ export const interactionEditReply = (
     | MessageContextMenuCommandInteraction,
   options: Parameters<typeof interaction.editReply>[0],
 ) =>
-  Effect.tryPromise({
-    try: () => interaction.editReply(options),
-    catch: (error) =>
-      new DiscordApiError({ operation: "interactionEditReply", cause: error }),
-  }).pipe(Effect.withSpan("discord.interactionEditReply"));
+  tryDiscord("interactionEditReply", () => interaction.editReply(options)).pipe(
+    Effect.withSpan("discord.interactionEditReply"),
+  );
 
 export const interactionFollowUp = (
   interaction:
@@ -308,34 +261,25 @@ export const interactionFollowUp = (
     | MessageContextMenuCommandInteraction,
   options: Parameters<typeof interaction.followUp>[0],
 ) =>
-  Effect.tryPromise({
-    try: () => interaction.followUp(options),
-    catch: (error) =>
-      new DiscordApiError({ operation: "interactionFollowUp", cause: error }),
-  }).pipe(Effect.withSpan("discord.interactionFollowUp"));
+  tryDiscord("interactionFollowUp", () => interaction.followUp(options)).pipe(
+    Effect.withSpan("discord.interactionFollowUp"),
+  );
 
 export const interactionUpdate = (
   interaction: MessageComponentInteraction,
   options: Parameters<typeof interaction.update>[0],
 ) =>
-  Effect.tryPromise({
-    try: () => interaction.update(options),
-    catch: (error) =>
-      new DiscordApiError({ operation: "interactionUpdate", cause: error }),
-  }).pipe(Effect.withSpan("discord.interactionUpdate"));
+  tryDiscord("interactionUpdate", () => interaction.update(options)).pipe(
+    Effect.withSpan("discord.interactionUpdate"),
+  );
 
 export const interactionDeferUpdate = (
   interaction: MessageComponentInteraction,
   options?: Parameters<typeof interaction.deferUpdate>[0],
 ) =>
-  Effect.tryPromise({
-    try: () => interaction.deferUpdate(options),
-    catch: (error) =>
-      new DiscordApiError({
-        operation: "interactionDeferUpdate",
-        cause: error,
-      }),
-  }).pipe(Effect.withSpan("discord.interactionDeferUpdate"));
+  tryDiscord("interactionDeferUpdate", () =>
+    interaction.deferUpdate(options),
+  ).pipe(Effect.withSpan("discord.interactionDeferUpdate"));
 
 /**
  * Softban a member: ban to delete their recent messages, then immediately
@@ -343,7 +287,7 @@ export const interactionDeferUpdate = (
  * server-side based on `deleteMessageSeconds`.
  *
  * If `ban` succeeds but `unban` fails, the user is left BANNED. This case is
- * logged at error level inside the helper before the `DiscordApiError`
+ * logged at error level inside the helper before the `DiscordError`
  * propagates, so the operational incident is never lost even if a caller
  * forgets to handle it. Callers can distinguish the failure mode by checking
  * `error.operation` — `softbanMember.ban` vs `softbanMember.unban`.
@@ -352,25 +296,15 @@ export const softbanMember = (
   member: GuildMember,
   reason: string,
   deleteMessageSeconds: number,
-): Effect.Effect<void, DiscordApiError, never> =>
+): Effect.Effect<void, DiscordError, never> =>
   Effect.gen(function* () {
-    yield* Effect.tryPromise({
-      try: () => member.ban({ reason, deleteMessageSeconds }),
-      catch: (error) =>
-        new DiscordApiError({
-          operation: "softbanMember.ban",
-          cause: error,
-        }),
-    });
+    yield* tryDiscord("softbanMember.ban", () =>
+      member.ban({ reason, deleteMessageSeconds }),
+    );
 
-    yield* Effect.tryPromise({
-      try: () => member.guild.members.unban(member, reason),
-      catch: (error) =>
-        new DiscordApiError({
-          operation: "softbanMember.unban",
-          cause: error,
-        }),
-    }).pipe(
+    yield* tryDiscord("softbanMember.unban", () =>
+      member.guild.members.unban(member, reason),
+    ).pipe(
       Effect.tapError((error) =>
         logEffect(
           "error",

--- a/app/effects/errorHandling.test.ts
+++ b/app/effects/errorHandling.test.ts
@@ -4,12 +4,14 @@ import { describe, expect, test } from "vitest";
 import {
   escalateExhausted,
   isRetriable,
+  toUserResponse,
   withRetry,
 } from "#~/effects/errorHandling";
 import {
   ForbiddenError,
   RateLimitError,
   TransientError,
+  ValidationError,
 } from "#~/effects/errors";
 
 const transient = () =>
@@ -96,5 +98,39 @@ describe("escalateExhausted", () => {
         expect(maybeFailure.value._tag).toBe("ForbiddenError");
       }
     }
+  });
+});
+
+describe("toUserResponse", () => {
+  test("ForbiddenError → permission guidance, ephemeral", () => {
+    const r = toUserResponse(
+      new ForbiddenError({
+        source: "discord",
+        operation: "ban",
+        cause: new Error("403"),
+      }),
+    );
+    expect(r.ephemeral).toBe(true);
+    expect(r.content.toLowerCase()).toContain("permission");
+  });
+
+  test("ValidationError surfaces the field message", () => {
+    const r = toUserResponse(
+      new ValidationError({ field: "reason", message: "Reason is required" }),
+    );
+    expect(r.content).toContain("Reason is required");
+  });
+
+  test("unknown infra error → generic safe message, never leaks a cause", () => {
+    const r = toUserResponse(
+      new TransientError({
+        source: "discord",
+        operation: "op",
+        status: 500,
+        cause: new Error("secret internal detail"),
+      }),
+    );
+    expect(r.content).not.toContain("secret internal detail");
+    expect(r.content.length).toBeGreaterThan(0);
   });
 });

--- a/app/effects/errorHandling.test.ts
+++ b/app/effects/errorHandling.test.ts
@@ -1,0 +1,100 @@
+import { Cause, Effect, Exit } from "effect";
+import { describe, expect, test } from "vitest";
+
+import {
+  escalateExhausted,
+  isRetriable,
+  withRetry,
+} from "#~/effects/errorHandling";
+import {
+  ForbiddenError,
+  RateLimitError,
+  TransientError,
+} from "#~/effects/errors";
+
+const transient = () =>
+  new TransientError({
+    source: "discord",
+    operation: "op",
+    status: 500,
+    cause: new Error("5xx"),
+  });
+const forbidden = () =>
+  new ForbiddenError({
+    source: "discord",
+    operation: "op",
+    cause: new Error("403"),
+  });
+
+describe("isRetriable", () => {
+  test("TransientError and RateLimitError are retriable", () => {
+    expect(isRetriable(transient())).toBe(true);
+    expect(
+      isRetriable(
+        new RateLimitError({
+          source: "discord",
+          operation: "op",
+          retryAfterMs: 1000,
+          cause: new Error("429"),
+        }),
+      ),
+    ).toBe(true);
+  });
+  test("ForbiddenError is not retriable", () => {
+    expect(isRetriable(forbidden())).toBe(false);
+  });
+});
+
+describe("withRetry", () => {
+  test("retries a transient failure then succeeds", async () => {
+    let attempts = 0;
+    const eff = Effect.suspend(() => {
+      attempts += 1;
+      return attempts < 3 ? Effect.fail(transient()) : Effect.succeed("ok");
+    });
+    const result = await Effect.runPromise(withRetry(eff));
+    expect(result).toBe("ok");
+    expect(attempts).toBe(3);
+  });
+
+  test("does not retry a non-retriable failure", async () => {
+    let attempts = 0;
+    const eff = Effect.suspend(() => {
+      attempts += 1;
+      return Effect.fail(forbidden());
+    });
+    const exit = await Effect.runPromiseExit(withRetry(eff));
+    expect(exit._tag).toBe("Failure");
+    expect(attempts).toBe(1);
+  });
+});
+
+describe("escalateExhausted", () => {
+  test("maps a surviving retriable failure to ServiceUnavailableError", async () => {
+    const exit = await Effect.runPromiseExit(
+      escalateExhausted(Effect.fail(transient())),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const maybeFailure = Cause.failureOption(exit.cause);
+      expect(maybeFailure._tag).toBe("Some");
+      if (maybeFailure._tag === "Some") {
+        expect(maybeFailure.value._tag).toBe("ServiceUnavailableError");
+      }
+    }
+  });
+
+  test("passes through non-retriable failures unchanged", async () => {
+    const exit = await Effect.runPromiseExit(
+      escalateExhausted(Effect.fail(forbidden())),
+    );
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const maybeFailure = Cause.failureOption(exit.cause);
+      expect(maybeFailure._tag).toBe("Some");
+      if (maybeFailure._tag === "Some") {
+        expect(maybeFailure.value._tag).toBe("ForbiddenError");
+      }
+    }
+  });
+});

--- a/app/effects/errorHandling.test.ts
+++ b/app/effects/errorHandling.test.ts
@@ -114,6 +114,32 @@ describe("toUserResponse", () => {
     expect(r.content.toLowerCase()).toContain("permission");
   });
 
+  test("ForbiddenError on forceBan → role-hierarchy hint, ephemeral", () => {
+    const r = toUserResponse(
+      new ForbiddenError({
+        source: "discord",
+        operation: "forceBan",
+        cause: new Error("403"),
+      }),
+    );
+    expect(r.ephemeral).toBe(true);
+    expect(r.content.toLowerCase()).toContain("role");
+  });
+
+  test("ForbiddenError on non-ban operation → generic permission message, no hierarchy hint", () => {
+    const r = toUserResponse(
+      new ForbiddenError({
+        source: "discord",
+        operation: "createChannel",
+        cause: new Error("403"),
+      }),
+    );
+    expect(r.ephemeral).toBe(true);
+    expect(r.content.toLowerCase()).toContain("permission");
+    // The role-hierarchy hint ("roles list", "roles above their own") must NOT appear
+    expect(r.content.toLowerCase()).not.toContain("roles list");
+  });
+
   test("ValidationError surfaces the field message", () => {
     const r = toUserResponse(
       new ValidationError({ field: "reason", message: "Reason is required" }),

--- a/app/effects/errorHandling.test.ts
+++ b/app/effects/errorHandling.test.ts
@@ -102,7 +102,7 @@ describe("escalateExhausted", () => {
 });
 
 describe("toUserResponse", () => {
-  test("ForbiddenError on ban → role-hierarchy hint, ephemeral", () => {
+  test("ForbiddenError → permission guidance with hierarchy hint, ephemeral", () => {
     const r = toUserResponse(
       new ForbiddenError({
         source: "discord",
@@ -111,58 +111,27 @@ describe("toUserResponse", () => {
       }),
     );
     expect(r.ephemeral).toBe(true);
-    expect(r.content.toLowerCase()).toContain("roles list");
-  });
-
-  test("ForbiddenError on forceBan → role-hierarchy hint, ephemeral", () => {
-    const r = toUserResponse(
-      new ForbiddenError({
-        source: "discord",
-        operation: "forceBan",
-        cause: new Error("403"),
-      }),
-    );
-    expect(r.ephemeral).toBe(true);
-    expect(r.content.toLowerCase()).toContain("roles list");
-  });
-
-  test("ForbiddenError on softbanMember.ban → role-hierarchy hint, ephemeral", () => {
-    const r = toUserResponse(
-      new ForbiddenError({
-        source: "discord",
-        operation: "softbanMember.ban",
-        cause: new Error("403"),
-      }),
-    );
-    expect(r.ephemeral).toBe(true);
-    expect(r.content.toLowerCase()).toContain("roles list");
-  });
-
-  test("ForbiddenError → generic permission guidance, ephemeral", () => {
-    const r = toUserResponse(
-      new ForbiddenError({
-        source: "discord",
-        operation: "kick",
-        cause: new Error("403"),
-      }),
-    );
-    expect(r.ephemeral).toBe(true);
     expect(r.content.toLowerCase()).toContain("permission");
-    expect(r.content.toLowerCase()).not.toContain("roles list");
+    expect(r.content.toLowerCase()).toContain("roles list");
+    expect(r.content).toContain("/check-requirements");
   });
 
-  test("ForbiddenError on non-ban operation → generic permission message, no hierarchy hint", () => {
-    const r = toUserResponse(
+  test("ForbiddenError message is operation-agnostic (same copy for every operation)", () => {
+    const ban = toUserResponse(
+      new ForbiddenError({
+        source: "discord",
+        operation: "ban",
+        cause: new Error("403"),
+      }),
+    );
+    const nonBan = toUserResponse(
       new ForbiddenError({
         source: "discord",
         operation: "createChannel",
         cause: new Error("403"),
       }),
     );
-    expect(r.ephemeral).toBe(true);
-    expect(r.content.toLowerCase()).toContain("permission");
-    // The role-hierarchy hint ("roles list", "roles above their own") must NOT appear
-    expect(r.content.toLowerCase()).not.toContain("roles list");
+    expect(nonBan.content).toBe(ban.content);
   });
 
   test("ValidationError surfaces the field message", () => {

--- a/app/effects/errorHandling.test.ts
+++ b/app/effects/errorHandling.test.ts
@@ -102,7 +102,7 @@ describe("escalateExhausted", () => {
 });
 
 describe("toUserResponse", () => {
-  test("ForbiddenError → permission guidance, ephemeral", () => {
+  test("ForbiddenError on ban → role-hierarchy hint, ephemeral", () => {
     const r = toUserResponse(
       new ForbiddenError({
         source: "discord",
@@ -111,7 +111,7 @@ describe("toUserResponse", () => {
       }),
     );
     expect(r.ephemeral).toBe(true);
-    expect(r.content.toLowerCase()).toContain("permission");
+    expect(r.content.toLowerCase()).toContain("roles list");
   });
 
   test("ForbiddenError on forceBan → role-hierarchy hint, ephemeral", () => {
@@ -123,7 +123,32 @@ describe("toUserResponse", () => {
       }),
     );
     expect(r.ephemeral).toBe(true);
-    expect(r.content.toLowerCase()).toContain("role");
+    expect(r.content.toLowerCase()).toContain("roles list");
+  });
+
+  test("ForbiddenError on softbanMember.ban → role-hierarchy hint, ephemeral", () => {
+    const r = toUserResponse(
+      new ForbiddenError({
+        source: "discord",
+        operation: "softbanMember.ban",
+        cause: new Error("403"),
+      }),
+    );
+    expect(r.ephemeral).toBe(true);
+    expect(r.content.toLowerCase()).toContain("roles list");
+  });
+
+  test("ForbiddenError → generic permission guidance, ephemeral", () => {
+    const r = toUserResponse(
+      new ForbiddenError({
+        source: "discord",
+        operation: "kick",
+        cause: new Error("403"),
+      }),
+    );
+    expect(r.ephemeral).toBe(true);
+    expect(r.content.toLowerCase()).toContain("permission");
+    expect(r.content.toLowerCase()).not.toContain("roles list");
   });
 
   test("ForbiddenError on non-ban operation → generic permission message, no hierarchy hint", () => {

--- a/app/effects/errorHandling.ts
+++ b/app/effects/errorHandling.ts
@@ -58,6 +58,17 @@ export const toUserResponse = (
 ): { content: string; ephemeral: boolean } => {
   switch (e._tag) {
     case "ForbiddenError":
+      // Permission failures on member-ban operations are almost always a role-
+      // hierarchy problem; give the actionable hint. Other ForbiddenError
+      // operations fall through to the generic permission message. Add more
+      // operation-specific copy here as outcomes need more precise articulation.
+      if (e.operation === "forceBan" || e.operation === "softbanMember.ban") {
+        return {
+          content:
+            "Failed to ban user, try checking the bot's permissions. If they look okay, make sure that the bot's role is near the top of the roles list — bots can't ban users with roles above their own.",
+          ephemeral: true,
+        };
+      }
       return {
         content:
           "I don't have permission to do that. Check my role permissions and try again.",

--- a/app/effects/errorHandling.ts
+++ b/app/effects/errorHandling.ts
@@ -1,0 +1,16 @@
+import type { DiscordError } from "#~/effects/errors";
+
+const DISCORD_TAGS = new Set([
+  "RateLimitError",
+  "TransientError",
+  "ForbiddenError",
+  "ResourceMissingError",
+  "ClientError",
+  "ServerError",
+]);
+
+export const isDiscordError = (e: unknown): e is DiscordError =>
+  typeof e === "object" &&
+  e !== null &&
+  "_tag" in e &&
+  DISCORD_TAGS.has((e as { _tag: string })._tag);

--- a/app/effects/errorHandling.ts
+++ b/app/effects/errorHandling.ts
@@ -62,7 +62,11 @@ export const toUserResponse = (
       // hierarchy problem; give the actionable hint. Other ForbiddenError
       // operations fall through to the generic permission message. Add more
       // operation-specific copy here as outcomes need more precise articulation.
-      if (e.operation === "forceBan" || e.operation === "softbanMember.ban") {
+      if (
+        e.operation === "forceBan" ||
+        e.operation === "ban" ||
+        e.operation === "softbanMember.ban"
+      ) {
         return {
           content:
             "Failed to ban user, try checking the bot's permissions. If they look okay, make sure that the bot's role is near the top of the roles list — bots can't ban users with roles above their own.",

--- a/app/effects/errorHandling.ts
+++ b/app/effects/errorHandling.ts
@@ -2,6 +2,7 @@ import { Effect, Schedule } from "effect";
 
 import {
   ServiceUnavailableError,
+  type AppError,
   type DiscordError,
   type RateLimitError,
   type TransientError,
@@ -46,3 +47,50 @@ export const escalateExhausted = <A, R>(
       new ServiceUnavailableError({ source: "discord", lastCause: e }),
     ),
   );
+
+const GENERIC = {
+  content: "Something went wrong handling that. The team has been notified.",
+  ephemeral: true,
+};
+
+export const toUserResponse = (
+  e: AppError,
+): { content: string; ephemeral: boolean } => {
+  switch (e._tag) {
+    case "ForbiddenError":
+      return {
+        content:
+          "I don't have permission to do that. Check my role permissions and try again.",
+        ephemeral: true,
+      };
+    case "ResourceMissingError":
+      return {
+        content: "That target no longer exists.",
+        ephemeral: true,
+      };
+    case "NotAuthorizedError":
+      return {
+        content: "You're not authorized to use that command.",
+        ephemeral: true,
+      };
+    case "ValidationError":
+      return { content: e.message, ephemeral: true };
+    case "FeatureDisabledError":
+      return {
+        content: "That feature isn't enabled for this server.",
+        ephemeral: true,
+      };
+    case "RateLimitError":
+    case "TransientError":
+    case "ServiceUnavailableError":
+      return {
+        content:
+          "Discord is having trouble right now — please try again shortly.",
+        ephemeral: true,
+      };
+    // ClientError, ServerError, ConfigError, SqlError, DatabaseCorruptionError,
+    // NotFoundError, AlreadyResolvedError, NoLeaderError, ResolutionExecutionError
+    default:
+      return GENERIC;
+  }
+};

--- a/app/effects/errorHandling.ts
+++ b/app/effects/errorHandling.ts
@@ -1,4 +1,11 @@
-import type { DiscordError } from "#~/effects/errors";
+import { Effect, Schedule } from "effect";
+
+import {
+  ServiceUnavailableError,
+  type DiscordError,
+  type RateLimitError,
+  type TransientError,
+} from "#~/effects/errors";
 
 const DISCORD_TAGS = new Set([
   "RateLimitError",
@@ -14,3 +21,28 @@ export const isDiscordError = (e: unknown): e is DiscordError =>
   e !== null &&
   "_tag" in e &&
   DISCORD_TAGS.has((e as { _tag: string })._tag);
+
+export const isRetriable = (
+  e: DiscordError,
+): e is RateLimitError | TransientError =>
+  e._tag === "RateLimitError" || e._tag === "TransientError";
+
+/** Capped exponential backoff (base 200ms, ×2, jittered) over 4 attempts. */
+const cappedBackoff = Schedule.exponential("200 millis", 2).pipe(
+  Schedule.jittered,
+  Schedule.compose(Schedule.recurs(3)), // 1 initial + 3 retries = 4 attempts
+);
+
+export const withRetry = <A, R>(
+  self: Effect.Effect<A, DiscordError, R>,
+): Effect.Effect<A, DiscordError, R> =>
+  Effect.retry(self, { while: isRetriable, schedule: cappedBackoff });
+
+export const escalateExhausted = <A, R>(
+  self: Effect.Effect<A, DiscordError, R>,
+) =>
+  Effect.catchIf(self, isRetriable, (e) =>
+    Effect.fail(
+      new ServiceUnavailableError({ source: "discord", lastCause: e }),
+    ),
+  );

--- a/app/effects/errorHandling.ts
+++ b/app/effects/errorHandling.ts
@@ -58,24 +58,11 @@ export const toUserResponse = (
 ): { content: string; ephemeral: boolean } => {
   switch (e._tag) {
     case "ForbiddenError":
-      // Permission failures on member-ban operations are almost always a role-
-      // hierarchy problem; give the actionable hint. Other ForbiddenError
-      // operations fall through to the generic permission message. Add more
-      // operation-specific copy here as outcomes need more precise articulation.
-      if (
-        e.operation === "forceBan" ||
-        e.operation === "ban" ||
-        e.operation === "softbanMember.ban"
-      ) {
-        return {
-          content:
-            "Failed to ban user, try checking the bot's permissions. If they look okay, make sure that the bot's role is near the top of the roles list — bots can't ban users with roles above their own.",
-          ephemeral: true,
-        };
-      }
+      // Any permission failure: point at /check-requirements and the most common
+      // cause (the bot's role sitting below the target in the role hierarchy).
       return {
         content:
-          "I don't have permission to do that. Check my role permissions and try again.",
+          "This failed because of a permissions error, please use the `/check-requirements` command to verify permissions.\n\nIf requirements are met, make sure that the bot's role is near the top of the roles list — [bots can't ban users with roles above their own](https://support.discord.com/hc/en-us/articles/214836687-Discord-Roles-and-Permissions#h_01JJ7FF0ES91KDVXNT9MQ6FQTC).",
         ephemeral: true,
       };
     case "ResourceMissingError":

--- a/app/effects/errors.ts
+++ b/app/effects/errors.ts
@@ -1,5 +1,7 @@
 import { Data } from "effect";
 
+import type { SqlError as SqlErrorType } from "@effect/sql/SqlError";
+
 // Re-export SQL errors from @effect/sql for convenience
 export { SqlError, ResultLengthMismatch } from "@effect/sql/SqlError";
 
@@ -11,12 +13,6 @@ export class NotAuthorizedError extends Data.TaggedError("NotAuthorizedError")<{
 
 // TODO: refine
 export class DiscordApiError extends Data.TaggedError("DiscordApiError")<{
-  operation: string;
-  cause: unknown;
-}> {}
-
-// TODO: refine
-export class StripeApiError extends Data.TaggedError("StripeApiError")<{
   operation: string;
   cause: unknown;
 }> {}
@@ -61,7 +57,7 @@ export class ResolutionExecutionError extends Data.TaggedError(
 )<{
   escalationId: string;
   resolution: string;
-  cause: unknown;
+  cause: Error;
 }> {}
 
 export class FeatureDisabledError extends Data.TaggedError(
@@ -71,3 +67,87 @@ export class FeatureDisabledError extends Data.TaggedError(
   guildId: string;
   reason: "not_in_rollout" | "tier_required" | "flag_unavailable";
 }> {}
+
+// --- Infra error taxonomy (named by the decision each drives) -------------
+// `cause` is always a serializable Error (narrowed at the classifier boundary).
+
+/** Retriable: rate-limited. Carries the suggested delay for observability. */
+export class RateLimitError extends Data.TaggedError("RateLimitError")<{
+  source: "discord";
+  operation: string;
+  retryAfterMs: number;
+  cause: Error;
+}> {}
+
+/** Retriable: transient 5xx / network fault. */
+export class TransientError extends Data.TaggedError("TransientError")<{
+  source: "discord";
+  operation: string;
+  status?: number;
+  cause: Error;
+}> {}
+
+/** Non-retriable 403: the bot lacks a Discord permission. */
+export class ForbiddenError extends Data.TaggedError("ForbiddenError")<{
+  source: "discord";
+  operation: string;
+  cause: Error;
+}> {}
+
+/** Non-retriable 404: target gone — frequently recover-as-success. */
+export class ResourceMissingError extends Data.TaggedError(
+  "ResourceMissingError",
+)<{
+  source: "discord";
+  operation: string;
+  cause: Error;
+}> {}
+
+/** Non-retriable, generic 4xx (not 403/404). */
+export class ClientError extends Data.TaggedError("ClientError")<{
+  source: "discord";
+  operation: string;
+  status: number;
+  code?: number | string;
+  cause: Error;
+}> {}
+
+/** Non-retriable, permanent 5xx. Named slot — no classifier branch emits it yet. */
+export class ServerError extends Data.TaggedError("ServerError")<{
+  source: "discord";
+  operation: string;
+  status: number;
+  cause: Error;
+}> {}
+
+/** Escalated outage: exhausted retriable failure → alert path. */
+export class ServiceUnavailableError extends Data.TaggedError(
+  "ServiceUnavailableError",
+)<{
+  source: "discord";
+  lastCause: DiscordError;
+}> {}
+
+/** Union of transport errors the classifier can produce. */
+export type DiscordError =
+  | RateLimitError
+  | TransientError
+  | ForbiddenError
+  | ResourceMissingError
+  | ClientError
+  | ServerError;
+
+/** App-wide union for `toUserResponse` exhaustiveness. */
+export type AppError =
+  | DiscordError
+  | ServiceUnavailableError
+  | NotAuthorizedError
+  | NotFoundError
+  | ValidationError
+  | ConfigError
+  | DatabaseCorruptionError
+  | AlreadyResolvedError
+  | NoLeaderError
+  | ResolutionExecutionError
+  | FeatureDisabledError
+  | SqlErrorType;

--- a/app/effects/errors.ts
+++ b/app/effects/errors.ts
@@ -1,4 +1,4 @@
-import { Data } from "effect";
+import { Data, type Cause } from "effect";
 
 import type { SqlError as SqlErrorType } from "@effect/sql/SqlError";
 
@@ -144,4 +144,7 @@ export type AppError =
   | NoLeaderError
   | ResolutionExecutionError
   | FeatureDisabledError
-  | SqlErrorType;
+  | SqlErrorType
+  /** Effect.tryPromise wraps thrown exceptions in UnknownException; command-level
+   *  catchAll blocks see this whenever a raw promise rejects with an untyped error. */
+  | Cause.UnknownException;

--- a/app/effects/errors.ts
+++ b/app/effects/errors.ts
@@ -11,12 +11,6 @@ export class NotAuthorizedError extends Data.TaggedError("NotAuthorizedError")<{
   requiredRole?: string;
 }> {}
 
-// TODO: refine
-export class DiscordApiError extends Data.TaggedError("DiscordApiError")<{
-  operation: string;
-  cause: unknown;
-}> {}
-
 export class NotFoundError extends Data.TaggedError("NotFoundError")<{
   resource: string;
   id: string;

--- a/app/effects/featureFlags.ts
+++ b/app/effects/featureFlags.ts
@@ -59,7 +59,7 @@ export const FeatureFlagServiceLive = Layer.scoped(
               "warn",
               "FeatureFlagService",
               "PostHog flag check failed, defaulting to disabled",
-              { flag, guildId, error: String(error) },
+              { flag, guildId, error },
             ).pipe(Effect.as(false as boolean)),
           ),
           Effect.tap((enabled) => Effect.annotateCurrentSpan({ enabled })),

--- a/app/effects/logger.test.ts
+++ b/app/effects/logger.test.ts
@@ -1,7 +1,7 @@
 import { Cause, Effect, Logger } from "effect";
 import { describe, expect, test, vi } from "vitest";
 
-import { DiscordApiError } from "#~/effects/errors";
+import { ForbiddenError } from "#~/effects/errors";
 import { JsonLoggerWithCause } from "#~/effects/logger";
 
 const runAndCapture = async (effect: Effect.Effect<void>): Promise<string> => {
@@ -40,14 +40,15 @@ describe("JsonLoggerWithCause", () => {
       Effect.logError("failed").pipe(
         Effect.annotateLogs({
           service: "Test",
-          error: new DiscordApiError({
+          error: new ForbiddenError({
+            source: "discord",
             operation: "addMemberRole",
             cause: new Error("403 Forbidden"),
           }),
         }),
       ),
     );
-    expect(out).toContain("DiscordApiError");
+    expect(out).toContain("ForbiddenError");
     expect(out).toContain("addMemberRole");
     expect(out).toContain("403 Forbidden");
   });
@@ -56,7 +57,8 @@ describe("JsonLoggerWithCause", () => {
   // This test documents that limitation: the tag name appears in the string but
   // the cause field is NOT a structured object.
   test("fiber-level cause (Cause.pretty) renders tagged error as a string containing its tag", async () => {
-    const taggedError = new DiscordApiError({
+    const taggedError = new ForbiddenError({
+      source: "discord",
       operation: "testOp",
       cause: new Error("underlying"),
     });
@@ -68,7 +70,7 @@ describe("JsonLoggerWithCause", () => {
     );
     const parsed = JSON.parse(out);
     expect(typeof parsed.cause).toBe("string");
-    expect(parsed.cause).toContain("DiscordApiError");
+    expect(parsed.cause).toContain("ForbiddenError");
   });
 
   test("emits the structured envelope keys", async () => {

--- a/app/effects/logger.test.ts
+++ b/app/effects/logger.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Logger } from "effect";
+import { Cause, Effect, Logger } from "effect";
 import { describe, expect, test, vi } from "vitest";
 
 import { DiscordApiError } from "#~/effects/errors";
@@ -50,6 +50,25 @@ describe("JsonLoggerWithCause", () => {
     expect(out).toContain("DiscordApiError");
     expect(out).toContain("addMemberRole");
     expect(out).toContain("403 Forbidden");
+  });
+
+  // Fiber-level cause (options.cause) uses Cause.pretty — a string, not errorReplacer.
+  // This test documents that limitation: the tag name appears in the string but
+  // the cause field is NOT a structured object.
+  test("fiber-level cause (Cause.pretty) renders tagged error as a string containing its tag", async () => {
+    const taggedError = new DiscordApiError({
+      operation: "testOp",
+      cause: new Error("underlying"),
+    });
+    const cause = Cause.fail(taggedError);
+    const out = await runAndCapture(
+      Effect.logError("failed", cause).pipe(
+        Effect.annotateLogs({ service: "Test" }),
+      ),
+    );
+    const parsed = JSON.parse(out);
+    expect(typeof parsed.cause).toBe("string");
+    expect(parsed.cause).toContain("DiscordApiError");
   });
 
   test("emits the structured envelope keys", async () => {

--- a/app/effects/logger.test.ts
+++ b/app/effects/logger.test.ts
@@ -1,0 +1,64 @@
+import { Effect, Logger } from "effect";
+import { describe, expect, test, vi } from "vitest";
+
+import { DiscordApiError } from "#~/effects/errors";
+import { JsonLoggerWithCause } from "#~/effects/logger";
+
+const runAndCapture = async (effect: Effect.Effect<void>): Promise<string> => {
+  const spy = vi.spyOn(console, "log").mockImplementation(vi.fn());
+  try {
+    await Effect.runPromise(
+      effect.pipe(
+        Effect.provide(
+          Logger.replace(Logger.defaultLogger, JsonLoggerWithCause),
+        ),
+      ),
+    );
+    const call = spy.mock.calls.at(-1);
+    return call ? String(call[0]) : "";
+  } finally {
+    spy.mockRestore();
+  }
+};
+
+describe("JsonLoggerWithCause", () => {
+  test("serializes a native Error cause's message (not {} or [object Object])", async () => {
+    const out = await runAndCapture(
+      Effect.logError("boom").pipe(
+        Effect.annotateLogs({
+          service: "Test",
+          error: new Error("native detail"),
+        }),
+      ),
+    );
+    expect(out).toContain("native detail");
+    expect(out).not.toContain('"error":{}');
+  });
+
+  test("preserves a tagged error's _tag, fields, and nested native cause", async () => {
+    const out = await runAndCapture(
+      Effect.logError("failed").pipe(
+        Effect.annotateLogs({
+          service: "Test",
+          error: new DiscordApiError({
+            operation: "addMemberRole",
+            cause: new Error("403 Forbidden"),
+          }),
+        }),
+      ),
+    );
+    expect(out).toContain("DiscordApiError");
+    expect(out).toContain("addMemberRole");
+    expect(out).toContain("403 Forbidden");
+  });
+
+  test("emits the structured envelope keys", async () => {
+    const out = await runAndCapture(
+      Effect.logInfo("hello").pipe(Effect.annotateLogs({ service: "Test" })),
+    );
+    const parsed = JSON.parse(out);
+    expect(parsed.logLevel).toBe("INFO");
+    expect(parsed.annotations.service).toBe("Test");
+    expect(typeof parsed.timestamp).toBe("string");
+  });
+});

--- a/app/effects/logger.ts
+++ b/app/effects/logger.ts
@@ -1,0 +1,49 @@
+import { Cause, FiberId, Logger } from "effect";
+
+import { errorReplacer } from "#~/helpers/formatError";
+
+/**
+ * JSON logger that preserves Error causes. Effect's built-in `Logger.json`
+ * pre-collapses each annotation value through `Inspectable.toJSON`, which turns
+ * a native Error into `{}` before serialization — losing message/stack/cause.
+ *
+ * This logger keeps annotation values raw and serializes the whole record with
+ * `errorReplacer`, so native Errors and tagged-error causes serialize fully.
+ * Output shape matches `Logger.json` (message/logLevel/timestamp/cause/
+ * annotations/spans/fiberId) so log consumers are unaffected.
+ */
+export const JsonLoggerWithCause = Logger.make((options) => {
+  const { annotations, cause, date, fiberId, logLevel, message, spans } =
+    options;
+
+  const annotationsObj: Record<string, unknown> = {};
+  for (const [key, value] of annotations) {
+    annotationsObj[key] = value;
+  }
+
+  const now = date.getTime();
+  const spansObj: Record<string, number> = {};
+  for (const span of spans) {
+    spansObj[span.label] = now - span.startTime;
+  }
+
+  const record = {
+    message,
+    logLevel: logLevel.label,
+    timestamp: date.toISOString(),
+    cause: Cause.isEmpty(cause)
+      ? undefined
+      : Cause.pretty(cause, { renderErrorCause: true }),
+    annotations: annotationsObj,
+    spans: spansObj,
+    fiberId: FiberId.threadName(fiberId),
+  };
+
+  globalThis.console.log(JSON.stringify(record, errorReplacer));
+});
+
+/** Layer that replaces the default logger with the error-aware JSON logger. */
+export const JsonLoggerLayer = Logger.replace(
+  Logger.defaultLogger,
+  JsonLoggerWithCause,
+);

--- a/app/effects/logger.ts
+++ b/app/effects/logger.ts
@@ -3,12 +3,21 @@ import { Cause, FiberId, Logger } from "effect";
 import { errorReplacer } from "#~/helpers/formatError";
 
 /**
- * JSON logger that preserves Error causes. Effect's built-in `Logger.json`
- * pre-collapses each annotation value through `Inspectable.toJSON`, which turns
- * a native Error into `{}` before serialization — losing message/stack/cause.
+ * JSON logger that preserves Error causes in annotation values. Effect's
+ * built-in `Logger.json` pre-collapses each annotation value through
+ * `Inspectable.toJSON`, which turns a native Error into `{}` before
+ * serialization — losing message/stack/cause.
  *
  * This logger keeps annotation values raw and serializes the whole record with
- * `errorReplacer`, so native Errors and tagged-error causes serialize fully.
+ * `errorReplacer`, so native Errors and tagged errors passed as annotation
+ * values (e.g. `Effect.annotateLogs({ error })`) serialize fully with their
+ * `_tag`, fields, and nested cause.
+ *
+ * The fiber-level `cause` field (from a failed effect surfacing in
+ * `options.cause`) is rendered as a human-readable string via
+ * `Cause.pretty(cause, { renderErrorCause: true })`, matching `Logger.json`'s
+ * behavior — it is NOT run through `errorReplacer`.
+ *
  * Output shape matches `Logger.json` (message/logLevel/timestamp/cause/
  * annotations/spans/fiberId) so log consumers are unaffected.
  */

--- a/app/effects/posthog.ts
+++ b/app/effects/posthog.ts
@@ -75,7 +75,7 @@ export const syncGuildGroup = (guildId: string, guild?: Guild) =>
         Effect.sync(() =>
           log("warn", "PostHogService", "Failed to sync guild group", {
             guildId,
-            error: String(error),
+            error,
           }),
         ),
       ),

--- a/app/features/spam/service.ts
+++ b/app/features/spam/service.ts
@@ -268,7 +268,7 @@ export const SpamDetectionServiceLive = Layer.effect(
                 "error",
                 "SpamDetection",
                 "Spam check failed, falling through",
-                { error: String(error) },
+                { error },
               );
               // Spam detection failure should never block message processing
               return computeVerdict([]);
@@ -282,7 +282,7 @@ export const SpamDetectionServiceLive = Layer.effect(
           Effect.provide(Layer.succeed(DatabaseService, db)),
           Effect.catchAll((error) =>
             logEffect("error", "SpamDetection", "Response execution failed", {
-              error: String(error),
+              error,
             }),
           ),
           Effect.withSpan("SpamDetection.executeResponse"),

--- a/app/features/spam/spamResponseHandler.ts
+++ b/app/features/spam/spamResponseHandler.ts
@@ -9,6 +9,7 @@ import { Effect } from "effect";
 import { logUserMessage } from "#~/commands/report/userLog.ts";
 import { client } from "#~/discord/client.server.ts";
 import { deleteMessage, softbanMember } from "#~/effects/discordSdk.ts";
+import { isDiscordError } from "#~/effects/errorHandling.ts";
 import { logEffect } from "#~/effects/observability.ts";
 import { featureStats } from "#~/helpers/metrics.ts";
 import { applyRestriction, timeout } from "#~/models/discord.server.ts";
@@ -73,7 +74,7 @@ export const executeResponse = (
     // Medium and high: delete the message first
     yield* deleteMessage(message).pipe(
       Effect.tap(() => markMessageAsDeleted(message.id, guildId)),
-      Effect.catchTag("DiscordApiError", (e) =>
+      Effect.catchIf(isDiscordError, (e) =>
         logEffect("warn", "SpamResponse", "Failed to delete spam message", {
           error: e,
         }),
@@ -119,7 +120,7 @@ export const executeResponse = (
           "Autokicked for repeated spam (1h message cleanup)",
           3600,
         ).pipe(
-          Effect.catchTag("DiscordApiError", (error) =>
+          Effect.catchIf(isDiscordError, (error) =>
             logEffect("warn", "SpamResponse", "Failed to softban spammer", {
               error,
               operation: error.operation,
@@ -354,7 +355,7 @@ const executeSoftban = (
 ) =>
   Effect.gen(function* () {
     yield* softbanMember(member, "honeypot spam detected", 604800).pipe(
-      Effect.catchTag("DiscordApiError", (error) =>
+      Effect.catchIf(isDiscordError, (error) =>
         logEffect("error", "SpamResponse", "Failed to softban user", {
           error,
           operation: error.operation,

--- a/app/features/spam/spamResponseHandler.ts
+++ b/app/features/spam/spamResponseHandler.ts
@@ -75,7 +75,7 @@ export const executeResponse = (
       Effect.tap(() => markMessageAsDeleted(message.id, guildId)),
       Effect.catchTag("DiscordApiError", (e) =>
         logEffect("warn", "SpamResponse", "Failed to delete spam message", {
-          error: String(e.cause),
+          error: e,
         }),
       ),
     );
@@ -85,7 +85,7 @@ export const executeResponse = (
       yield* Effect.tryPromise(() => applyRestriction(member)).pipe(
         Effect.catchAll((error) =>
           logEffect("warn", "SpamResponse", "Failed to apply restriction", {
-            error: String(error),
+            error,
           }),
         ),
       );
@@ -99,7 +99,7 @@ export const executeResponse = (
       ).pipe(
         Effect.catchAll((error) =>
           logEffect("warn", "SpamResponse", "Failed to timeout user", {
-            error: String(error),
+            error,
           }),
         ),
       );
@@ -121,7 +121,7 @@ export const executeResponse = (
         ).pipe(
           Effect.catchTag("DiscordApiError", (error) =>
             logEffect("warn", "SpamResponse", "Failed to softban spammer", {
-              error: String(error.cause),
+              error,
               operation: error.operation,
             }),
           ),
@@ -135,7 +135,7 @@ export const executeResponse = (
               "warn",
               "SpamResponse",
               "Failed to delete reported messages after autokick",
-              { error: String(error), userId, guildId },
+              { error, userId, guildId },
             ),
           ),
         );
@@ -201,7 +201,7 @@ const checkCrossGuildSpam = (userId: string) =>
               "warn",
               "SpamResponse",
               "Failed to apply cross-guild timeout",
-              { error: String(error), guildId: guild.id, userId },
+              { error, guildId: guild.id, userId },
             ),
           ),
         ),
@@ -228,7 +228,7 @@ const checkCrossGuildSpam = (userId: string) =>
             "warn",
             "SpamResponse",
             "Failed to send cross-guild DM to user",
-            { error: String(error), userId },
+            { error, userId },
           ),
         ),
       );
@@ -253,7 +253,7 @@ const logSpamReport = (message: Message, verdict: SpamVerdict) =>
             "SpamResponse",
             "Failed to log spam report",
             {
-              error: String(error),
+              error,
             },
           );
           return null;
@@ -356,7 +356,7 @@ const executeSoftban = (
     yield* softbanMember(member, "honeypot spam detected", 604800).pipe(
       Effect.catchTag("DiscordApiError", (error) =>
         logEffect("error", "SpamResponse", "Failed to softban user", {
-          error: String(error.cause),
+          error,
           operation: error.operation,
           userId: member.id,
           guildId: message.guild!.id,

--- a/app/helpers/discord.ts
+++ b/app/helpers/discord.ts
@@ -25,7 +25,7 @@ import prettyBytes from "pretty-bytes";
 
 import type { RuntimeContext } from "#~/AppRuntime";
 import { resolveMessagePartial } from "#~/effects/discordSdk";
-import { NotFoundError, type DiscordApiError } from "#~/effects/errors.ts";
+import { NotFoundError, type DiscordError } from "#~/effects/errors.ts";
 import {
   getChars,
   getWords,
@@ -218,7 +218,7 @@ export interface MessageStats {
  */
 export const getMessageStats = (
   msg: Message | PartialMessage,
-): Effect.Effect<MessageStats, NotFoundError | DiscordApiError, never> =>
+): Effect.Effect<MessageStats, NotFoundError | DiscordError, never> =>
   Effect.gen(function* () {
     const message = yield* resolveMessagePartial(msg);
 

--- a/app/helpers/formatError.test.ts
+++ b/app/helpers/formatError.test.ts
@@ -1,0 +1,43 @@
+import { Data } from "effect";
+import { describe, expect, test } from "vitest";
+
+import { formatError } from "#~/helpers/formatError";
+
+class DiscordApiError extends Data.TaggedError("DiscordApiError")<{
+  operation: string;
+  cause: unknown;
+}> {}
+
+describe("formatError", () => {
+  test("preserves the _tag and structured fields of a tagged error", () => {
+    const err = new DiscordApiError({
+      operation: "addMemberRole",
+      cause: "403 Forbidden",
+    });
+    const out = formatError(err);
+    expect(out).toContain("DiscordApiError");
+    expect(out).toContain("addMemberRole");
+    expect(out).toContain("403 Forbidden");
+  });
+
+  test("returns a string unchanged", () => {
+    expect(formatError("already a string")).toBe("already a string");
+  });
+
+  test("serializes a native Error's message (not [object Object] or {})", () => {
+    const out = formatError(new Error("boom"));
+    expect(out).toContain("boom");
+    expect(out).not.toBe("[object Object]");
+    expect(out).not.toBe("{}");
+  });
+
+  test("serializes a native Error nested in a tagged error's cause", () => {
+    const err = new DiscordApiError({
+      operation: "deleteMessage",
+      cause: new Error("404 Unknown Message"),
+    });
+    const out = formatError(err);
+    expect(out).toContain("DiscordApiError");
+    expect(out).toContain("404 Unknown Message");
+  });
+});

--- a/app/helpers/formatError.ts
+++ b/app/helpers/formatError.ts
@@ -1,0 +1,33 @@
+/**
+ * JSON.stringify replacer that serializes Error objects, whose `message`,
+ * `stack`, and `cause` are non-enumerable and would otherwise vanish (yielding
+ * "{}"). Tagged errors (Data.TaggedError) already expose their fields and `_tag`
+ * as own enumerable properties, so they serialize without help.
+ */
+export const errorReplacer = (_key: string, value: unknown) => {
+  if (value instanceof Error) {
+    const errorObj: Record<string, unknown> = {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+    const cause = (value as { cause?: unknown }).cause;
+    if (cause !== undefined) {
+      errorObj.cause = cause;
+    }
+    return errorObj;
+  }
+  return value;
+};
+
+/**
+ * Render any error as a readable string for the rare contexts that genuinely
+ * need one — a DB column, a user-facing webhook alert, an analytics field.
+ *
+ * Prefer passing the error object through to a structured logger instead; only
+ * reach for this when an API requires a string. Unlike `String(error)`, this
+ * preserves the `_tag` discriminant and structured fields of tagged errors and
+ * the message/cause of native Errors.
+ */
+export const formatError = (error: unknown): string =>
+  typeof error === "string" ? error : JSON.stringify(error, errorReplacer);

--- a/app/helpers/observability.ts
+++ b/app/helpers/observability.ts
@@ -1,3 +1,4 @@
+import { errorReplacer } from "#~/helpers/formatError";
 import Sentry from "#~/helpers/sentry.server";
 
 // Structured logging with consistent format
@@ -19,23 +20,7 @@ export const log = (
 
   // Use structured logging for better parsing
   // Error objects have non-enumerable properties, so we need a replacer
-  console.log(
-    JSON.stringify(logEntry, (key, value) => {
-      if (value instanceof Error) {
-        const errorObj: Record<string, unknown> = {
-          name: value.name,
-          message: value.message,
-          stack: value.stack,
-        };
-        const cause = (value as { cause?: unknown }).cause;
-        if (cause !== undefined) {
-          errorObj.cause = cause;
-        }
-        return errorObj;
-      }
-      return value;
-    }),
-  );
+  console.log(JSON.stringify(logEntry, errorReplacer));
 };
 
 // Performance tracking helper

--- a/app/jobs/bulkRoleAssignment.test.ts
+++ b/app/jobs/bulkRoleAssignment.test.ts
@@ -10,6 +10,7 @@ import {
   vi,
 } from "vitest";
 
+import { DiscordAPIError } from "@discordjs/rest";
 import * as Reactivity from "@effect/experimental/Reactivity";
 import { SqlClient } from "@effect/sql";
 import * as Sqlite from "@effect/sql-kysely/Sqlite";
@@ -25,6 +26,18 @@ import {
   scanFinalCursorEffect,
 } from "./bulkRoleAssignment";
 import type { Job } from "./jobRunner";
+
+// Helper to construct a DiscordAPIError with a given HTTP status.
+// 403 → ForbiddenError (non-retriable), 404 → ResourceMissingError (recovered).
+const makeDiscordApiError = (status: number) =>
+  new DiscordAPIError(
+    { code: 0, message: "x" },
+    0,
+    status,
+    "PUT",
+    "https://discord/x",
+    { body: undefined, files: undefined },
+  );
 
 const { mockGet, mockPut, mockPatch } = vi.hoisted(() => {
   const mockGet = vi.fn();
@@ -196,9 +209,11 @@ describe("processBatchEffect", () => {
       { user: { id: "1099511627776", bot: false } },
       { user: { id: "1099511627777", bot: false } },
     ]);
+    // Use a non-retriable 403 (ForbiddenError) so the failure is immediate;
+    // a plain Error would be classified as TransientError and retried up to 4×.
     mockPut
       .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(new Error("left guild"));
+      .mockRejectedValueOnce(makeDiscordApiError(403));
 
     const result = await Effect.runPromise(
       processBatchEffect({
@@ -250,6 +265,56 @@ describe("processBatchEffect", () => {
 
     expect(result.done).toBe(true);
     expect(result.assigned).toBe(0);
+  });
+
+  it("a missing member is recovered (not counted as error)", async () => {
+    // 404 → ResourceMissingError; the pipeline recovers it with Effect.void
+    // (success-equivalent). The batch should complete without errors.
+    mockGet.mockResolvedValue([
+      { user: { id: "1099511627776", bot: false } },
+      { user: { id: "1099511627777", bot: false } },
+    ]);
+    mockPut
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(makeDiscordApiError(404));
+
+    const result = await Effect.runPromise(
+      processBatchEffect({
+        guildId: "guild-1",
+        roleId: "role-1",
+        cursor: { after: "0" },
+        finalCursor: { lastMemberId: "9999999999999999999", memberCount: 2 },
+        batchSize: 1000,
+      }),
+    );
+
+    expect(result.errors).toBe(0);
+    // The recovered member counts as success-equivalent
+    expect(result.assigned).toBe(2);
+  });
+
+  it("a forbidden member is counted and the batch continues", async () => {
+    // 403 → ForbiddenError; not retried, counted as error, batch continues.
+    mockGet.mockResolvedValue([
+      { user: { id: "1099511627776", bot: false } },
+      { user: { id: "1099511627777", bot: false } },
+    ]);
+    mockPut
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(makeDiscordApiError(403));
+
+    const result = await Effect.runPromise(
+      processBatchEffect({
+        guildId: "guild-1",
+        roleId: "role-1",
+        cursor: { after: "0" },
+        finalCursor: { lastMemberId: "9999999999999999999", memberCount: 2 },
+        batchSize: 1000,
+      }),
+    );
+
+    expect(result.assigned).toBe(1);
+    expect(result.errors).toBe(1);
   });
 });
 
@@ -398,7 +463,9 @@ describe("executeJobEffect", () => {
         // batch
         { user: { id: "1099511627776", bot: false } },
       ]);
-    mockPut.mockRejectedValue(new Error("Discord error"));
+    // Use a non-retriable 403 (ForbiddenError) so the failure is immediate;
+    // a plain Error would be classified as TransientError and retried, making this slow.
+    mockPut.mockRejectedValue(makeDiscordApiError(403));
 
     await runTest(executeJobEffect(makeJob() as unknown as Job));
 

--- a/app/jobs/bulkRoleAssignment.ts
+++ b/app/jobs/bulkRoleAssignment.ts
@@ -10,6 +10,7 @@ import { Effect } from "effect";
 import { DatabaseService } from "#~/Database";
 import { ssrDiscordSdk } from "#~/discord/api";
 import { tryDiscord } from "#~/effects/classifyDiscordError";
+import { withRetry } from "#~/effects/errorHandling";
 import { logEffect } from "#~/effects/observability";
 
 import {
@@ -123,11 +124,26 @@ export const processBatchEffect = (options: ProcessBatchOptions) =>
 
       if (member.user.bot) continue;
 
+      // Decision: do NOT escalateExhausted per-member. One member's outage must
+      // not abort a 100k-member migration. withRetry handles transient blips
+      // (RateLimit/Transient) with capped backoff. ResourceMissingError (member
+      // already left) is recovered silently as success-equivalent — assigning a
+      // role to a departed member is a no-op outcome, not a failure.
+      // ForbiddenError, ClientError, and exhausted-Transient fall through to
+      // the else branch below, where they are counted and logged with their full
+      // typed payload. The batch-level failJobEffect (called when totalErrors > 0)
+      // handles job-level abort. escalateExhausted is reserved for command
+      // handlers (Task 9) where a single failure IS the whole outcome.
       const exit = yield* tryDiscord("addMemberRole", () =>
         ssrDiscordSdk.put(
           Routes.guildMemberRole(guildId, member.user.id, roleId),
         ),
-      ).pipe(Effect.exit);
+      ).pipe(
+        withRetry, // RateLimit/Transient retried with capped backoff
+        // member already gone → success-equivalent, drop silently
+        Effect.catchTag("ResourceMissingError", () => Effect.void),
+        Effect.exit,
+      );
 
       if (exit._tag === "Success") {
         assigned++;

--- a/app/jobs/bulkRoleAssignment.ts
+++ b/app/jobs/bulkRoleAssignment.ts
@@ -149,7 +149,7 @@ export const processBatchEffect = (options: ProcessBatchOptions) =>
           {
             guildId,
             userId: member.user.id,
-            error: String(exit.cause),
+            error: exit.cause,
           },
         );
       }
@@ -243,7 +243,7 @@ export const activateMembershipGateEffect = (
       "Failed to deny @everyone ViewChannel — rolling back member role to original permissions. " +
         "Server is in original state; no members lost access. " +
         "Re-run /setup or manually update @everyone permissions.",
-      { guildId, error: String(denyExit.cause) },
+      { guildId, error: denyExit.cause },
     );
 
     const rollbackExit = yield* Effect.tryPromise({
@@ -261,7 +261,7 @@ export const activateMembershipGateEffect = (
         "BulkRoleAssignment",
         "Rollback also failed — member role has extra ViewChannel but @everyone unchanged. " +
           "This is safe (extra access, not lost access).",
-        { guildId, error: String(rollbackExit.cause) },
+        { guildId, error: rollbackExit.cause },
       );
     }
 

--- a/app/jobs/bulkRoleAssignment.ts
+++ b/app/jobs/bulkRoleAssignment.ts
@@ -9,7 +9,7 @@ import { Effect } from "effect";
 
 import { DatabaseService } from "#~/Database";
 import { ssrDiscordSdk } from "#~/discord/api";
-import { DiscordApiError } from "#~/effects/errors";
+import { tryDiscord } from "#~/effects/classifyDiscordError";
 import { logEffect } from "#~/effects/observability";
 
 import {
@@ -63,14 +63,11 @@ export const scanFinalCursorEffect = (guildId: string) =>
     let after = "0";
     let memberCount = 0;
     while (true) {
-      const page = (yield* Effect.tryPromise({
-        try: () =>
-          ssrDiscordSdk.get(Routes.guildMembers(guildId), {
-            query: new URLSearchParams({ limit: "1000", after }),
-          }),
-        catch: (error) =>
-          new DiscordApiError({ operation: "listGuildMembers", cause: error }),
-      })) as APIGuildMember[];
+      const page = (yield* tryDiscord("listGuildMembers", () =>
+        ssrDiscordSdk.get(Routes.guildMembers(guildId), {
+          query: new URLSearchParams({ limit: "1000", after }),
+        }),
+      )) as APIGuildMember[];
       if (page.length === 0) break;
       memberCount += page.length;
       const lastUser = page[page.length - 1].user;
@@ -91,17 +88,14 @@ export const processBatchEffect = (options: ProcessBatchOptions) =>
   Effect.gen(function* () {
     const { guildId, roleId, cursor, finalCursor, batchSize } = options;
 
-    const members = (yield* Effect.tryPromise({
-      try: () =>
-        ssrDiscordSdk.get(Routes.guildMembers(guildId), {
-          query: new URLSearchParams({
-            limit: String(batchSize),
-            after: cursor.after,
-          }),
+    const members = (yield* tryDiscord("listGuildMembers", () =>
+      ssrDiscordSdk.get(Routes.guildMembers(guildId), {
+        query: new URLSearchParams({
+          limit: String(batchSize),
+          after: cursor.after,
         }),
-      catch: (error) =>
-        new DiscordApiError({ operation: "listGuildMembers", cause: error }),
-    })) as APIGuildMember[];
+      }),
+    )) as APIGuildMember[];
 
     if (members.length === 0) {
       return {
@@ -129,14 +123,11 @@ export const processBatchEffect = (options: ProcessBatchOptions) =>
 
       if (member.user.bot) continue;
 
-      const exit = yield* Effect.tryPromise({
-        try: () =>
-          ssrDiscordSdk.put(
-            Routes.guildMemberRole(guildId, member.user.id, roleId),
-          ),
-        catch: (error) =>
-          new DiscordApiError({ operation: "addMemberRole", cause: error }),
-      }).pipe(Effect.exit);
+      const exit = yield* tryDiscord("addMemberRole", () =>
+        ssrDiscordSdk.put(
+          Routes.guildMemberRole(guildId, member.user.id, roleId),
+        ),
+      ).pipe(Effect.exit);
 
       if (exit._tag === "Success") {
         assigned++;
@@ -186,19 +177,13 @@ export const activateMembershipGateEffect = (
     const everyonePerms = BigInt(everyonePermissions);
 
     // Step 1: Grant ViewChannel on @member role (safe — adds access)
-    yield* Effect.tryPromise({
-      try: () =>
-        ssrDiscordSdk.patch(Routes.guildRole(guildId, roleId), {
-          body: {
-            permissions: String(memberPerms | PermissionFlagsBits.ViewChannel),
-          },
-        }),
-      catch: (error) =>
-        new DiscordApiError({
-          operation: "grantMemberViewChannel",
-          cause: error,
-        }),
-    });
+    yield* tryDiscord("grantMemberViewChannel", () =>
+      ssrDiscordSdk.patch(Routes.guildRole(guildId, roleId), {
+        body: {
+          permissions: String(memberPerms | PermissionFlagsBits.ViewChannel),
+        },
+      }),
+    );
 
     yield* logEffect(
       "info",
@@ -208,23 +193,17 @@ export const activateMembershipGateEffect = (
     );
 
     // Step 2: Deny ViewChannel on @everyone (dangerous — removes access)
-    const denyExit = yield* Effect.tryPromise({
-      try: () =>
-        ssrDiscordSdk.patch(Routes.guildRole(guildId, guildId), {
-          body: {
-            permissions: String(
-              everyonePerms &
-                ~PermissionFlagsBits.ViewChannel &
-                ~PermissionFlagsBits.MentionEveryone,
-            ),
-          },
-        }),
-      catch: (error) =>
-        new DiscordApiError({
-          operation: "denyEveryoneViewChannel",
-          cause: error,
-        }),
-    }).pipe(Effect.exit);
+    const denyExit = yield* tryDiscord("denyEveryoneViewChannel", () =>
+      ssrDiscordSdk.patch(Routes.guildRole(guildId, guildId), {
+        body: {
+          permissions: String(
+            everyonePerms &
+              ~PermissionFlagsBits.ViewChannel &
+              ~PermissionFlagsBits.MentionEveryone,
+          ),
+        },
+      }),
+    ).pipe(Effect.exit);
 
     if (denyExit._tag === "Success") {
       yield* logEffect(
@@ -246,14 +225,11 @@ export const activateMembershipGateEffect = (
       { guildId, error: denyExit.cause },
     );
 
-    const rollbackExit = yield* Effect.tryPromise({
-      try: () =>
-        ssrDiscordSdk.patch(Routes.guildRole(guildId, roleId), {
-          body: { permissions: String(memberPerms) },
-        }),
-      catch: (error) =>
-        new DiscordApiError({ operation: "rollbackMemberRole", cause: error }),
-    }).pipe(Effect.exit);
+    const rollbackExit = yield* tryDiscord("rollbackMemberRole", () =>
+      ssrDiscordSdk.patch(Routes.guildRole(guildId, roleId), {
+        body: { permissions: String(memberPerms) },
+      }),
+    ).pipe(Effect.exit);
 
     if (rollbackExit._tag === "Failure") {
       yield* logEffect(
@@ -323,22 +299,16 @@ const executePhase1Effect = (job: Job, payload: BulkRoleAssignmentPayload) =>
             ? `~${estimatedHours}h ${remainingMinutes}m`
             : `~${estimatedMinutes}m`;
 
-        yield* Effect.tryPromise({
-          try: () =>
-            ssrDiscordSdk.post(Routes.channelMessages(job.notify_channel_id!), {
-              body: {
-                content:
-                  `**Member role migration started**\n` +
-                  `Assigning <@&${payload.roleId}> to ~${finalCursor.memberCount.toLocaleString()} existing members.\n` +
-                  `Estimated time: ${timeEstimate}. Progress updates will be posted every 30 minutes.`,
-              },
-            }),
-          catch: (error) =>
-            new DiscordApiError({
-              operation: "notifyMigrationStart",
-              cause: error,
-            }),
-        }).pipe(Effect.catchAll(() => Effect.void));
+        yield* tryDiscord("notifyMigrationStart", () =>
+          ssrDiscordSdk.post(Routes.channelMessages(job.notify_channel_id!), {
+            body: {
+              content:
+                `**Member role migration started**\n` +
+                `Assigning <@&${payload.roleId}> to ~${finalCursor.memberCount.toLocaleString()} existing members.\n` +
+                `Estimated time: ${timeEstimate}. Progress updates will be posted every 30 minutes.`,
+            },
+          }),
+        ).pipe(Effect.catchAll(() => Effect.void));
       }
     }
 
@@ -393,22 +363,16 @@ const executePhase1Effect = (job: Job, payload: BulkRoleAssignmentPayload) =>
             ? Math.round((totalAssigned / totalMembers) * 100)
             : 0;
 
-        yield* Effect.tryPromise({
-          try: () =>
-            ssrDiscordSdk.post(Routes.channelMessages(job.notify_channel_id!), {
-              body: {
-                content:
-                  `**Member role migration progress**\n` +
-                  `${totalAssigned.toLocaleString()} / ~${totalMembers.toLocaleString()} members (${pct}%)\n` +
-                  `Estimated time remaining: ${eta}`,
-              },
-            }),
-          catch: (error) =>
-            new DiscordApiError({
-              operation: "notifyProgress",
-              cause: error,
-            }),
-        }).pipe(Effect.catchAll(() => Effect.void));
+        yield* tryDiscord("notifyProgress", () =>
+          ssrDiscordSdk.post(Routes.channelMessages(job.notify_channel_id!), {
+            body: {
+              content:
+                `**Member role migration progress**\n` +
+                `${totalAssigned.toLocaleString()} / ~${totalMembers.toLocaleString()} members (${pct}%)\n` +
+                `Estimated time remaining: ${eta}`,
+            },
+          }),
+        ).pipe(Effect.catchAll(() => Effect.void));
       }
 
       if (result.errors > 0) {

--- a/app/jobs/jobRunner.ts
+++ b/app/jobs/jobRunner.ts
@@ -9,6 +9,7 @@ import { ssrDiscordSdk } from "#~/discord/api";
 import { DiscordApiError } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import { jobMetaRef, type ActiveJobMeta } from "#~/effects/supervisor";
+import { formatError } from "#~/helpers/formatError";
 
 export type Job = Selectable<DB["background_jobs"]>;
 
@@ -323,7 +324,7 @@ const notifyChannelEffect = (channelId: string, job: Job) =>
       Effect.catchAll((err) =>
         logEffect("warn", "JobRunner", "Failed to send progress notification", {
           channelId,
-          error: String(err),
+          error: err,
         }),
       ),
     );
@@ -358,10 +359,10 @@ export const pollAndExecuteEffect = Effect.gen(function* () {
           "Unhandled error in job execution",
           {
             jobId: job.id,
-            error: String(err),
+            error: err,
           },
         );
-        yield* failJobEffect(job.id, `Unhandled: ${String(err)}`);
+        yield* failJobEffect(job.id, `Unhandled: ${formatError(err)}`);
       }),
     ),
     Effect.fork, // Fork as child fiber — visible to Supervisor
@@ -378,7 +379,7 @@ export const pollAndExecuteEffect = Effect.gen(function* () {
   // Catch errors from claimNextJob (e.g., SqlError) so the loop continues
   Effect.catchAll((err) =>
     logEffect("error", "JobRunner", "Poll cycle failed", {
-      error: String(err),
+      error: err,
     }),
   ),
   Effect.withSpan("pollAndExecute"),

--- a/app/jobs/jobRunner.ts
+++ b/app/jobs/jobRunner.ts
@@ -6,7 +6,8 @@ import { runEffect } from "#~/AppRuntime";
 import { DatabaseService, type SqlError } from "#~/Database";
 import type { DB } from "#~/db";
 import { ssrDiscordSdk } from "#~/discord/api";
-import { DiscordApiError } from "#~/effects/errors";
+import { tryDiscord } from "#~/effects/classifyDiscordError";
+import { type DiscordError } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import { jobMetaRef, type ActiveJobMeta } from "#~/effects/supervisor";
 import { formatError } from "#~/helpers/formatError";
@@ -266,7 +267,7 @@ export const createJob = (options: CreateJobOptions): Promise<Job> =>
 
 type JobHandler = (
   job: Job,
-) => Effect.Effect<void, DiscordApiError | SqlError, DatabaseService>;
+) => Effect.Effect<void, DiscordError | SqlError, DatabaseService>;
 
 const handlers: Record<string, JobHandler> = {};
 
@@ -313,14 +314,11 @@ const notifyChannelEffect = (channelId: string, job: Job) =>
 
     if (!body) return;
 
-    yield* Effect.tryPromise({
-      try: () =>
-        ssrDiscordSdk.post(Routes.channelMessages(channelId), {
-          body,
-        }),
-      catch: (error) =>
-        new DiscordApiError({ operation: "notifyChannel", cause: error }),
-    }).pipe(
+    yield* tryDiscord("notifyChannel", () =>
+      ssrDiscordSdk.post(Routes.channelMessages(channelId), {
+        body,
+      }),
+    ).pipe(
       Effect.catchAll((err) =>
         logEffect("warn", "JobRunner", "Failed to send progress notification", {
           channelId,

--- a/app/models/deletionLogThreads.ts
+++ b/app/models/deletionLogThreads.ts
@@ -10,12 +10,17 @@ import type { Selectable } from "kysely";
 
 import { DatabaseService, type SqlError } from "#~/Database";
 import type { DB } from "#~/db";
+import { tryDiscord } from "#~/effects/classifyDiscordError";
 import { fetchChannel } from "#~/effects/discordSdk.ts";
-import { DiscordApiError, type NotFoundError } from "#~/effects/errors";
+import {
+  TransientError,
+  type DiscordError,
+  type NotFoundError,
+} from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
 
-type ThreadError = DiscordApiError | SqlError | NotFoundError;
+type ThreadError = DiscordError | SqlError | NotFoundError;
 
 export type DeletionLogThread = Selectable<DB["deletion_log_threads"]>;
 
@@ -93,11 +98,9 @@ export const upsertDeletionLogThread = (
   );
 
 const makeDeletionLogThread = (channel: TextChannel, user: User) =>
-  Effect.tryPromise({
-    try: () => channel.threads.create({ name: `${user.username} messages` }),
-    catch: (error) =>
-      new DiscordApiError({ operation: "createThread", cause: error }),
-  });
+  tryDiscord("createThread", () =>
+    channel.threads.create({ name: `${user.username} messages` }),
+  );
 
 type InflightResult =
   | {
@@ -193,7 +196,8 @@ const doGetOrCreateDeletionLogThread = (guild: Guild, user: User) =>
 
     if (!deletionLogId) {
       return yield* Effect.fail(
-        new DiscordApiError({
+        new TransientError({
+          source: "discord",
           operation: "getOrCreateDeletionLogThread",
           cause: new Error("Deletion log channel not configured"),
         }),
@@ -204,7 +208,8 @@ const doGetOrCreateDeletionLogThread = (guild: Guild, user: User) =>
 
     if (!deletionLog || deletionLog.type !== ChannelType.GuildText) {
       return yield* Effect.fail(
-        new DiscordApiError({
+        new TransientError({
+          source: "discord",
           operation: "getOrCreateDeletionLogThread",
           cause: new Error("Invalid deletion log channel"),
         }),

--- a/app/models/reportedMessages.ts
+++ b/app/models/reportedMessages.ts
@@ -574,7 +574,7 @@ const deleteSingleMessage = (
           "Failed to delete message",
           {
             messageId,
-            error: error instanceof Error ? error.message : String(error),
+            error,
           },
         );
         return { success: false as const, messageId, error };

--- a/app/models/reportedMessages.ts
+++ b/app/models/reportedMessages.ts
@@ -5,6 +5,7 @@ import type { Selectable } from "kysely";
 import { DatabaseService } from "#~/Database";
 import type { DB } from "#~/db";
 import { client } from "#~/discord/client.server";
+import { tryDiscord } from "#~/effects/classifyDiscordError";
 import { logEffect } from "#~/effects/observability";
 
 export type ReportedMessage = Selectable<DB["reported_messages"]>;
@@ -531,24 +532,15 @@ const deleteSingleMessage = (
       return { success: false as const, messageId, error: "Channel not found" };
     }
 
-    const result = yield* Effect.tryPromise({
-      try: async () => {
-        const message = await channel.messages.fetch(messageId);
-        await message.delete();
-        return { deleted: true };
-      },
-      catch: (error) => error,
+    const result = yield* tryDiscord("deleteReportedMessage", async () => {
+      const message = await channel.messages.fetch(messageId);
+      await message.delete();
+      return { deleted: true as const };
     }).pipe(
-      Effect.catchAll((error) => {
-        // If message is already deleted, that's fine - mark it as deleted in DB
-        if (
-          error instanceof Error &&
-          error.message.includes("Unknown Message")
-        ) {
-          return Effect.succeed({ deleted: false, alreadyGone: true });
-        }
-        return Effect.fail(error);
-      }),
+      // Message already gone (404) → recover as alreadyGone.
+      Effect.catchTag("ResourceMissingError", () =>
+        Effect.succeed({ deleted: false as const, alreadyGone: true as const }),
+      ),
     );
 
     // Mark as deleted in database

--- a/app/models/userThreads.ts
+++ b/app/models/userThreads.ts
@@ -10,13 +10,18 @@ import type { Selectable } from "kysely";
 
 import { DatabaseService, type SqlError } from "#~/Database";
 import type { DB } from "#~/db";
+import { tryDiscord } from "#~/effects/classifyDiscordError";
 import { fetchChannel } from "#~/effects/discordSdk.ts";
-import { DiscordApiError, type NotFoundError } from "#~/effects/errors";
+import {
+  TransientError,
+  type DiscordError,
+  type NotFoundError,
+} from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import { escalationControls } from "#~/helpers/escalate";
 import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
 
-type ThreadError = DiscordApiError | SqlError | NotFoundError;
+type ThreadError = DiscordError | SqlError | NotFoundError;
 
 // Use Selectable to get the type that Kysely returns from queries
 export type UserThread = Selectable<DB["user_threads"]>;
@@ -90,11 +95,9 @@ export const upsertUserThread = (
   );
 
 const makeUserThread = (channel: TextChannel, user: User) =>
-  Effect.tryPromise({
-    try: () => channel.threads.create({ name: `${user.username} logs` }),
-    catch: (error) =>
-      new DiscordApiError({ operation: "createThread", cause: error }),
-  });
+  tryDiscord("createThread", () =>
+    channel.threads.create({ name: `${user.username} logs` }),
+  );
 
 /**
  * Get or create a user thread with singleflight deduplication.
@@ -199,7 +202,8 @@ const doGetOrCreateUserThread = (guild: Guild, user: User) =>
 
     if (!modLog || modLog.type !== ChannelType.GuildText) {
       return yield* Effect.fail(
-        new DiscordApiError({
+        new TransientError({
+          source: "discord",
           operation: "getOrCreateUserThread",
           cause: new Error("Invalid mod log channel"),
         }),
@@ -209,11 +213,9 @@ const doGetOrCreateUserThread = (guild: Guild, user: User) =>
     // Create freestanding private thread
     const thread = yield* makeUserThread(modLog, user);
 
-    yield* Effect.tryPromise({
-      try: () => escalationControls(user.id, thread),
-      catch: (error) =>
-        new DiscordApiError({ operation: "escalationControls", cause: error }),
-    });
+    yield* tryDiscord("escalationControls", () =>
+      escalationControls(user.id, thread),
+    );
 
     // Store or update the thread reference
     yield* upsertUserThread(user.id, guild.id, thread.id);

--- a/app/routes/auth.tsx
+++ b/app/routes/auth.tsx
@@ -47,9 +47,9 @@ export async function action({ request }: Route.ActionArgs) {
 
   return initOauthLogin({
     request,
-    // redirectTo is FormDataEntryValue (string | File); File has no meaningful
-    // toString, but in practice this field is always a string from the form.
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    redirectTo: redirectTo?.toString() ?? "/app",
+    // redirectTo is FormDataEntryValue (string | File); in practice this field is
+    // always a string from the form. Narrow rather than stringify so a stray File
+    // falls back to "/app" instead of "[object File]".
+    redirectTo: typeof redirectTo === "string" ? redirectTo : "/app",
   });
 }

--- a/app/routes/auth.tsx
+++ b/app/routes/auth.tsx
@@ -47,6 +47,8 @@ export async function action({ request }: Route.ActionArgs) {
 
   return initOauthLogin({
     request,
+    // redirectTo is FormDataEntryValue (string | File); File has no meaningful
+    // toString, but in practice this field is always a string from the form.
     // eslint-disable-next-line @typescript-eslint/no-base-to-string
     redirectTo: redirectTo?.toString() ?? "/app",
   });

--- a/app/server.ts
+++ b/app/server.ts
@@ -149,7 +149,7 @@ const startup = Effect.gen(function* () {
               "MessageCacheExpiration",
               "Expiration run failed",
               {
-                error: String(e),
+                error: e,
               },
             ),
           ),

--- a/app/server.ts
+++ b/app/server.ts
@@ -46,7 +46,7 @@ import { runJobRunner } from "#~/jobs/jobRunner";
 
 import { runEffect, runtime } from "./AppRuntime";
 import { checkpointWal, runIntegrityCheck } from "./Database";
-import { DiscordApiError } from "./effects/errors";
+import { tryDiscord } from "./effects/classifyDiscordError";
 import { logEffect } from "./effects/observability";
 import { initializeGroups } from "./effects/posthog";
 import { botStats } from "./helpers/metrics";
@@ -129,11 +129,7 @@ const startup = Effect.gen(function* () {
   if (!globalThis.__discordOneTimeSetupDone) {
     globalThis.__discordOneTimeSetupDone = true;
 
-    yield* Effect.tryPromise({
-      try: () => deployCommands(discordClient),
-      catch: (error) =>
-        new DiscordApiError({ operation: "init", cause: error }),
-    });
+    yield* tryDiscord("init", () => deployCommands(discordClient));
 
     // Message cache expiration (was inside startDeletionLogging, now standalone)
     startMessageCacheExpiration(() =>

--- a/eslint-rules/no-error-string-cast.js
+++ b/eslint-rules/no-error-string-cast.js
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview Flag stringifying typed Effect errors. `Data.TaggedError`
+ * instances have a custom `toString()` that returns only the `_tag` (e.g.
+ * `"DiscordApiError"`), so `String(error)` / `${error}` silently drops the
+ * `cause` chain and every structured field. `@typescript-eslint/no-base-to-string`
+ * does NOT catch this (the custom toString isn't "base"), hence this rule.
+ *
+ * The fix is always to pass the error through directly — `logEffect` runs it
+ * through Effect's JSON logger, which serializes `_tag` and the tagged fields.
+ *
+ */
+
+// Identifiers conventionally bound to errors in this codebase.
+const ERROR_NAMES = new Set(["error", "err", "e", "cause"]);
+
+// Effect error-channel handlers whose first arrow param is the error/cause,
+// even when named something other than the conventional names above.
+const CATCH_METHODS = new Set([
+  "catchAll",
+  "catchAllCause",
+  "catchTag",
+  "catchTags",
+]);
+
+/** Is this arrow the handler argument of `X.catchAll(...)` / `X.catchTag(...)` etc.? */
+function isCatchHandler(arrow) {
+  const call = arrow.parent;
+  return (
+    call?.type === "CallExpression" &&
+    call.callee.type === "MemberExpression" &&
+    call.callee.property.type === "Identifier" &&
+    CATCH_METHODS.has(call.callee.property.name) &&
+    call.arguments.includes(arrow)
+  );
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow stringifying typed Effect errors; pass them through to logEffect instead",
+    },
+    schema: [],
+    messages: {
+      noStringify:
+        "Don't stringify errors — pass the tagged error through; logEffect serializes structured payloads.",
+    },
+  },
+  create(context) {
+    // Stack of active catch-handler param-name sets, so an error-channel
+    // param is recognized even when not named error/err/e/cause.
+    const catchParams = [];
+    const catchParamActive = (name) => catchParams.some((s) => s.has(name));
+
+    /** Does stringifying this expression destroy an error payload? */
+    const isErrorish = (node) => {
+      if (node.type === "Identifier") {
+        return ERROR_NAMES.has(node.name) || catchParamActive(node.name);
+      }
+      // `x.cause` — stringifying a cause is always lossy, whatever `x` is named.
+      return (
+        node.type === "MemberExpression" &&
+        !node.computed &&
+        node.property.type === "Identifier" &&
+        node.property.name === "cause"
+      );
+    };
+
+    return {
+      ArrowFunctionExpression(node) {
+        if (isCatchHandler(node)) {
+          catchParams.push(
+            new Set(
+              node.params
+                .filter((p) => p.type === "Identifier")
+                .map((p) => p.name),
+            ),
+          );
+        }
+      },
+      "ArrowFunctionExpression:exit"(node) {
+        if (isCatchHandler(node)) catchParams.pop();
+      },
+      // String(error) — and only the global String, not a shadowed local.
+      CallExpression(node) {
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "String" &&
+          node.arguments.length === 1 &&
+          isErrorish(node.arguments[0])
+        ) {
+          context.report({ node, messageId: "noStringify" });
+        }
+      },
+      // `${error}` in a template literal expression position.
+      TemplateLiteral(node) {
+        for (const expr of node.expressions) {
+          if (isErrorish(expr)) {
+            context.report({ node: expr, messageId: "noStringify" });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint-rules/no-error-string-cast.test.ts
+++ b/eslint-rules/no-error-string-cast.test.ts
@@ -1,0 +1,85 @@
+import { RuleTester } from "eslint";
+
+import tsParser from "@typescript-eslint/parser";
+
+import rule from "./no-error-string-cast.js";
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tsParser,
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+ruleTester.run("no-error-string-cast", rule, {
+  valid: [
+    // Passing the error through directly is the whole point.
+    `logEffect("error", "Svc", "failed", { error });`,
+    `logEffect("error", "Svc", "failed", { error: err });`,
+    // Non-error values may legitimately be stringified.
+    `const limit = String(batchSize);`,
+    `const perms = String(memberPerms | PermissionFlagsBits.ViewChannel);`,
+    `const month = String(row.month);`,
+    `const stamp = String(d.getMonth() + 1);`,
+    // Template literals over non-error values are fine.
+    "const msg = `count: ${count}`;",
+    // Member access that isn't `.cause` is fine.
+    `const s = String(error.message);`,
+    // An identifier merely named like an error but not stringified is fine.
+    `const guild = e.guild;`,
+  ],
+  invalid: [
+    // Bare error-named identifiers.
+    {
+      code: `const s = String(error);`,
+      errors: [{ messageId: "noStringify" }],
+    },
+    {
+      code: `const s = String(err);`,
+      errors: [{ messageId: "noStringify" }],
+    },
+    {
+      code: `const s = String(e);`,
+      errors: [{ messageId: "noStringify" }],
+    },
+    // Inside a logEffect context object.
+    {
+      code: `logEffect("error", "Svc", "failed", { error: String(error) });`,
+      errors: [{ messageId: "noStringify" }],
+    },
+    // `.cause` member access is always wrong to stringify, regardless of the
+    // object's name (covers Effect Exit causes like `String(exit.cause)`).
+    {
+      code: `const s = String(error.cause);`,
+      errors: [{ messageId: "noStringify" }],
+    },
+    {
+      code: `const s = String(exit.cause);`,
+      errors: [{ messageId: "noStringify" }],
+    },
+    // Error identifiers in template-literal expression positions.
+    {
+      code: "const s = `boom: ${error}`;",
+      errors: [{ messageId: "noStringify" }],
+    },
+    {
+      code: "yield* failJobEffect(job.id, `Unhandled: ${String(err)}`);",
+      errors: [{ messageId: "noStringify" }],
+    },
+    // new Error(String(error)) — the inner cast is flagged.
+    {
+      code: `const wrapped = new Error(String(error));`,
+      errors: [{ messageId: "noStringify" }],
+    },
+    // catchAll/catchTag/catchAllCause arrow param, even with a non-matching name.
+    {
+      code: `pipe(self, Effect.catchAll((failure) => String(failure)));`,
+      errors: [{ messageId: "noStringify" }],
+    },
+    {
+      code: `pipe(self, Effect.catchTag("X", (boom) => logEffect("error", "S", "m", { error: String(boom) })));`,
+      errors: [{ messageId: "noStringify" }],
+    },
+  ],
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,14 @@ import tseslint from "typescript-eslint";
 import { FlatCompat } from "@eslint/eslintrc";
 import pluginJs from "@eslint/js";
 
+import noErrorStringCast from "./eslint-rules/no-error-string-cast.js";
+
 const compat = new FlatCompat();
+
+// Local rules for codebase conventions the shared plugins can't know about.
+const localPlugin = {
+  rules: { "no-error-string-cast": noErrorStringCast },
+};
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
@@ -64,6 +71,7 @@ export default [
     ],
   },
   {
+    plugins: { local: localPlugin },
     rules: {
       // General JavaScript rules
       "no-debugger": "warn",
@@ -111,8 +119,39 @@ export default [
       "@typescript-eslint/require-await": "off",
       "@typescript-eslint/prefer-nullish-coalescing": "warn",
 
+      // Errors are tagged (Data.TaggedError) — stringifying them collapses the
+      // _tag discriminant, cause chain, and structured fields into "[object
+      // Object]" or a useless top-line. Pass the typed error through to
+      // logEffect, which serializes the structured payload. See issue #366 and
+      // the no-error-string-cast rule below.
+      "@typescript-eslint/no-base-to-string": "error",
+
+      // Pass typed Effect errors through to logEffect instead of stringifying
+      // them — String(taggedError) collapses to just the _tag. See issue #366.
+      "local/no-error-string-cast": "warn",
+
       "no-console": "off",
       "@typescript-eslint/unbound-method": "off",
     },
+  },
+  {
+    // These three run in async/await + discord.js event zones, not Effect: the
+    // caught value is `unknown` from a try/catch or Promise `.catch`, not a
+    // typed tagged error, and they use the legacy `log` helper. The
+    // instanceof-Error pattern here is a separate concern (see issue #366
+    // "Out of scope"); a future async-zone rule should cover them.
+    files: [
+      "app/discord/api.ts",
+      "app/discord/client.server.ts",
+      "app/discord/gateway.ts",
+    ],
+    rules: { "local/no-error-string-cast": "off" },
+  },
+  {
+    // Local ESLint rule modules are plain-JS tooling (untyped AST callbacks),
+    // not app code — type-aware lint rules produce false positives here. This
+    // must come last so it overrides the global type-checked rule block above.
+    files: ["eslint-rules/**/*.js"],
+    ...tseslint.configs.disableTypeChecked,
   },
 ];

--- a/notes/EFFECT.md
+++ b/notes/EFFECT.md
@@ -122,6 +122,8 @@ effect.pipe(
 Discord transport errors live in `app/effects/errors.ts` and are named by the
 decision they drive, not by HTTP family:
 
+`type DiscordError` is the union of the six transport/classifier outputs below (excludes `ServiceUnavailableError`, which is an escalation product):
+
 | Tag | Decision |
 |---|---|
 | `RateLimitError` | Retriable — carries `retryAfterMs` for observability |
@@ -130,9 +132,13 @@ decision they drive, not by HTTP family:
 | `ResourceMissingError` | Non-retriable — target gone; frequently recover-as-success |
 | `ClientError` | Non-retriable — other 4xx |
 | `ServerError` | Non-retriable, permanent 5xx — named slot, no classifier branch emits it yet |
+
+`ServiceUnavailableError` is separate — an escalation product from `escalateExhausted`, NOT emitted by `classifyDiscordError`, NOT a member of `DiscordError`:
+
+| Tag | Decision |
+|---|---|
 | `ServiceUnavailableError` | Escalated outage — exhausted retriable failure, carries `lastCause` |
 
-`type DiscordError` is the union of the six transport errors.
 `type AppError` is the app-wide union (DiscordError + domain errors + SqlError +
 `Cause.UnknownException`) used for `toUserResponse` exhaustiveness.
 
@@ -160,7 +166,8 @@ if (isDiscordError(e)) { ... }
 if (isRetriable(e)) { ... }
 
 // Retry transient failures with capped exponential backoff (base 200ms, ×2,
-// jittered, 4 total attempts) — uses Schedule.exponential + jittered + recurs:
+// jittered) — Schedule.exponential("200 millis", 2) |> jittered |>
+// compose(recurs(3)) = 1 initial attempt + 3 retries = 4 total:
 yield* tryDiscord("op", fn).pipe(withRetry);
 
 // Map a surviving retriable failure to ServiceUnavailableError (alert path):

--- a/notes/EFFECT.md
+++ b/notes/EFFECT.md
@@ -109,13 +109,98 @@ Catch all errors uniformly:
 effect.pipe(
   Effect.catchAll((error) =>
     logEffect("error", "Handler", "Operation failed", {
-      error: String(error),
+      error,
     }),
   ),
 );
 ```
 
 **See:** `app/effects/errors.ts` for all error types
+
+#### Decision-oriented errors (infra taxonomy)
+
+Discord transport errors live in `app/effects/errors.ts` and are named by the
+decision they drive, not by HTTP family:
+
+| Tag | Decision |
+|---|---|
+| `RateLimitError` | Retriable — carries `retryAfterMs` for observability |
+| `TransientError` | Retriable — 5xx/network fault, optional `status` |
+| `ForbiddenError` | Non-retriable — bot lacks a Discord permission; give guidance |
+| `ResourceMissingError` | Non-retriable — target gone; frequently recover-as-success |
+| `ClientError` | Non-retriable — other 4xx |
+| `ServerError` | Non-retriable, permanent 5xx — named slot, no classifier branch emits it yet |
+| `ServiceUnavailableError` | Escalated outage — exhausted retriable failure, carries `lastCause` |
+
+`type DiscordError` is the union of the six transport errors.
+`type AppError` is the app-wide union (DiscordError + domain errors + SqlError +
+`Cause.UnknownException`) used for `toUserResponse` exhaustiveness.
+
+**Classifier boundary** (`app/effects/classifyDiscordError.ts`): the only place
+`instanceof` against `@discordjs/rest` SDK errors is allowed. Converts an
+unknown rejection to a typed `DiscordError`:
+
+```typescript
+// Only place SDK instanceof checks live — the unknown→typed boundary:
+const e: DiscordError = classifyDiscordError("addRole", rejection);
+
+// DRY replacement for Effect.tryPromise({ try, catch }) at every Discord call site:
+yield* tryDiscord("addMemberRole", () =>
+  ssrDiscordSdk.put(Routes.guildMemberRole(guildId, userId, roleId)),
+);
+```
+
+**Decision helpers** (`app/effects/errorHandling.ts`):
+
+```typescript
+// Membership guard over the six DiscordError tags:
+if (isDiscordError(e)) { ... }
+
+// Retriable predicate (RateLimitError | TransientError):
+if (isRetriable(e)) { ... }
+
+// Retry transient failures with capped exponential backoff (base 200ms, ×2,
+// jittered, 4 total attempts) — uses Schedule.exponential + jittered + recurs:
+yield* tryDiscord("op", fn).pipe(withRetry);
+
+// Map a surviving retriable failure to ServiceUnavailableError (alert path):
+yield* tryDiscord("op", fn).pipe(withRetry, escalateExhausted);
+
+// Pure, total mapper from any AppError tag to safe user copy:
+const reply = toUserResponse(e); // { content: string; ephemeral: boolean }
+```
+
+**Before / after — job: retry transient, drop member-gone**
+(`app/jobs/bulkRoleAssignment.ts`)
+
+```typescript
+// before: log-and-drop every failure, no distinction
+// after:
+yield* tryDiscord("addMemberRole", () => ssrDiscordSdk.put(...)).pipe(
+  withRetry,                                            // RateLimit/Transient retried
+  Effect.catchTag("ResourceMissingError", () => Effect.void), // member gone → fine
+  Effect.exit,
+);
+// NOTE: escalateExhausted is NOT used here — one member's outage must not abort
+// a 100k-member migration. escalateExhausted suits command handlers where a
+// single failure IS the whole outcome.
+```
+
+**Before / after — command handler: structured error → user reply**
+
+```typescript
+// before: ad-hoc generic string
+// after:
+Effect.catchAll((e) =>
+  Effect.all([
+    logEffect("error", "Commands", "Operation failed", { error: e }), // full structured payload
+    interactionReply(interaction, toUserResponse(e)),                  // safe, specific-where-known
+  ]),
+)
+```
+
+**See:** `app/effects/errors.ts` (taxonomy), `app/effects/classifyDiscordError.ts`
+(boundary), `app/effects/errorHandling.ts` (helpers)
 
 ### Parallel Operations
 
@@ -143,7 +228,7 @@ const results = yield* Effect.forEach(due, (escalation) =>
     Effect.catchAll((error) =>
       logEffect("error", "EscalationResolver", "Error processing escalation", {
         escalationId: escalation.id,
-        error: String(error),
+        error,
       }),
     ),
   ),
@@ -294,7 +379,7 @@ export const handleMyCommand = (input: Input) =>
     // DatabaseLayer is provided by the ManagedRuntime — no need to provide it here
     Effect.catchAll((error) =>
       logEffect("error", "MyCommand", "Command failed", {
-        error: String(error),
+        error,
       }),
     ),
     Effect.withSpan("handleMyCommand"),
@@ -517,5 +602,5 @@ unabridged versions of the documentation are
 [indexed here](https://effect.website/llms.txt); you can retrieve a URL with
 more detailed information from there.
 
-For patterns not used in this codebase (Streams, Schedules, etc.), see
+For patterns not used in this codebase (Streams, etc.), see
 [EFFECT_ADVANCED.md](./EFFECT_ADVANCED.md).

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "build": "run-s build:*",
-    "lint": "eslint --no-warn-ignored --cache --cache-location ./node_modules/.cache/eslint .",
+    "lint": "eslint --no-warn-ignored --max-warnings=0 --cache --cache-location ./node_modules/.cache/eslint .",
     "lint:fix": "eslint --no-warn-ignored --fix --max-warnings=0",
     "format": "prettier --write .",
     "format:check": "prettier --check .",


### PR DESCRIPTION
## Summary

Replaces ad-hoc Discord error handling with a **decision-oriented typed error taxonomy**: every Discord SDK call goes through a single boundary that classifies failures into tagged errors (`ForbiddenError`, `ResourceMissingError`, `RateLimitError`, `TransientError`, `ClientError`), and callers branch on the tag to decide *retry / recover / escalate / show-the-user*. User-facing replies are mapped from the tag (never raw error strings), and a lint rule enforces that typed errors are never stringified.

57 files changed; ~1,880 insertions / ~564 deletions across `app/effects`, `app/commands`, `app/discord`, `app/jobs`, plus lint rules and docs.

## What changed

- **Taxonomy** (`app/effects/errors.ts`) — a decision-oriented tagged union; dropped the dead `StripeApiError`.
- **Boundary classifier** (`app/effects/classifyDiscordError.ts`, `tryDiscord`) — wraps Discord SDK calls and classifies rejections **structurally** (by `status` / `code` / `rawError` shape), not by `instanceof`. All `discordSdk` wrappers and remaining `DiscordApiError` sites migrated onto it.
- **Decision helpers** — retry/escalate helpers; `toUserResponse` maps each tag to safe user copy. Escalate actions (ban/kick/gate) and `reportedMessages` 404-recovery now route through it, preserving the ban-hierarchy and gate-activation guidance with unified `ForbiddenError` copy.
- **Jobs** — bulk role assignment retries transient failures and recovers missing-member (404) as success instead of hard-failing.
- **Observability** — the Effect JSON logger now serializes `Error` causes under `annotations.error` (`_tag` + `cause`), so typed errors are fully inspectable in logs.
- **Lint enforcement** — new `local/no-error-string-cast` rule + `formatError()` helper; migrated existing `String(error)` sites. Authored as `warn`, gated by the repo's `--max-warnings=0` policy.
- **Docs** — `notes/EFFECT.md` error-taxonomy/retry section, and a `qa-session` `error-handling` QA checklist.

## Notable bug caught (live QA, not unit tests)

The classifier originally used `instanceof @discordjs/rest.DiscordAPIError`. Because the app imports the **ESM** build while `discord.js` `require`s the **CJS** build, those are two module instances with distinct class identities — so the check missed **every** real Discord error and defaulted it to `TransientError`. A genuine 403 (Missing Permissions) surfaced to users as "Discord is having trouble, try again" *and* became retriable. **456 passing unit tests missed this** because mocks constructed the matching class; only live QA against a real throw path caught it. Fixed via structural detection (commit 1905166), with a regression test that builds the **real** CJS error object. (Also fixed a latent 1000× `retryAfterMs` unit bug found alongside it.)

## Testing

- `npm test` — 456 passing, including a cross-build (CJS+ESM) classifier matrix.
- `npm run typecheck` and `npm run lint` — clean / zero warnings.
- Live-QA'd on the test guild: force-ban / escalate-ban / escalate-kick 403s, gate already-active + activation-failure, and already-deleted-message 404 recovery all verified against the actual log annotations and DB rows.

## Merge

Feature PR → `main`, squash-merged per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)