### PR TITLE
refactor(logging): migrate Effect-flow log() callsites to logEffect (#381)

### DIFF
--- a/app/Database.ts
+++ b/app/Database.ts
@@ -63,18 +63,21 @@ const sendWebhookAlert = (message: string) =>
     catch: (e) => e,
   }).pipe(
     Effect.tapError((e) =>
-      Effect.sync(() =>
-        log("error", "IntegrityCheck", "Failed to send webhook alert", {
-          error: e,
-        }),
-      ),
+      logEffect("error", "IntegrityCheck", "Failed to send webhook alert", {
+        error: e,
+      }),
     ),
     Effect.ignore, // Don't fail the whole check if webhook fails
   );
 
 /** Run SQLite integrity check using the existing database connection */
 export const runIntegrityCheck = Effect.gen(function* () {
-  log("info", "IntegrityCheck", "Running scheduled integrity check", {});
+  yield* logEffect(
+    "info",
+    "IntegrityCheck",
+    "Running scheduled integrity check",
+    {},
+  );
 
   const sql = yield* SqlClient.SqlClient;
   const result = yield* sql.unsafe<{ integrity_check: string }>(
@@ -82,12 +85,19 @@ export const runIntegrityCheck = Effect.gen(function* () {
   );
 
   if (result[0]?.integrity_check === "ok") {
-    log("info", "IntegrityCheck", "Database integrity check passed", {});
+    yield* logEffect(
+      "info",
+      "IntegrityCheck",
+      "Database integrity check passed",
+      {},
+    );
     return "ok" as const;
   }
 
   const errors = result.map((r) => r.integrity_check).join("\n");
-  log("error", "IntegrityCheck", "Database corruption detected!", { errors });
+  yield* logEffect("error", "IntegrityCheck", "Database corruption detected!", {
+    errors,
+  });
 
   yield* sendWebhookAlert(
     `🚨 **Database Corruption Detected**\n\`\`\`\n${errors.slice(0, 1800)}\n\`\`\``,

--- a/app/discord/eventBus.ts
+++ b/app/discord/eventBus.ts
@@ -16,6 +16,7 @@ import type {
   GuildMessageDelete,
   GuildMessageUpdate,
 } from "#~/discord/events";
+import { logEffect } from "#~/effects/observability.ts";
 import { log } from "#~/helpers/observability";
 
 // --- Pure enrichment functions ---
@@ -231,7 +232,7 @@ export const DiscordEventBusLive = Layer.scoped(
       Effect.runFork(Queue.offer(queue, { type: "GuildDelete", guild }));
     });
 
-    log("info", "DiscordEventBus", "Event source registered");
+    yield* logEffect("info", "DiscordEventBus", "Event source registered");
 
     // Create broadcast stream — each subscriber gets independent backpressure.
     // The Scope from Layer.scoped keeps the broadcast alive for the runtime lifetime.

--- a/app/effects/posthog.ts
+++ b/app/effects/posthog.ts
@@ -2,8 +2,8 @@ import type { Collection, Guild } from "discord.js";
 import { Context, Effect, Layer } from "effect";
 import { PostHog } from "posthog-node";
 
+import { logEffect } from "#~/effects/observability.ts";
 import { posthogApiKey, posthogHost } from "#~/helpers/env.server";
-import { log } from "#~/helpers/observability";
 import { SubscriptionService } from "#~/models/subscriptions.server";
 
 export class PostHogService extends Context.Tag("PostHogService")<
@@ -14,9 +14,9 @@ export class PostHogService extends Context.Tag("PostHogService")<
 export const PostHogServiceLive = Layer.scoped(
   PostHogService,
   Effect.acquireRelease(
-    Effect.sync(() => {
+    Effect.gen(function* () {
       if (!posthogApiKey) {
-        log(
+        yield* logEffect(
           "info",
           "PostHogService",
           "No PostHog API key configured, metrics disabled",
@@ -28,14 +28,18 @@ export const PostHogServiceLive = Layer.scoped(
         flushAt: 20,
         flushInterval: 10000,
       });
-      log("info", "PostHogService", "PostHog client initialized");
+      yield* logEffect("info", "PostHogService", "PostHog client initialized");
       return client;
     }),
     (client) =>
-      Effect.promise(async () => {
+      Effect.gen(function* () {
         if (client) {
-          await client.shutdown();
-          log("info", "PostHogService", "PostHog client shut down");
+          yield* Effect.promise(() => client.shutdown());
+          yield* logEffect(
+            "info",
+            "PostHogService",
+            "PostHog client shut down",
+          );
         }
       }),
   ),
@@ -72,12 +76,10 @@ export const syncGuildGroup = (guildId: string, guild?: Guild) =>
       }),
     ).pipe(
       Effect.catchAll((error) =>
-        Effect.sync(() =>
-          log("warn", "PostHogService", "Failed to sync guild group", {
-            guildId,
-            error,
-          }),
-        ),
+        logEffect("warn", "PostHogService", "Failed to sync guild group", {
+          guildId,
+          error,
+        }),
       ),
     );
   });
@@ -94,7 +96,7 @@ export const initializeGroups = (guilds: Collection<string, Guild>) =>
       yield* syncGuildGroup(guildId, guild);
     }
 
-    log(
+    yield* logEffect(
       "info",
       "PostHogService",
       `Initialized ${guilds.size} guild groups in PostHog`,


### PR DESCRIPTION
## Summary

Phase 1 of #381 (legacy logger removal). Migrates the **incidental leftovers** — `log()` calls already sitting inside an Effect program's flow, where the swap to `logEffect` is a faithful 1:1 replacement with no control-flow change.

The **structural holdouts** (sync `client.on` event callbacks, Remix loaders/actions, plain model/helper functions, module-load statements) are deferred to a separate evaluation, so the legacy `log()` in `app/helpers/observability.ts` is **not** removed yet.

## Changes

- **`app/effects/posthog.ts`** — all 5 calls (pure Effect Layer module). Acquire `Effect.sync` → `Effect.gen`; release `Effect.promise` → `Effect.gen`; `catchAll`/gen-body → `logEffect`. Removed the now-unused legacy `log` import.
- **`app/discord/eventBus.ts`** — the `Layer.scoped` gen-body call. Kept the `log` import for the structural `client.on` callback that remains.
- **`app/Database.ts`** — `runIntegrityCheck` gen-body calls + the `tapError` `Effect.sync(() => log)`. Kept the `log` import for the module-load statement.

## Verification

`npm run typecheck` (tsc -b, whole project), `eslint --max-warnings=0`, `prettier --check`, and `app/effects/logger.test.ts` all pass.

## Follow-up

The structural holdouts remain on `log()`; the legacy logger can't be deleted until those migrate too (#381 stays open after this).

Refs #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)