### PR TITLE
Add local-qa skill for QA during active development

### DIFF
--- a/.claude/skills/local-qa/SKILL.md
+++ b/.claude/skills/local-qa/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: local-qa
+description:
+  Use when QA-testing mod-bot during active local development against a dev bot
+  you start and drive yourself — typically a feature branch in a git worktree,
+  before there's an RC. Covers standing up the dev environment, deciding per
+  finding whether to fix-now/log/defer, and authoring or re-validating
+  checklists. For release/RC verification against a deployed pod, use qa-session
+  instead.
+---
+
+# Local QA — verification during active development
+
+Same engine as `qa-session`, different job. `qa-session` verifies a release
+candidate and reports findings to a PR without touching code. `local-qa` runs
+while you're still _building_: the environment isn't ready yet, hot-reload can't
+be trusted, and when you find a bug you usually want to **fix it and re-test
+live**, not just file it.
+
+This skill closes the four gaps `qa-session` leaves for dev work. It does
+**not** restate the engine — read these `qa-session` sections and apply them
+as-is:
+
+- **The split of labor** — you do everything mechanical (logs, DB, tests); the
+  human does only Discord-client actions.
+- **Proof strength** — read the actual log line / DB row. A green Discord reply
+  proves nothing. (Local SQLite is the strongest proof you have.)
+- **How you communicate** — conclusions, not mechanics; resolve before asking.
+- **Run log** — `.claude/qa-runs/<YYYY-MM-DD>_local.md`, gitignored, your resume
+  state across `/clear`.
+
+The payoff for doing this live: in the 2026-06-20 run, reading the actual error
+annotation caught a classifier that mistagged **every** real Discord error as
+`TransientError` (ESM/CJS dual-instance broke an `instanceof`) — a bug **456
+passing unit tests missed**, because the mocks constructed objects the real
+throw path never produces.
+
+## Checklists
+
+Shared with `qa-session` — they live at
+`.claude/skills/qa-session/checklists/*.md` (`error-handling`, `spam`,
+`automod`, `commands`, `logging`, `event-bus`, `purge`, `flags-and-web`). Read
+them as your reference; the format is in `qa-session`. `local-qa` reads and
+**updates** them (see Capability 4); `qa-session` only reads.
+
+---
+
+## Capability 1 — Stand up a working environment (the biggest gap)
+
+**The worktree `.env` is a symlink to the root `.env`** — tokens (Discord,
+PostHog) are already present. Don't copy or recreate it.
+
+**Trap 1 — the relative DB path.** `.env` has `DATABASE_URL=./mod-bot.sqlite3`
+(relative). Run the bot from a worktree and that resolves to a _fresh empty DB
+in the worktree_ — no configured guild, so escalate / gate / report features
+have nothing to act on. Fix: copy the dev DB into the worktree (it's gitignored;
+this leaves the canonical dev DB untouched):
+
+```bash
+cp /Users/vcarl/workspace/mod-bot/mod-bot.sqlite3 ./        # plus the WAL sidecars:
+cp /Users/vcarl/workspace/mod-bot/mod-bot.sqlite3-wal ./ 2>/dev/null
+cp /Users/vcarl/workspace/mod-bot/mod-bot.sqlite3-shm ./ 2>/dev/null
+```
+
+Real test guild in that copy: **Test server, guildId `614601782152265748`**.
+
+**Trap 2 — `npm run dev` reseeds.** `dev` runs `dev:init; dev:bot`, and
+`dev:init` runs `kysely:seed`, which can overwrite the guild data you just
+copied in. Start the bot **directly with `dev:bot`** (skip `dev:init`):
+
+```bash
+ps aux | grep '[i]ndex.dev.js'    # FIRST: no second bot on the same token/DB
+node --enable-source-maps --trace-warnings index.dev.js > .claude/qa-runs/dev-bot.log 2>&1 &
+```
+
+Confirm the server is up by grepping the log for the ready line, and verify the
+pid (a backgrounded `node … &` inside a wrapper can be reparented):
+
+```bash
+grep '"message":"Discord application ready"' .claude/qa-runs/dev-bot.log
+```
+
+**Hot-reload is partial** The watcher only reloads files matching these
+prefixes:
+
+```
+app/server.ts   app/discord/   app/commands/   app/helpers/   app/models/
+```
+
+**`app/effects/` and everything else are NOT watched.** Edits to the error
+system, classifier, or logger do **not** hot-reload — you'll test stale code and
+chase a ghost. Rule: after any edit, check whether the changed path is on that
+list; if not, **restart the bot** before re-testing.
+
+**Logs are JSON lines, two shapes** — grep both:
+
+- Effect logger: `{"message":[…],"annotations":{"service":…}}`. Typed errors
+  logged via `logEffect(…, { error })` land at `annotations.error` with `_tag` +
+  a serialized `cause`.
+- Legacy logger: `{"level":…,"service":…,"context":{}}`.
+
+**DB read = strongest proof:** `sqlite3 ./mod-bot.sqlite3 '<query>'`.
+
+## Capability 2 — Fix posture: immediate vs deferred
+
+`qa-session` is findings-only. Here, decide per finding. Ask the human their
+default posture up front, then treat each finding as a quick choice between
+three dispositions:
+
+- **Log-and-continue** — record observed-vs-expected in the run log, keep
+  testing. Best for mapping a bug's blast radius _before_ fixing.
+- **Stop-and-fix (immediate)** — the right call when the bug blocks the path
+  under test. Mandatory steps, in order:
+  1. Hand the fixer the **real evidence** — the actual error object/shape from
+     the log, not a guess. (The classifier bug looked like a mock-shape issue;
+     the real cause was deeper.)
+  2. Require a regression test built from the **real** object, not a mock —
+     mocks hid this class of bug entirely.
+  3. After the fix, **restart the bot if the changed path isn't hot-reloaded**
+     (Capability 1).
+  4. Re-run the live check and confirm against the log/DB, not the Discord
+     reply.
+- **Defer-to-issue** — file a GitHub issue and move on. For findings outside the
+  current work's scope (e.g. the 2026-06-20 member-applications flag-gating gap
+  → `Euno-HQ/discord#379`).
+
+## Capability 3 — Author a new checklist
+
+When the work under test has no checklist, build one before testing. Procedure
+(worked example: `error-handling.md`):
+
+1. **Ground in code.** Read the code under test. For each user- or
+   log-observable behavior, find the exact `file:line`, the user-facing copy,
+   and the log marker / DB row that proves it.
+2. **Triage every behavior** into one of:
+   - **auto-verified** — a unit test already proves it → skip live, name the
+     test in the checklist.
+   - **human-triggerable** — needs a Discord action → becomes a checklist item.
+   - **fault-injection-only** — can't be triggered from a Discord client (real
+     5xx, rate-limit) → skip live, note the covering test.
+3. **Write `do:` / `prove: local→… uat→…` / `pass:` triples** in the
+   `qa-session` format, grounded with `file:line` and the real log markers / DB
+   queries.
+
+## Capability 4 — Re-validate checklists after new work (regression pass)
+
+Checklists are living specs, not write-once docs. When a branch changes code,
+re-ground the affected checklists against HEAD. This is subagent-friendly —
+dispatch one to check drift and report. For each cited check:
+
+- Do the `file:line` groundings still resolve? (code moves.)
+- Did behavior change so a `pass:` is now wrong? (2026-06-20: collapsing
+  `toUserResponse`'s operation-aware ForbiddenError branch made the old "kick
+  shows generic copy, no hierarchy hint" expectation obsolete — kick now shows
+  the same unified copy as ban.)
+- Are there **new** behaviors needing checks? Did anything become — or stop
+  being — auto-verified?
+
+Update the checklist in place so the next run starts from truth.
+
+## The deliverable
+
+Not a findings-only PR comment. A `local-qa` pass produces: **fixes committed**,
+**checklists updated**, and the **run log** (`.claude/qa-runs/<date>_local.md`)
+summarizing what was tested, what passed, and what was deferred (with issue
+links).
+
+## Common mistakes
+
+| Mistake                                                                  | Consequence                                                                                                 |
+| ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| Running the bot from the worktree without copying the dev DB             | Empty DB, no guild — every feature looks broken                                                             |
+| Using `npm run dev` instead of `dev:bot`                                 | `dev:init` reseeds and clobbers your copied guild data                                                      |
+| Trusting hot-reload after editing `app/effects/` (or anything unwatched) | You test stale code and chase a phantom bug                                                                 |
+| Trusting a green Discord reply                                           | The reply lies — the classifier bug returned user-visible copy while mistagging the error. Read the log/DB. |
+| Fixing from a guessed error shape / mocked regression test               | The mock-vs-real gap is exactly what live QA exists to catch                                                |

--- a/.claude/skills/qa-session/SKILL.md
+++ b/.claude/skills/qa-session/SKILL.md
@@ -1,59 +1,63 @@
 ---
 name: qa-session
-description: Use to run an interactive human↔agent QA pass on mod-bot before a release (RC verification, post-merge spot-checks, "let's QA the bot"). The agent monitors logs/DB and drives; the human performs only the Discord-client actions that require a human. Produces a findings-only QA report posted to the active branch's PR.
+description:
+  Use to run an interactive human↔agent QA pass on mod-bot ("let's QA"). The
+  agent monitors logs/DB and drives multi-action verification steps; the human
+  performs only the Discord-client actions that require a human. Produces a
+  findings-only QA report; shown to the human if testing a local branch, posted
+  to a PR if available.
 ---
 
 # QA Session — human↔agent verification
 
-You and the human are two colleagues running a release-quality pass together. The
-human has the Discord client and does the things only a human can (clicking,
+You and the human are two colleagues running a release-quality pass together.
+The human has the Discord client and does the things only a human can (clicking,
 typing, reacting). You hold everything mechanical: you run the test suite, read
 the logs live, query SQLite, and **prove** that internal state matches intent
-before either of you moves on. Talk like a colleague, not a form.
+before either of you moves on. Talk like a friendly colleague with a lot of
+other work to get done after this.
 
 ## How you communicate (high-EQ partner, not a build log)
 
-The human is a busy colleague, not a debugger watching your stdout. Protect their
-attention.
+The human is a busy colleague, not a debugger watching your stdout. Protect
+their attention.
 
-- **Never narrate implementation detail.** No filenames, no line numbers, no log
-  strings, no SQL, no internal IDs unless they ask. Those live in the checklists as
-  *your* reference — translate them into plain outcomes. Say "the spam verdict fired
-  and the duplicates were back-filled cleanly," not "grepped `SpamResponse` /
-  `Back-fill complete` at spamResponseHandler.ts:339."
-- **Report conclusions, not mechanics.** They want to know *did it work and how do
-  you know*, in a sentence — not which tool you ran.
+- **Never narrate implementation detail.** No filenames/line numbers/raw
+  logs/etc. Those live in the checklists as _your_ reference — translate them
+  into plain outcomes. Say "the spam verdict fired and the duplicates were
+  back-filled cleanly," not "grepped `SpamResponse` / `Back-fill complete` at
+  spamResponseHandler.ts:339."
+- **Report conclusions, not mechanics.** They want to know _did it work and how
+  do you know_, in a sentence — not which tool you ran.
 - **Resolve before asking.** Anything you can learn from logs, the DB, the test
   suite, or the running bot, learn it silently. Only ask the human for what
   genuinely needs a human, and ask it the moment it matters, not as an upfront
   intake form.
-- **One small ask at a time.** Keep questions short and within tool limits (an
-  options question allows **at most 4** options — never list all the checklists as
-  choices; default to full scope and narrow in conversation instead).
-- **Warm and concise.** A teammate pairing with you, calm and specific. Celebrate
-  green, surface red plainly without alarm.
+- **Warm and concise.** A teammate pairing with you, calm and specific (if
+  slightly impatient). Celebrate green, surface red plainly without alarm.
 
 ## The split of labor
 
 - **You do everything verifiable without a human:** run `npm test`, read code,
-  query `./mod-bot.sqlite3`, tail logs, reason about whether a result is correct.
-  Report what's *already* proven so the human's list shrinks to human-only work.
-- **The human does only what requires a human:** Discord-client actions, granting
-  permissions, having multiple accounts, eyeballing rendered UI.
-- **Never ask the human to do something you can verify yourself.** If a `npm test`
-  case already covers it, say so and skip it.
+  query `./mod-bot.sqlite3`, tail logs, reason about whether a result is
+  correct. Report what's _already_ proven so the human's list shrinks to
+  human-only work.
+- **The human does only what requires a human:** Discord-client actions,
+  granting permissions, having multiple accounts, eyeballing rendered UI.
+- **Never ask the human to do something you can verify yourself.**
 
 ## Environments (proof strength differs — say which you're in)
 
-| | Local (`npm run dev`) | UAT (deployed pod) |
-|---|---|---|
-| Logs | dev-server stdout | `kubectl -n staging logs …` |
-| DB | direct: `sqlite3 ./mod-bot.sqlite3 '<query>'` | **none** |
-| Proof strength | **strong** — read the actual row | **weaker** — log line only |
+|                | Local (`npm run dev`)                         | UAT (deployed pod)          |
+| -------------- | --------------------------------------------- | --------------------------- |
+| Logs           | dev-server stdout                             | `kubectl -n staging logs …` |
+| DB             | direct: `sqlite3 ./mod-bot.sqlite3 '<query>'` | **none**                    |
+| Proof strength | **strong** — read the actual row              | **weaker** — log line only  |
 
-Each checklist `prove:` line has a `local:` form (favor the SQLite read — it's the
-strongest proof) and a `uat:` form (log-line match only). Both are publishable; the
-report just labels which ran and notes UAT's limited internal-state visibility.
+Each checklist `prove:` line has a `local:` form (favor the SQLite read — it's
+the strongest proof) and a `uat:` form (log-line match only). Both are
+publishable; the report just labels which ran and notes UAT's limited
+internal-state visibility.
 
 Logs are **JSON lines**: `{"timestamp","level","service","message",...context}`.
 Every log proof is a grep for `"service":"X"` and `"message":"Y"`; correlate a
@@ -61,84 +65,92 @@ single message end-to-end on its `messageId` context field.
 
 ## The session protocol
 
-### 1. Pre-flight (you, silently — this is your job, not the human's)
-Default scope to the **full project**. Default environment to **local** unless told
-otherwise. Do all of the following yourself before involving the human; surface only
-a one-line "ready" summary when done.
+### 1. Pre-flight (yours)
 
-- **Own the log stream.** You start and read the bot's logs — never ask the human
-  to run a server or pipe output.
-  - **local:** start the dev server yourself in the background (`npm run dev`) so
-    you own its stdout, then read from that stream. If you already have one running,
-    reuse it — **do not restart it** between checks; it hot-reloads. (Don't spin up a
-    second instance alongside one the human is running — they'd double up on the same
-    bot token/DB. If you detect that, pause and sort it out before proceeding.)
+Default scope to the **full project**. Default environment to **local** unless
+told otherwise. Do all of the following yourself before involving the human;
+surface only a one-line "ready" summary when done.
+
+- **Own the log stream.** You start and read the bot's logs.
+  - **local:** start the dev server yourself in the background (`npm run dev`)
+    so you own its stdout, then read from that stream. If you already have one
+    running, reuse it — **do not restart it** between checks; it hot-reloads.
+    (Don't spin up a second instance alongside one the human is running — they'd
+    double up on the same bot token/DB. If you detect that, pause and sort it
+    out before proceeding.)
   - **UAT:** confirm the pod image SHA matches the RC tip and start the pod log
     stream yourself.
 - **Run `npm test` quietly.** Report only the headline (all green, or which area
   failed). Note which checks are already covered so you skip them live.
-- **Learn the environment yourself.** Derive the test guild, current feature-flag
-  state, and bot permissions from the DB / admin view / logs. Pick up account IDs,
-  message IDs, and channel IDs by watching the log stream as the human acts — don't
-  ask for IDs you can read.
+- **Learn the environment yourself.** Derive the test guild, current
+  feature-flag state, and bot permissions from the DB / admin view / logs. Pick
+  up account IDs, message IDs, and channel IDs by watching the log stream as the
+  human acts — don't ask for IDs you can read.
 - Open/append the run log (see below) and the relevant `checklists/*.md` (your
   reference — the human never sees these).
 
 ### 2. Setup (one human ask to start)
-Once pre-flight is done, your **first** message to the human is a single concrete
-request: open two Discord sessions side by side — two browser windows or profiles,
-each signed into a different account in the test server: one a **moderator**, one an
-**ordinary member**. Explain briefly why two: you'll drive spam and abuse tests from
-the ordinary member because moderators are exempt from the spam path (so spam from a
-mod account looks broken), and use the moderator window for staff actions.
 
-That's the only upfront ask. Everything else, resolve yourself and only raise if it
-actually blocks you, in plain language at the moment it matters — e.g. "the bot's
-missing Manage Server, so automod rule events won't arrive; can you grant it when we
-get there?" or "the escalate feature reads as off for this guild — is that expected,
-or should we flip the flag before testing it?" If a later check needs a third
-account, ask then, not now.
+Once pre-flight is done, your **first** message to the human is a single
+concrete request: open two Discord sessions side by side — two browser windows
+or profiles, each signed into a different account in the test server: one a
+**moderator**, one an **ordinary member**. Explain briefly why two: you'll drive
+spam and abuse tests from the ordinary member because moderators are exempt from
+the spam path (so spam from a mod account looks broken), and use the moderator
+window for staff actions.
+
+That's the only upfront ask. Everything else, resolve yourself and only raise if
+it actually blocks you, in plain language at the moment it matters — e.g. "the
+bot's missing Manage Server, so automod rule events won't arrive; can you grant
+it when we get there?" or "the escalate feature reads as off for this guild — is
+that expected, or should we flip the flag before testing it?" If a later check
+needs a third account, ask then, not now.
 
 ### 3. The loop (batched, collaborative)
+
 - Work one checklist (subsystem) at a time.
 - Group its checks into **batches** — a short sequence of human actions whose
-  combined effect you can disentangle from logs/DB in one read. Size each batch to
-  what you can verify unambiguously; no fixed cap. Present it conversationally:
-  *"Let's exercise spam: from a fresh account, post the same message 3× fast across
-  two channels, then ping me — I'll confirm the verdict chain landed and the
-  back-fill stayed idempotent."*
+  combined effect you can disentangle from logs/DB in one read. Size each batch
+  to what you can verify unambiguously; no fixed cap. Present it
+  conversationally: _"Let's exercise spam: from a fresh account, post the same
+  message 3× fast across two channels, then ping me — I'll confirm the verdict
+  chain landed and the back-fill stayed idempotent."_
 - Human performs the batch → says done → you run every `prove:` for that batch →
-  report **PASS/FAIL with the actual evidence** (the row or the log line, quoted) →
-  next batch.
+  report **PASS/FAIL with the actual evidence** (the row or the log line,
+  quoted) → next batch.
 - On **FAIL**: capture the offending row/log line verbatim into the run log.
   Findings only — record observed-vs-expected; **do not** diagnose root cause or
   propose a fix. Ask whether to continue or stop.
 
 ### 4. Context checkpoints (you prompt these proactively)
+
 A live QA pass dumps a lot of logs into your context. Manage it on purpose:
-- **`/compact`** at the end of each batch when context feels heavy — light reset,
-  you keep going.
+
+- **`/compact`** at the end of each batch when context feels heavy — light
+  reset, you keep going.
 - **`/clear` + re-invoke `qa-session`** at subsystem boundaries — full reset. On
   re-invoke, **read the run log first** and resume at the next unchecked item.
-- Call the checkpoint out loud: *"That's the spam suite done and logged. Good
+- Call the checkpoint out loud: _"That's the spam suite done and logged. Good
   moment to `/clear` and re-invoke me — I'll reload the run log and pick up at
-  automod."*
+  automod."_
 
 ## Run log (durable state) + QA report (the deliverable)
 
 **Run log** — ephemeral, your resume state, never committed:
 `.claude/qa-runs/<YYYY-MM-DD>_<env>.md` (gitignored). Update it as you go: env,
-prerequisites confirmed, and a per-check tally (`PASS` / `FAIL` / `auto-verified` /
-`skipped`) with evidence quoted on failures. This is the source of truth across a
-`/clear`, not your context.
+prerequisites confirmed, and a per-check tally (`PASS` / `FAIL` /
+`auto-verified` / `skipped`) with evidence quoted on failures. This is the
+source of truth across a `/clear`, not your context.
 
 **QA report** — the artifact, rendered from the run log at the end:
-- Header: env, RC/branch, image SHA (UAT), date, and a **confidence note** — local
-  = SQLite-backed; UAT = log-only, limited internal-state visibility.
+
+- Header: env, RC/branch, image SHA (UAT), date, and a **confidence note** —
+  local = SQLite-backed; UAT = log-only, limited internal-state visibility.
 - Body: per-subsystem tally; failures show observed-vs-expected with the quoted
   evidence. **Findings only — no root-causing, no repair proposals.**
 - Delivery:
-  - Active branch has a PR → post as a comment: `gh pr comment <#> --body-file <rendered>`.
+  - Active branch has a PR → post as a comment:
+    `gh pr comment <#> --body-file <rendered>`.
   - No PR for the branch → print the report in the conversation for the human.
   - Both local and UAT findings are publishable; just label the environment.
 
@@ -155,6 +167,6 @@ pass:  <exact expected observable>
 ```
 
 `do:` describes the Discord UI well enough for a competent human to infer exact
-names/labels; it does not hardcode strings that drift. The `prove:`/`pass:` lines
-are grounded in code at the cited `file:line` — if code moves, re-ground before
-trusting them.
+names/labels; it does not hardcode strings that drift. The `prove:`/`pass:`
+lines are grounded in code at the cited `file:line` — if code moves, re-ground
+before trusting them.


### PR DESCRIPTION
## Summary

Adds a `local-qa` skill: an interactive human↔agent QA pass for use **during active development** against a dev bot you start and drive yourself (typically a feature branch in a git worktree, before there's an RC). It complements `qa-session` (which is for release/RC verification against a deployed pod and reports findings without touching code).

`local-qa` reuses `qa-session`'s engine — the human/agent labor split, proof-strength discipline (read the actual log line / DB row), and the run log — **by reference rather than restating it**, and shares the same checklists under `qa-session/checklists/`.

## Why

It came out of the 2026-06-20 error-system QA run (now merged as #383). Running `qa-session` against that branch worked, but its release-framing fought dev use: it assumes a ready environment, trusts hot-reload blindly, and is findings-only when mid-session we wanted to stop and fix. The proof-strength discipline still earned its keep — reading the actual error annotation caught a classifier mistagging **every** real Discord error as `TransientError`, a bug **456 passing unit tests missed**. `local-qa` keeps that engine and closes the dev-mode gaps.

## What it covers (four capabilities)

1. **Stand up a working environment** — the worktree `.env` symlink, the relative-`DATABASE_URL` empty-DB trap (copy the dev DB in), the `npm run dev` → `dev:init` reseed trap (start via `dev:bot`), and the **partial hot-reload watch list** (`app/effects/` is *not* watched → restart or test stale code).
2. **Fix posture** — per finding, choose log-and-continue / stop-and-fix / defer-to-issue, with mandatory steps for fixing live from the real error shape and a real-object regression test.
3. **Authoring checklists** — the ground-in-code → triage (auto-verified / human-triggerable / fault-injection-only) → write-triples procedure.
4. **Checklist regression pass** — re-ground `file:line` cites against HEAD and catch obsolete `pass:` expectations after new work.

Every environment specific (symlink, watch prefixes, `dev:bot` command, ready-log marker, log shapes) was verified against the code, not assumed.

## Also included

A reformat + description tweak to `qa-session/SKILL.md` (no behavioral change to that skill).

## Notes

- Checklists stay under `qa-session/checklists/` and are referenced by path (design decision (a) — simplest, reversible, doesn't disturb `qa-session`). `local-qa` reads **and updates** them; `qa-session` only reads.
- Markdown only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)