### PR TITLE
refactor: lazy AppRuntime exports + migrate guilds/subscriptions/activity models to Effect (#386)

### DIFF
--- a/app/AppRuntime.test.ts
+++ b/app/AppRuntime.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { db, getPosthog } from "#~/AppRuntime";
+
+// These run WITHOUT calling warmRuntime() — so they never open the real DB.
+// They lock the contract that importing AppRuntime has no side effect and that
+// using the handles before warmup fails loudly.
+describe("AppRuntime lazy handles (unwarmed)", () => {
+  it("getPosthog() throws before warmRuntime()", () => {
+    expect(() => getPosthog()).toThrow(/not warmed/);
+  });
+
+  it("accessing a db property throws before warmRuntime()", () => {
+    expect(() => db.selectFrom("users")).toThrow(/not warmed/);
+  });
+});

--- a/app/AppRuntime.ts
+++ b/app/AppRuntime.ts
@@ -54,12 +54,52 @@ export type RuntimeContext = ManagedRuntime.ManagedRuntime.Context<
   typeof runtime
 >;
 
-// Extract the PostHog client for use by metrics.ts (null when no API key configured).
-export const [posthogClient, db]: [PostHog | null, EffectKysely] =
-  await Promise.all([
+// Lazily-warmed runtime handles. Importing AppRuntime has NO side effect; the
+// PostHog client + DB connection are resolved once at the process entry point
+// via warmRuntime() (called from app/server.ts). This keeps the import graph
+// free of an import-time DB open, so tests that transitively import AppRuntime
+// don't open the real database.
+let _realDb: EffectKysely | undefined;
+let _posthog: PostHog | null = null;
+let _warmed = false;
+
+const NOT_WARMED =
+  "AppRuntime not warmed — call warmRuntime() at startup before using db/getPosthog()";
+
+/**
+ * Resolve the PostHog client and DB connection once. Called at the process
+ * entry point (app/server.ts) before any request/event is served. Idempotent,
+ * so HMR re-execution is safe.
+ */
+export const warmRuntime = async (): Promise<void> => {
+  if (_warmed) return;
+  const [posthog, realDb] = await Promise.all([
     runtime.runPromise(PostHogService),
     runtime.runPromise(DatabaseService),
   ]);
+  _posthog = posthog;
+  _realDb = realDb;
+  _warmed = true;
+};
+
+/** The PostHog client (null when no API key). Throws if used before warmRuntime(). */
+export const getPosthog = (): PostHog | null => {
+  if (!_warmed) throw new Error(NOT_WARMED);
+  return _posthog;
+};
+
+/**
+ * Lazy EffectKysely handle for legacy async/await code. Forwards to the real
+ * instance once warmRuntime() has run; throws a clear error if used before then.
+ * Keeps the `db` name + type so existing consumers are unchanged.
+ */
+export const db: EffectKysely = new Proxy({} as EffectKysely, {
+  get(_target, prop) {
+    if (!_warmed || !_realDb) throw new Error(NOT_WARMED);
+    const value = _realDb[prop as keyof EffectKysely];
+    return typeof value === "function" ? value.bind(_realDb) : value;
+  },
+});
 
 // --- Bridge functions for legacy async/await code ---
 
@@ -130,7 +170,7 @@ export const runGatedFeature = <A>(
       const flags = yield* FeatureFlagService;
       const enabled = yield* flags.isPostHogEnabled(flag, guildId);
       if (!enabled) {
-        posthogClient?.capture({
+        getPosthog()?.capture({
           distinctId: guildId,
           event: "premium gate hit",
           properties: { flag, $groups: { guild: guildId } },

--- a/app/AppRuntime.ts
+++ b/app/AppRuntime.ts
@@ -70,6 +70,13 @@ const NOT_WARMED =
  * Resolve the PostHog client and DB connection once. Called at the process
  * entry point (app/server.ts) before any request/event is served. Idempotent,
  * so HMR re-execution is safe.
+ *
+ * NOT safe against concurrent first-callers: the `if (_warmed) return;` guard
+ * only short-circuits AFTER a prior call has resolved, so two callers racing
+ * before either settles would both run `Promise.all` (a second connection).
+ * This relies on the single serial top-level `await warmRuntime()` in
+ * server.ts being the only caller. If a second caller is ever added, cache the
+ * in-flight promise (`let _warming: Promise<void> | undefined`) and return it.
  */
 export const warmRuntime = async (): Promise<void> => {
   if (_warmed) return;

--- a/app/commands/checkRequirements.ts
+++ b/app/commands/checkRequirements.ts
@@ -24,7 +24,7 @@ import {
 import type { SlashCommand } from "#~/helpers/discord";
 import { formatError } from "#~/helpers/formatError";
 import { commandStats } from "#~/helpers/metrics";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 
 export interface CheckResult {
   name: string;
@@ -129,7 +129,7 @@ export const Command = {
       const results: CheckResult[] = [];
 
       // --- Guild settings ---
-      const settings = yield* fetchSettingsEffect(guildId, [
+      const settings = yield* fetchSettings(guildId, [
         SETTINGS.moderator,
         SETTINGS.modLog,
         SETTINGS.deletionLog,

--- a/app/commands/escalate/directActions.ts
+++ b/app/commands/escalate/directActions.ts
@@ -10,7 +10,7 @@ import { NotAuthorizedError } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import { hasModRole } from "#~/helpers/discord";
 import { applyRestriction, ban, kick, timeout } from "#~/models/discord.server";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 import { deleteAllReportedForUser } from "#~/models/reportedMessages";
 
 export interface DeleteMessagesResult {
@@ -78,7 +78,7 @@ export const kickUser = (interaction: MessageComponentInteraction) =>
     const guildId = interaction.guildId!;
 
     // Get settings and check permissions
-    const { moderator: modRoleId } = yield* fetchSettingsEffect(guildId, [
+    const { moderator: modRoleId } = yield* fetchSettings(guildId, [
       SETTINGS.moderator,
     ]);
 
@@ -129,7 +129,7 @@ export const banUser = (interaction: MessageComponentInteraction) =>
     const guildId = interaction.guildId!;
 
     // Get settings and check permissions
-    const { moderator: modRoleId } = yield* fetchSettingsEffect(guildId, [
+    const { moderator: modRoleId } = yield* fetchSettings(guildId, [
       SETTINGS.moderator,
     ]);
 
@@ -184,7 +184,7 @@ export const banUserAndDeleteMessages = (
     const guildId = interaction.guildId!;
 
     // Get settings and check permissions
-    const { moderator: modRoleId } = yield* fetchSettingsEffect(guildId, [
+    const { moderator: modRoleId } = yield* fetchSettings(guildId, [
       SETTINGS.moderator,
     ]);
 
@@ -248,7 +248,7 @@ export const restrictUser = (interaction: MessageComponentInteraction) =>
     const guildId = interaction.guildId!;
 
     // Get settings and check permissions
-    const { moderator: modRoleId } = yield* fetchSettingsEffect(guildId, [
+    const { moderator: modRoleId } = yield* fetchSettings(guildId, [
       SETTINGS.moderator,
     ]);
 
@@ -299,7 +299,7 @@ export const timeoutUser = (interaction: MessageComponentInteraction) =>
     const guildId = interaction.guildId!;
 
     // Get settings and check permissions
-    const { moderator: modRoleId } = yield* fetchSettingsEffect(guildId, [
+    const { moderator: modRoleId } = yield* fetchSettings(guildId, [
       SETTINGS.moderator,
     ]);
 

--- a/app/commands/escalate/escalate.ts
+++ b/app/commands/escalate/escalate.ts
@@ -21,7 +21,7 @@ import type { Features } from "#~/helpers/featuresFlags";
 import { votingStrategies, type Resolution } from "#~/helpers/modResponse";
 import {
   DEFAULT_QUORUM,
-  fetchSettingsEffect,
+  fetchSettings,
   SETTINGS,
 } from "#~/models/guilds.server";
 
@@ -54,10 +54,10 @@ export const createEscalationEffect = (
     const features: Features[] = [];
 
     // Get settings
-    const { moderator: modRoleId, restricted } = yield* fetchSettingsEffect(
-      guildId,
-      [SETTINGS.moderator, SETTINGS.restricted],
-    );
+    const { moderator: modRoleId, restricted } = yield* fetchSettings(guildId, [
+      SETTINGS.moderator,
+      SETTINGS.restricted,
+    ]);
 
     if (restricted) {
       features.push("restrict");
@@ -171,10 +171,10 @@ export const upgradeToMajorityEffect = (
     const features: Features[] = [];
 
     // Get settings
-    const { moderator: modRoleId, restricted } = yield* fetchSettingsEffect(
-      guildId,
-      [SETTINGS.moderator, SETTINGS.restricted],
-    );
+    const { moderator: modRoleId, restricted } = yield* fetchSettings(guildId, [
+      SETTINGS.moderator,
+      SETTINGS.restricted,
+    ]);
 
     if (restricted) {
       features.push("restrict");

--- a/app/commands/escalate/escalationResolver.ts
+++ b/app/commands/escalate/escalationResolver.ts
@@ -24,7 +24,7 @@ import {
   resolutions,
   type Resolution,
 } from "#~/helpers/modResponse";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 
 import { EscalationService, type Escalation } from "./service";
 import { buildVotesListContent } from "./strings";
@@ -94,7 +94,7 @@ export const processEscalationEffect = (
     }
 
     const [{ modLog }, reportedUser, guild, channel] = yield* Effect.all([
-      fetchSettingsEffect(escalation.guild_id, [SETTINGS.modLog]),
+      fetchSettings(escalation.guild_id, [SETTINGS.modLog]),
       fetchUserOrNull(client, escalation.reported_user_id),
       fetchGuild(client, escalation.guild_id),
       fetchChannelFromClient<ThreadChannel>(client, escalation.thread_id),

--- a/app/commands/escalate/expedite.ts
+++ b/app/commands/escalate/expedite.ts
@@ -10,7 +10,7 @@ import {
 import { logEffect } from "#~/effects/observability";
 import { hasModRole } from "#~/helpers/discord";
 import type { Resolution } from "#~/helpers/modResponse";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 
 import { EscalationService, type Escalation } from "./service";
 import { tallyVotes, type VoteTally } from "./voting";
@@ -39,7 +39,7 @@ export const expediteEffect = (interaction: MessageComponentInteraction) =>
     const expeditedBy = interaction.user.id;
 
     // Get settings and check mod role
-    const { moderator: modRoleId } = yield* fetchSettingsEffect(guildId, [
+    const { moderator: modRoleId } = yield* fetchSettings(guildId, [
       SETTINGS.moderator,
     ]);
 

--- a/app/commands/escalate/vote.ts
+++ b/app/commands/escalate/vote.ts
@@ -7,7 +7,7 @@ import { hasModRole } from "#~/helpers/discord";
 import { calculateScheduledFor, parseFlags } from "#~/helpers/escalationVotes";
 import type { Features } from "#~/helpers/featuresFlags";
 import type { Resolution, VotingStrategy } from "#~/helpers/modResponse";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 
 import { EscalationService, type Escalation } from "./service";
 import {
@@ -39,7 +39,7 @@ export const voteEffect =
       const features: Features[] = [];
 
       // Get settings
-      const { moderator: modRoleId, restricted } = yield* fetchSettingsEffect(
+      const { moderator: modRoleId, restricted } = yield* fetchSettings(
         guildId,
         [SETTINGS.moderator, SETTINGS.restricted],
       );

--- a/app/commands/memberApplications.test.ts
+++ b/app/commands/memberApplications.test.ts
@@ -17,10 +17,10 @@ vi.mock("#~/discord/api", () => ({
   },
 }));
 
-// Mock fetchSettingsEffect so resolveLogMessage doesn't need a guilds table
+// Mock fetchSettings so resolveLogMessage doesn't need a guilds table
 vi.mock("#~/models/guilds.server", () => ({
   SETTINGS: { modLog: "modLog" },
-  fetchSettingsEffect: () => Effect.succeed({ modLog: "fake-mod-log-channel" }),
+  fetchSettings: () => Effect.succeed({ modLog: "fake-mod-log-channel" }),
 }));
 
 // The apply-to-join handler now imports FeatureFlagService, so loading this

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -35,7 +35,7 @@ import {
   type ModalCommand,
 } from "#~/helpers/discord";
 import { activateMembershipGateEffect } from "#~/jobs/bulkRoleAssignment";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 import { getOrCreateUserThread } from "#~/models/userThreads";
 
 /**
@@ -80,7 +80,7 @@ const resolveLogMessage = (
 ) =>
   Effect.gen(function* () {
     const db = yield* DatabaseService;
-    const { [SETTINGS.modLog]: modLog } = yield* fetchSettingsEffect(guildId, [
+    const { [SETTINGS.modLog]: modLog } = yield* fetchSettings(guildId, [
       SETTINGS.modLog,
     ]);
 
@@ -355,7 +355,7 @@ export const Command = [
         )) as { id: string };
 
         // Post summary to mod-log channel with link to the review message
-        const { [SETTINGS.modLog]: modLog } = yield* fetchSettingsEffect(
+        const { [SETTINGS.modLog]: modLog } = yield* fetchSettings(
           interaction.guild.id,
           [SETTINGS.modLog],
         );
@@ -432,7 +432,7 @@ export const Command = [
         const approverId = interaction.user.id;
 
         // Verify the user has the moderator role
-        const { [SETTINGS.moderator]: modRoleId } = yield* fetchSettingsEffect(
+        const { [SETTINGS.moderator]: modRoleId } = yield* fetchSettings(
           guildId,
           [SETTINGS.moderator],
         );
@@ -561,8 +561,10 @@ export const Command = [
         const denierId = interaction.user.id;
 
         // Verify the user has the moderator role
-        const { [SETTINGS.moderator]: denyModRoleId } =
-          yield* fetchSettingsEffect(guildId, [SETTINGS.moderator]);
+        const { [SETTINGS.moderator]: denyModRoleId } = yield* fetchSettings(
+          guildId,
+          [SETTINGS.moderator],
+        );
         if (!hasModRole(interaction, denyModRoleId)) {
           yield* interactionReply(interaction, {
             content: "Only moderators can deny applications.",
@@ -857,7 +859,7 @@ export const Command = [
         }
 
         // Verify the user has the moderator role
-        const { [SETTINGS.moderator]: modRoleId } = yield* fetchSettingsEffect(
+        const { [SETTINGS.moderator]: modRoleId } = yield* fetchSettings(
           guildId,
           [SETTINGS.moderator],
         );

--- a/app/commands/report/automodLog.ts
+++ b/app/commands/report/automodLog.ts
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 
 import { forwardMessageSafe, sendMessage } from "#~/effects/discordSdk";
 import { logEffect } from "#~/effects/observability";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 import { getOrCreateUserThread } from "#~/models/userThreads.ts";
 
 export interface AutomodReport {
@@ -50,7 +50,7 @@ export const logAutomod = ({
     const thread = yield* getOrCreateUserThread(guild, user);
 
     // Get mod log for forwarding
-    const { modLog, moderator } = yield* fetchSettingsEffect(guild.id, [
+    const { modLog, moderator } = yield* fetchSettings(guild.id, [
       SETTINGS.modLog,
       SETTINGS.moderator,
     ]);

--- a/app/commands/report/automodRuleLog.ts
+++ b/app/commands/report/automodRuleLog.ts
@@ -11,7 +11,7 @@ import { AUDIT_LOG_WINDOW_MS, fetchAuditLogEntry } from "#~/discord/auditLog";
 import { fetchChannelFromClient, sendMessage } from "#~/effects/discordSdk";
 import { logEffect } from "#~/effects/observability";
 import { truncateMessage } from "#~/helpers/string";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -108,9 +108,7 @@ const buildUpdateDiff = (
 
 const fetchModLogChannel = (rule: AutoModerationRule) =>
   Effect.gen(function* () {
-    const { modLog } = yield* fetchSettingsEffect(rule.guild.id, [
-      SETTINGS.modLog,
-    ]);
+    const { modLog } = yield* fetchSettings(rule.guild.id, [SETTINGS.modLog]);
     if (!modLog) {
       yield* logEffect(
         "debug",

--- a/app/commands/report/constructLog.ts
+++ b/app/commands/report/constructLog.ts
@@ -9,7 +9,7 @@ import {
   isForwardedMessage,
 } from "#~/helpers/discord";
 import { truncateMessage } from "#~/helpers/string";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 import { ReportReasons, type Report } from "#~/models/reportedMessages";
 
 export const ReadableReasons: Record<ReportReasons, string> = {
@@ -41,10 +41,9 @@ export const constructLog = ({
     }
     const { message } = lastReport;
     const { author } = message;
-    const { moderator } = yield* fetchSettingsEffect(
-      lastReport.message.guild.id,
-      [SETTINGS.moderator],
-    );
+    const { moderator } = yield* fetchSettings(lastReport.message.guild.id, [
+      SETTINGS.moderator,
+    ]);
 
     // This should never be possible but we gotta satisfy types
     if (!moderator) {

--- a/app/commands/report/modActionLog.ts
+++ b/app/commands/report/modActionLog.ts
@@ -4,7 +4,7 @@ import { Effect } from "effect";
 import { forwardMessageSafe, sendMessage } from "#~/effects/discordSdk";
 import { logEffect } from "#~/effects/observability";
 import { truncateMessage } from "#~/helpers/string";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 import { recordModAction } from "#~/models/modActions";
 import { getOrCreateUserThread } from "#~/models/userThreads.ts";
 
@@ -64,7 +64,7 @@ export const logModAction = (report: ModActionReport) =>
     const thread = yield* getOrCreateUserThread(guild, user);
 
     // Get mod log for forwarding
-    const { modLog, moderator } = yield* fetchSettingsEffect(guild.id, [
+    const { modLog, moderator } = yield* fetchSettings(guild.id, [
       SETTINGS.modLog,
       SETTINGS.moderator,
     ]);

--- a/app/commands/report/userLog.ts
+++ b/app/commands/report/userLog.ts
@@ -28,7 +28,7 @@ import {
   quoteAndEscape,
   quoteAndEscapePoll,
 } from "#~/helpers/discord";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 import {
   getReportsForMessage,
   getUserReportStats,
@@ -85,7 +85,7 @@ export function logUserMessage({
     // Check if this exact message has already been reported
     const [existingReports, { modLog }, logBody, thread] = yield* Effect.all([
       getReportsForMessage(message.id, guild.id),
-      fetchSettingsEffect(guild.id, [SETTINGS.modLog]),
+      fetchSettings(guild.id, [SETTINGS.modLog]),
       constructLog({
         extra,
         logs: [{ message, reason, staff }],

--- a/app/commands/setupHandlers.test.ts
+++ b/app/commands/setupHandlers.test.ts
@@ -14,10 +14,6 @@ import {
 } from "./setupHandlers";
 
 // Mock modules with side effects before importing the module under test
-vi.mock("#~/AppRuntime", () => ({
-  db: {},
-  runTakeFirst: vi.fn(),
-}));
 vi.mock("#~/effects/discordSdk", () => ({}));
 vi.mock("#~/effects/observability", () => ({
   log: () => {

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -8,7 +8,7 @@ import {
 } from "discord.js";
 import { Effect } from "effect";
 
-import { db, runTakeFirst } from "#~/AppRuntime";
+import { db, runEffect, runTakeFirst } from "#~/AppRuntime";
 import {
   interactionDeferUpdate,
   interactionEditReply,
@@ -134,7 +134,7 @@ export async function initSetupForm(
 
   // Try to populate from existing guild settings
   const defaults = defaultSetup();
-  const guild = await fetchGuild(guildId);
+  const guild = await runEffect(fetchGuild(guildId));
   if (guild?.settings) {
     const settings = JSON.parse(guild.settings) as Record<string, string>;
 

--- a/app/commands/setupTickets.ts
+++ b/app/commands/setupTickets.ts
@@ -32,7 +32,7 @@ import {
 } from "#~/helpers/discord";
 import { webBaseUrl } from "#~/helpers/env.server";
 import { featureStats } from "#~/helpers/metrics";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 
 export const DEFAULT_BUTTON_TEXT = "Open a private ticket with the moderators";
 
@@ -126,7 +126,7 @@ export const Command = [
 
         let roleId = pingableRole?.id;
         if (!roleId) {
-          const { [SETTINGS.moderator]: mod } = yield* fetchSettingsEffect(
+          const { [SETTINGS.moderator]: mod } = yield* fetchSettings(
             interaction.guild.id,
             [SETTINGS.moderator, SETTINGS.modLog],
           );
@@ -257,7 +257,7 @@ export const Command = [
 
         // If there's no config, that means that the button was set up before the db was set up. Add one with default values
         if (!config) {
-          const { [SETTINGS.moderator]: mod } = yield* fetchSettingsEffect(
+          const { [SETTINGS.moderator]: mod } = yield* fetchSettings(
             interaction.guild.id,
             [SETTINGS.moderator, SETTINGS.modLog],
           );
@@ -383,7 +383,7 @@ export const Command = [
           return;
         }
 
-        const { [SETTINGS.modLog]: modLog } = yield* fetchSettingsEffect(
+        const { [SETTINGS.modLog]: modLog } = yield* fetchSettings(
           interaction.guild.id,
           [SETTINGS.modLog],
         );

--- a/app/discord/pipelines/activityTrackerHandlers.test.ts
+++ b/app/discord/pipelines/activityTrackerHandlers.test.ts
@@ -3,6 +3,8 @@ import { ChannelType } from "discord.js";
 import { Context, Effect, Layer } from "effect";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+import { DatabaseService } from "#~/Database";
+
 import {
   handleMessageCreate,
   handleMessageDelete,
@@ -32,10 +34,6 @@ const mockDeleteFrom = vi.fn().mockReturnValue({
 vi.mock("#~/AppRuntime", () => ({
   runEffect: vi.fn(),
   RuntimeContext: {},
-  db: {
-    insertInto: (...args: any[]) => mockInsertInto(...args),
-    deleteFrom: (...args: any[]) => mockDeleteFrom(...args),
-  },
 }));
 
 vi.mock("#~/helpers/discord.js", () => ({
@@ -57,7 +55,7 @@ vi.mock("#~/helpers/discord.js", () => ({
 }));
 
 vi.mock("#~/discord/utils", () => ({
-  getOrFetchChannel: vi.fn().mockResolvedValue({ category: "general" }),
+  getOrFetchChannel: vi.fn(() => Effect.succeed({ category: "general" })),
 }));
 
 vi.mock("#~/helpers/metrics", () => ({
@@ -66,9 +64,20 @@ vi.mock("#~/helpers/metrics", () => ({
 
 // --- Helpers ---
 
+// Only insertInto + deleteFrom are exercised by the two tested handlers
+// (handleMessageCreate / handleMessageDelete). Do NOT add updateTable here —
+// the reaction/update handlers aren't tested and an unused mock trips lint.
+const mockDb = {
+  insertInto: (...args: any[]) => mockInsertInto(...args),
+  deleteFrom: (...args: any[]) => mockDeleteFrom(...args),
+};
+
 const runHandler = (effect: Effect.Effect<void, unknown, any>) =>
-  // @ts-expect-error - test mock: RuntimeContext services are vi.mocked
-  Effect.runPromise(effect);
+  Effect.runPromise(
+    effect.pipe(
+      Effect.provide(Layer.succeed(DatabaseService, mockDb as any)),
+    ) as Effect.Effect<void, unknown, never>,
+  );
 
 const makeCreateEvent = (overrides: any = {}) => ({
   type: "GuildMemberMessage" as const,

--- a/app/discord/pipelines/activityTrackerHandlers.ts
+++ b/app/discord/pipelines/activityTrackerHandlers.ts
@@ -1,7 +1,8 @@
 import { ChannelType } from "discord.js";
 import { Effect } from "effect";
 
-import { db, type RuntimeContext } from "#~/AppRuntime";
+import { type RuntimeContext } from "#~/AppRuntime";
+import { DatabaseService } from "#~/Database";
 import type {
   GuildMemberMessage,
   GuildMessageDelete,
@@ -40,8 +41,9 @@ export const handleMessageCreate = (
   }
 
   return Effect.gen(function* () {
+    const db = yield* DatabaseService;
     const info = yield* getMessageStats(msg);
-    const channelInfo = yield* Effect.promise(() => getOrFetchChannel(msg));
+    const channelInfo = yield* getOrFetchChannel(msg);
 
     yield* db.insertInto("message_stats").values({
       ...info,
@@ -85,6 +87,7 @@ export const handleMessageUpdate = (
   e: GuildMessageUpdate,
 ): Effect.Effect<void, unknown, RuntimeContext> =>
   Effect.gen(function* () {
+    const db = yield* DatabaseService;
     const info = yield* getMessageStats(e.newMessage);
 
     yield* db
@@ -121,6 +124,7 @@ export const handleMessageDelete = (
   }
 
   return Effect.gen(function* () {
+    const db = yield* DatabaseService;
     yield* db
       .deleteFrom("message_stats")
       .where("message_id", "=", e.message.id);
@@ -145,6 +149,7 @@ export const handleReactionAdd = (
   e: MessageReactionAddEvent,
 ): Effect.Effect<void, unknown, RuntimeContext> =>
   Effect.gen(function* () {
+    const db = yield* DatabaseService;
     yield* db
       .updateTable("message_stats")
       .where("message_id", "=", e.reaction.message.id)
@@ -170,6 +175,7 @@ export const handleReactionRemove = (
   e: MessageReactionRemoveEvent,
 ): Effect.Effect<void, unknown, RuntimeContext> =>
   Effect.gen(function* () {
+    const db = yield* DatabaseService;
     yield* db
       .updateTable("message_stats")
       .where("message_id", "=", e.reaction.message.id)

--- a/app/discord/pipelines/deletionLogHandlers.test.ts
+++ b/app/discord/pipelines/deletionLogHandlers.test.ts
@@ -6,7 +6,7 @@ import { fetchAuditLogEntry } from "#~/discord/auditLog";
 import { MessageCacheService } from "#~/discord/messageCacheService";
 import { fetchChannel, fetchUserOrNull } from "#~/effects/discordSdk";
 import { getOrCreateDeletionLogThread } from "#~/models/deletionLogThreads";
-import { fetchSettingsEffect } from "#~/models/guilds.server";
+import { fetchSettings } from "#~/models/guilds.server";
 import { getOrCreateUserThread } from "#~/models/userThreads";
 
 import {
@@ -30,7 +30,7 @@ vi.mock("#~/Database", () => ({
 }));
 // These will be controlled per-test via vi.mocked()
 vi.mock("#~/models/guilds.server", () => ({
-  fetchSettingsEffect: vi.fn(),
+  fetchSettings: vi.fn(),
   SETTINGS: { deletionLog: "deletionLog", modLog: "modLog" },
 }));
 vi.mock("#~/discord/auditLog", () => ({
@@ -125,7 +125,7 @@ beforeEach(() => {
 
 describe("handleDelete", () => {
   test("returns early when guild has no deletion log configured", async () => {
-    vi.mocked(fetchSettingsEffect).mockReturnValue(Effect.succeed(null) as any);
+    vi.mocked(fetchSettings).mockReturnValue(Effect.succeed(null) as any);
 
     await runHandler(handleDelete(mockClient, makeDeleteEvent() as any));
 
@@ -133,7 +133,7 @@ describe("handleDelete", () => {
   });
 
   test("batches uncached deletions when no userId available", async () => {
-    vi.mocked(fetchSettingsEffect).mockReturnValue(
+    vi.mocked(fetchSettings).mockReturnValue(
       Effect.succeed({ deletionLog: "channel-1" }) as any,
     );
 
@@ -148,7 +148,7 @@ describe("handleDelete", () => {
   });
 
   test("resolves author from cache when message author is null", async () => {
-    vi.mocked(fetchSettingsEffect).mockReturnValue(
+    vi.mocked(fetchSettings).mockReturnValue(
       Effect.succeed({ deletionLog: "channel-1" }) as any,
     );
 
@@ -178,7 +178,7 @@ describe("handleDelete", () => {
   });
 
   test("posts to mod thread when audit log shows mod deletion", async () => {
-    vi.mocked(fetchSettingsEffect).mockReturnValue(
+    vi.mocked(fetchSettings).mockReturnValue(
       Effect.succeed({ deletionLog: "channel-1" }) as any,
     );
 
@@ -210,7 +210,7 @@ describe("handleDelete", () => {
 
 describe("handleEdit", () => {
   test("returns early when guild has no deletion log configured", async () => {
-    vi.mocked(fetchSettingsEffect).mockReturnValue(Effect.succeed(null) as any);
+    vi.mocked(fetchSettings).mockReturnValue(Effect.succeed(null) as any);
 
     await runHandler(handleEdit(mockClient, makeEditEvent() as any));
 
@@ -218,7 +218,7 @@ describe("handleEdit", () => {
   });
 
   test("returns early when newMessage has no author", async () => {
-    vi.mocked(fetchSettingsEffect).mockReturnValue(
+    vi.mocked(fetchSettings).mockReturnValue(
       Effect.succeed({ deletionLog: "channel-1" }) as any,
     );
 
@@ -232,7 +232,7 @@ describe("handleEdit", () => {
   });
 
   test("prefers cached content as before text", async () => {
-    vi.mocked(fetchSettingsEffect).mockReturnValue(
+    vi.mocked(fetchSettings).mockReturnValue(
       Effect.succeed({ deletionLog: "channel-1" }) as any,
     );
 
@@ -260,7 +260,7 @@ describe("handleEdit", () => {
 
 describe("handleBulkDelete", () => {
   test("returns early when guild has no deletion log configured", async () => {
-    vi.mocked(fetchSettingsEffect).mockReturnValue(Effect.succeed(null) as any);
+    vi.mocked(fetchSettings).mockReturnValue(Effect.succeed(null) as any);
 
     const event = {
       type: "GuildMessageBulkDelete" as const,
@@ -276,7 +276,7 @@ describe("handleBulkDelete", () => {
   });
 
   test("returns early when all messages are from bots", async () => {
-    vi.mocked(fetchSettingsEffect).mockReturnValue(
+    vi.mocked(fetchSettings).mockReturnValue(
       Effect.succeed({ deletionLog: "log-channel" }) as any,
     );
 
@@ -308,7 +308,7 @@ describe("handleBulkDelete", () => {
   });
 
   test("tallies non-bot messages per author", async () => {
-    vi.mocked(fetchSettingsEffect).mockReturnValue(
+    vi.mocked(fetchSettings).mockReturnValue(
       Effect.succeed({ deletionLog: "log-channel" }) as any,
     );
 

--- a/app/discord/pipelines/deletionLogHandlers.test.ts
+++ b/app/discord/pipelines/deletionLogHandlers.test.ts
@@ -28,11 +28,6 @@ vi.mock("#~/Database", () => ({
   DatabaseService: Context.GenericTag("DatabaseService"),
   DatabaseLayer: Layer.empty,
 }));
-vi.mock("#~/AppRuntime", () => ({
-  runEffect: vi.fn(),
-  RuntimeContext: {},
-}));
-
 // These will be controlled per-test via vi.mocked()
 vi.mock("#~/models/guilds.server", () => ({
   fetchSettingsEffect: vi.fn(),

--- a/app/discord/pipelines/deletionLogHandlers.ts
+++ b/app/discord/pipelines/deletionLogHandlers.ts
@@ -18,7 +18,7 @@ import { TransientError } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import { quoteMessageContent } from "#~/helpers/discord";
 import { getOrCreateDeletionLogThread } from "#~/models/deletionLogThreads";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 import { getOrCreateUserThread } from "#~/models/userThreads";
 
 // --- Uncached deletion batching ---
@@ -84,7 +84,7 @@ export const handleDelete = (
     const guild = e.guild;
     const msg = e.message;
 
-    const settings = yield* fetchSettingsEffect(guild.id, [
+    const settings = yield* fetchSettings(guild.id, [
       SETTINGS.deletionLog,
     ]).pipe(Effect.catchAll(() => Effect.succeed(null)));
 
@@ -251,7 +251,7 @@ export const handleEdit = (
     const newMessage = e.newMessage;
     const oldMessage = e.oldMessage;
 
-    const settings = yield* fetchSettingsEffect(guild.id, [
+    const settings = yield* fetchSettings(guild.id, [
       SETTINGS.deletionLog,
     ]).pipe(Effect.catchAll(() => Effect.succeed(null)));
 
@@ -337,7 +337,7 @@ export const handleBulkDelete = (
     const messages = e.messages;
     const channel = e.channel;
 
-    const settings = yield* fetchSettingsEffect(guild.id, [
+    const settings = yield* fetchSettings(guild.id, [
       SETTINGS.deletionLog,
     ]).pipe(Effect.catchAll(() => Effect.succeed(null)));
 

--- a/app/discord/pipelines/onboardGuildHandlers.test.ts
+++ b/app/discord/pipelines/onboardGuildHandlers.test.ts
@@ -19,10 +19,6 @@ vi.mock("#~/Database", () => ({
   DatabaseService: Context.GenericTag("DatabaseService"),
   DatabaseLayer: Layer.empty,
 }));
-vi.mock("#~/AppRuntime", () => ({
-  runEffect: vi.fn(),
-  RuntimeContext: {},
-}));
 vi.mock("#~/helpers/metrics", () => ({
   botStats: {
     guildJoined: vi.fn(),

--- a/app/discord/pipelines/onboardGuildHandlers.test.ts
+++ b/app/discord/pipelines/onboardGuildHandlers.test.ts
@@ -73,7 +73,9 @@ beforeEach(() => {
 describe("handleGuildCreate", () => {
   test("skips welcome and deploy when guild already exists (reconnect)", async () => {
     const { deployToGuild } = await import("#~/discord/deployCommands.server");
-    vi.mocked(fetchGuild).mockResolvedValue({ id: "guild-1" } as any);
+    vi.mocked(fetchGuild).mockReturnValue(
+      Effect.succeed({ id: "guild-1" } as any),
+    );
 
     const event = makeGuildCreateEvent();
     await runHandler(handleGuildCreate(event as any));
@@ -83,7 +85,7 @@ describe("handleGuildCreate", () => {
 
   test("deploys commands for new guild install", async () => {
     const { deployToGuild } = await import("#~/discord/deployCommands.server");
-    vi.mocked(fetchGuild).mockResolvedValue(undefined as any);
+    vi.mocked(fetchGuild).mockReturnValue(Effect.succeed(undefined as any));
 
     const event = makeGuildCreateEvent();
     await runHandler(handleGuildCreate(event as any));
@@ -94,7 +96,9 @@ describe("handleGuildCreate", () => {
   test("always emits guildJoined metric", async () => {
     const { botStats } = await import("#~/helpers/metrics");
 
-    vi.mocked(fetchGuild).mockResolvedValue({ id: "guild-1" } as any);
+    vi.mocked(fetchGuild).mockReturnValue(
+      Effect.succeed({ id: "guild-1" } as any),
+    );
 
     const event = makeGuildCreateEvent();
     await runHandler(handleGuildCreate(event as any));
@@ -119,7 +123,7 @@ describe("handleGuildDelete", () => {
 
   test("returns early when guild not found in DB", async () => {
     const { botStats } = await import("#~/helpers/metrics");
-    vi.mocked(fetchGuild).mockResolvedValue(undefined as any);
+    vi.mocked(fetchGuild).mockReturnValue(Effect.succeed(undefined as any));
 
     const event = makeGuildDeleteEvent();
     await runHandler(handleGuildDelete(event as any));
@@ -130,7 +134,9 @@ describe("handleGuildDelete", () => {
 
   test("emits guildRemoved metric when guild exists in DB", async () => {
     const { botStats } = await import("#~/helpers/metrics");
-    vi.mocked(fetchGuild).mockResolvedValue({ id: "guild-1" } as any);
+    vi.mocked(fetchGuild).mockReturnValue(
+      Effect.succeed({ id: "guild-1" } as any),
+    );
 
     const event = makeGuildDeleteEvent();
     await runHandler(handleGuildDelete(event as any));

--- a/app/discord/pipelines/onboardGuildHandlers.ts
+++ b/app/discord/pipelines/onboardGuildHandlers.ts
@@ -63,10 +63,7 @@ export const handleGuildCreate = (
   e: GuildCreateEvent,
 ): Effect.Effect<void, unknown, RuntimeContext> =>
   Effect.gen(function* () {
-    const appGuild = yield* Effect.tryPromise({
-      try: () => fetchGuild(e.guild.id),
-      catch: (err) => err,
-    });
+    const appGuild = yield* fetchGuild(e.guild.id);
 
     botStats.guildJoined(e.guild);
 
@@ -93,10 +90,7 @@ export const handleGuildDelete = (
     // GuildDelete also fires when a guild becomes temporarily unavailable
     if (e.guild.available === false) return;
 
-    const appGuild = yield* Effect.tryPromise({
-      try: () => fetchGuild(e.guild.id),
-      catch: (err) => err,
-    });
+    const appGuild = yield* fetchGuild(e.guild.id);
 
     if (!appGuild) return;
 

--- a/app/discord/pipelines/reactjiChannelerHandler.test.ts
+++ b/app/discord/pipelines/reactjiChannelerHandler.test.ts
@@ -19,10 +19,6 @@ vi.mock("#~/Database", () => ({
   DatabaseService: Context.GenericTag("DatabaseService"),
   DatabaseLayer: Layer.empty,
 }));
-vi.mock("#~/AppRuntime", () => ({
-  runEffect: vi.fn(),
-  RuntimeContext: {},
-}));
 vi.mock("#~/helpers/metrics", () => ({
   featureStats: { reactjiTriggered: vi.fn() },
 }));

--- a/app/discord/utils.ts
+++ b/app/discord/utils.ts
@@ -1,43 +1,70 @@
 import type { Message, TextChannel } from "discord.js";
+import { Effect } from "effect";
 
-import { db, run, runTakeFirst } from "#~/AppRuntime";
-import { log } from "#~/helpers/observability";
+import { DatabaseService, type SqlError } from "#~/Database";
+import type { DB } from "#~/db";
+import { logEffect } from "#~/effects/observability";
 
-export async function getOrFetchChannel(msg: Message) {
-  // TODO: cache eviction?
-  const channelInfo = await runTakeFirst(
-    db.selectFrom("channel_info").selectAll().where("id", "=", msg.channelId),
-  );
+type ChannelInfo = DB["channel_info"];
 
-  if (channelInfo) {
-    log("debug", "ActivityTracker", "Channel info found in cache", {
-      channelId: msg.channelId,
-      channelName: channelInfo.name,
-      category: channelInfo.category,
-    });
-    return channelInfo;
-  }
+export const getOrFetchChannel = (
+  msg: Message,
+): Effect.Effect<ChannelInfo, SqlError, DatabaseService> =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
 
-  log("debug", "ActivityTracker", "Fetching channel info from Discord", {
-    channelId: msg.channelId,
+    // TODO: cache eviction?
+    const [channelInfo] = yield* db
+      .selectFrom("channel_info")
+      .selectAll()
+      .where("id", "=", msg.channelId);
+
+    if (channelInfo) {
+      yield* logEffect(
+        "debug",
+        "ActivityTracker",
+        "Channel info found in cache",
+        {
+          channelId: msg.channelId,
+          channelName: channelInfo.name,
+          category: channelInfo.category,
+        },
+      );
+      return channelInfo;
+    }
+
+    yield* logEffect(
+      "debug",
+      "ActivityTracker",
+      "Fetching channel info from Discord",
+      {
+        channelId: msg.channelId,
+      },
+    );
+
+    const data = yield* Effect.promise(
+      () => msg.channel.fetch() as Promise<TextChannel>,
+    );
+    const values: ChannelInfo = {
+      id: msg.channelId,
+      category: data.parent?.name ?? null,
+      category_id: data.parent?.id ?? null,
+      name: data.name,
+    };
+
+    yield* db.insertInto("channel_info").values(values);
+
+    yield* logEffect(
+      "debug",
+      "ActivityTracker",
+      "Channel info added to cache",
+      {
+        channelId: msg.channelId,
+        channelName: data.name,
+        category: data.parent?.name,
+        categoryId: data.parent?.id,
+      },
+    );
+
+    return values;
   });
-
-  const data = (await msg.channel.fetch()) as TextChannel;
-  const values = {
-    id: msg.channelId,
-    category: data.parent?.name ?? null,
-    category_id: data.parent?.id ?? null,
-    name: data.name,
-  };
-
-  await run(db.insertInto("channel_info").values(values));
-
-  log("debug", "ActivityTracker", "Channel info added to cache", {
-    channelId: msg.channelId,
-    channelName: data.name,
-    category: data.parent?.name,
-    categoryId: data.parent?.id,
-  });
-
-  return values;
-}

--- a/app/effects/errors.ts
+++ b/app/effects/errors.ts
@@ -62,6 +62,10 @@ export class FeatureDisabledError extends Data.TaggedError(
   reason: "not_in_rollout" | "tier_required" | "flag_unavailable";
 }> {}
 
+export class SubscriptionNotFoundError extends Data.TaggedError(
+  "SubscriptionNotFoundError",
+)<{ guildId: string }> {}
+
 // --- Infra error taxonomy (named by the decision each drives) -------------
 // `cause` is always a serializable Error (narrowed at the classifier boundary).
 
@@ -144,6 +148,7 @@ export type AppError =
   | NoLeaderError
   | ResolutionExecutionError
   | FeatureDisabledError
+  | SubscriptionNotFoundError
   | SqlErrorType
   /** Effect.tryPromise wraps thrown exceptions in UnknownException; command-level
    *  catchAll blocks see this whenever a raw promise rejects with an untyped error. */

--- a/app/effects/posthog.ts
+++ b/app/effects/posthog.ts
@@ -52,9 +52,9 @@ export const syncGuildGroup = (guildId: string, guild?: Guild) =>
     const posthog = yield* PostHogService;
     if (!posthog) return;
 
-    const sub = yield* Effect.tryPromise(() =>
-      SubscriptionService.getGuildSubscription(guildId),
-    ).pipe(Effect.catchAll(() => Effect.succeed(undefined)));
+    const sub = yield* SubscriptionService.getGuildSubscription(guildId).pipe(
+      Effect.catchAll(() => Effect.succeed(null)),
+    );
 
     // Best-effort projection: a PostHog failure must never reject the caller.
     // syncGuildGroup runs inside Stripe webhook handlers and the payment-success

--- a/app/features/Admin/helpers.server.ts
+++ b/app/features/Admin/helpers.server.ts
@@ -1,6 +1,6 @@
 import { data } from "react-router";
 
-import { posthogClient } from "#~/AppRuntime";
+import { getPosthog } from "#~/AppRuntime";
 import { requireUser } from "#~/models/session.server";
 import { StripeService } from "#~/models/stripe.server";
 
@@ -13,8 +13,9 @@ export async function requireAdmin(request: Request) {
 }
 
 export async function fetchFeatureFlags(guildId: string) {
-  if (!posthogClient) return null;
-  return (await posthogClient.getAllFlags(guildId, {
+  const posthog = getPosthog();
+  if (!posthog) return null;
+  return (await posthog.getAllFlags(guildId, {
     groups: { guild: guildId },
   })) as Record<string, string | boolean>;
 }

--- a/app/features/spam/service.ts
+++ b/app/features/spam/service.ts
@@ -145,17 +145,23 @@ export const SpamDetectionServiceLive = Layer.effect(
       Effect.gen(function* () {
         if (member.permissions.has("Administrator")) return true;
 
-        const settings = yield* Effect.tryPromise({
-          try: () => fetchSettings(guildId, [SETTINGS.moderator]),
-          catch: () => null,
-        }).pipe(Effect.catchAll(() => Effect.succeed(null)));
+        // Swallow both SqlError and NotFoundError (missing guild row) to null,
+        // matching the pre-Effect behavior: absent/unreadable settings → not a mod.
+        const settings = yield* fetchSettings(guildId, [
+          SETTINGS.moderator,
+        ]).pipe(Effect.catchAll(() => Effect.succeed(null)));
 
         if (!settings?.moderator) return false;
 
         return Array.isArray(member.roles)
           ? member.roles.includes(settings.moderator)
           : member.roles.cache.has(settings.moderator);
-      }).pipe(Effect.withSpan("SpamDetection.isModeratorOrAdmin"));
+      }).pipe(
+        // fetchSettings requires DatabaseService; provide the captured handle
+        // here so this helper's requirement channel stays `never`.
+        Effect.provide(Layer.succeed(DatabaseService, db)),
+        Effect.withSpan("SpamDetection.isModeratorOrAdmin"),
+      );
 
     return {
       checkMessage: (message, member) =>

--- a/app/helpers/cohortAnalysis.ts
+++ b/app/helpers/cohortAnalysis.ts
@@ -1,7 +1,7 @@
 import { sql } from "kysely";
 import { partition } from "lodash-es";
 
-import { run } from "#~/AppRuntime";
+import { db, run } from "#~/AppRuntime";
 import type { CodeStats } from "#~/helpers/discord";
 import { descriptiveStats, percentile } from "#~/helpers/statistics";
 import { createMessageStatsQuery } from "#~/models/activity.server";
@@ -266,7 +266,7 @@ export async function getCohortMetrics(
   minMessageThreshold = 10,
 ): Promise<UserCohortMetrics[]> {
   // Get aggregated user data
-  const userStatsQuery = createMessageStatsQuery(guildId, start, end)
+  const userStatsQuery = createMessageStatsQuery(db, guildId, start, end)
     .select((eb) => [
       "author_id",
       eb.fn.count<number>("author_id").as("message_count"),
@@ -285,7 +285,7 @@ export async function getCohortMetrics(
   const userStats = await run(userStatsQuery);
 
   // Get daily activity for streak calculation
-  const dailyActivityQuery = createMessageStatsQuery(guildId, start, end)
+  const dailyActivityQuery = createMessageStatsQuery(db, guildId, start, end)
     .select(({ fn, eb, lit }) => [
       "author_id",
       fn.count<number>("author_id").as("message_count"),

--- a/app/helpers/metrics.ts
+++ b/app/helpers/metrics.ts
@@ -8,7 +8,7 @@ import type {
   UserContextMenuCommandInteraction,
 } from "discord.js";
 
-import { posthogClient } from "#~/AppRuntime.ts";
+import { getPosthog } from "#~/AppRuntime.ts";
 import { log } from "#~/helpers/observability";
 
 type EventValue = string | number | boolean;
@@ -312,14 +312,15 @@ const emitEvent = (
     guildId,
   }: { data?: EmitEventData; userId?: string; guildId?: string } = {},
 ) => {
+  const posthog = getPosthog();
   log("info", "Metrics", "event emitted", {
     user_id: userId,
     event_type: eventName,
     event_properties: data,
-    client: Boolean(posthogClient),
+    client: Boolean(posthog),
   });
 
-  posthogClient?.capture({
+  posthog?.capture({
     distinctId: userId ?? "system",
     event: eventName,
     properties: {

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -11,7 +11,13 @@ import {
   type RESTPostAPIGuildChannelJSONBody,
 } from "discord-api-types/v10";
 
-import { db, isFeatureEnabled, run, runTakeFirst } from "#~/AppRuntime";
+import {
+  db,
+  isFeatureEnabled,
+  run,
+  runEffect,
+  runTakeFirst,
+} from "#~/AppRuntime";
 import { DEFAULT_MESSAGE_TEXT } from "#~/commands/setupHoneypot";
 import { DEFAULT_BUTTON_TEXT } from "#~/commands/setupTickets";
 import { ssrDiscordSdk } from "#~/discord/api";
@@ -421,7 +427,7 @@ export async function setupAll(
   }
 
   // --- Initialize free subscription ---
-  await SubscriptionService.initializeFreeSubscription(guildId);
+  await runEffect(SubscriptionService.initializeFreeSubscription(guildId));
 
   log("info", "setupAll", "Setup-all completed via web", {
     guildId,

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -110,7 +110,7 @@ export async function setupAll(
   const created: string[] = [];
 
   // Register guild (idempotent)
-  await registerGuild(guildId);
+  await runEffect(registerGuild(guildId));
 
   // --- Load existing config to skip unchanged values ---
   const existingAppConfig = await runTakeFirst(
@@ -325,20 +325,22 @@ export async function setupAll(
   }
 
   // --- Save guild settings ---
-  await setSettings(guildId, {
-    [SETTINGS.modLog]: modLogChannelId,
-    [SETTINGS.moderator]: moderatorRoleId,
-    [SETTINGS.restricted]: restrictedRoleId,
-    ...(deletionLogChannelId
-      ? { [SETTINGS.deletionLog]: deletionLogChannelId }
-      : {}),
-    ...(resolvedMemberRoleId
-      ? { [SETTINGS.memberRole]: resolvedMemberRoleId }
-      : {}),
-    ...(applicationChannelId
-      ? { [SETTINGS.applicationChannel]: applicationChannelId }
-      : {}),
-  });
+  await runEffect(
+    setSettings(guildId, {
+      [SETTINGS.modLog]: modLogChannelId,
+      [SETTINGS.moderator]: moderatorRoleId,
+      [SETTINGS.restricted]: restrictedRoleId,
+      ...(deletionLogChannelId
+        ? { [SETTINGS.deletionLog]: deletionLogChannelId }
+        : {}),
+      ...(resolvedMemberRoleId
+        ? { [SETTINGS.memberRole]: resolvedMemberRoleId }
+        : {}),
+      ...(applicationChannelId
+        ? { [SETTINGS.applicationChannel]: applicationChannelId }
+        : {}),
+    }),
+  );
 
   // --- Honeypot channel (optional) ---
   let honeypotChannelId: string | undefined;

--- a/app/models/activity.server.test.ts
+++ b/app/models/activity.server.test.ts
@@ -30,11 +30,6 @@ vi.mock("#~/helpers/userInfoCache", () => ({
   }),
 }));
 
-// --- mock cohortAnalysis (only used by getEnhancedUserAnalytics which was deleted) ---
-vi.mock("#~/helpers/cohortAnalysis", () => ({
-  getUserCohortAnalysis: vi.fn().mockResolvedValue(null),
-}));
-
 // In-memory SQLite test layer (mirrors app/models/user.server.test.ts)
 const TestSqliteLive = Layer.scoped(
   SqlClient.SqlClient,

--- a/app/models/activity.server.test.ts
+++ b/app/models/activity.server.test.ts
@@ -1,0 +1,368 @@
+import { Effect, Exit, Layer, ManagedRuntime } from "effect";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import * as Reactivity from "@effect/experimental/Reactivity";
+import { SqlClient } from "@effect/sql";
+import * as Sqlite from "@effect/sql-kysely/Sqlite";
+import { SqliteClient } from "@effect/sql-sqlite-node";
+
+import { DatabaseService, type DB } from "#~/Database";
+import {
+  AnalyticsFetchError,
+  getTopParticipantsEffect,
+  getUserMessageAnalyticsEffect,
+} from "#~/models/activity.server";
+
+// --- mock userInfoCache so tests don't hit Discord ---
+vi.mock("#~/helpers/userInfoCache", () => ({
+  getOrFetchUser: vi.fn().mockResolvedValue({
+    id: "user-1",
+    username: "testuser",
+    global_name: "Test User",
+  }),
+}));
+
+// --- mock cohortAnalysis (only used by getEnhancedUserAnalytics which was deleted) ---
+vi.mock("#~/helpers/cohortAnalysis", () => ({
+  getUserCohortAnalysis: vi.fn().mockResolvedValue(null),
+}));
+
+// In-memory SQLite test layer (mirrors app/models/user.server.test.ts)
+const TestSqliteLive = Layer.scoped(
+  SqlClient.SqlClient,
+  SqliteClient.make({ filename: ":memory:" }),
+).pipe(Layer.provide(Reactivity.layer));
+
+const TestKyselyLive = Layer.effect(DatabaseService, Sqlite.make<DB>()).pipe(
+  Layer.provide(TestSqliteLive),
+);
+
+// provideMerge keeps a single memoized in-memory connection.
+const TestBase = Layer.mergeAll(TestSqliteLive, TestKyselyLive);
+
+const testRuntime = ManagedRuntime.make(TestBase);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const runTest = <A>(effect: Effect.Effect<A, any, any>) =>
+  testRuntime.runPromise(effect);
+
+beforeAll(async () => {
+  await runTest(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql.unsafe(`
+        CREATE TABLE IF NOT EXISTS message_stats (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          guild_id TEXT NOT NULL,
+          author_id TEXT NOT NULL,
+          channel_id TEXT NOT NULL,
+          channel_category TEXT,
+          sent_at INTEGER NOT NULL,
+          word_count INTEGER DEFAULT 0,
+          react_count INTEGER DEFAULT 0,
+          code_stats TEXT
+        )
+      `);
+      yield* sql.unsafe(`
+        CREATE TABLE IF NOT EXISTS channel_info (
+          id TEXT PRIMARY KEY NOT NULL,
+          name TEXT
+        )
+      `);
+    }),
+  );
+});
+
+beforeEach(async () => {
+  await runTest(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql.unsafe("DELETE FROM message_stats");
+      yield* sql.unsafe("DELETE FROM channel_info");
+    }),
+  );
+});
+
+afterAll(async () => {
+  await testRuntime.dispose();
+});
+
+// Helper: insert a message_stats row
+function insertMessage(
+  sql: SqlClient.SqlClient,
+  opts: {
+    guild_id: string;
+    author_id: string;
+    channel_id: string;
+    channel_category?: string | null;
+    sent_at: number; // unix ms
+    word_count?: number;
+    react_count?: number;
+  },
+) {
+  return sql.unsafe(`
+    INSERT INTO message_stats (guild_id, author_id, channel_id, channel_category, sent_at, word_count, react_count)
+    VALUES ('${opts.guild_id}', '${opts.author_id}', '${opts.channel_id}', ${opts.channel_category ? `'${opts.channel_category}'` : "NULL"}, ${opts.sent_at}, ${opts.word_count ?? 0}, ${opts.react_count ?? 0})
+  `);
+}
+
+// A date in ms for a known date string
+function dateMs(dateStr: string): number {
+  return new Date(dateStr).getTime();
+}
+
+describe("getUserMessageAnalyticsEffect", () => {
+  it("returns gap-filled dailyBreakdown, aggregated categoryBreakdown and channelBreakdown", async () => {
+    const guildId = "guild-1";
+    const userId = "user-1";
+    const start = "2024-01-01";
+    const end = "2024-01-03";
+
+    await runTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        // Day 1: two messages in an allowed category
+        yield* insertMessage(sql, {
+          guild_id: guildId,
+          author_id: userId,
+          channel_id: "chan-1",
+          channel_category: "Need Help",
+          sent_at: dateMs("2024-01-01T10:00:00Z"),
+          word_count: 10,
+          react_count: 2,
+        });
+        yield* insertMessage(sql, {
+          guild_id: guildId,
+          author_id: userId,
+          channel_id: "chan-1",
+          channel_category: "Need Help",
+          sent_at: dateMs("2024-01-01T12:00:00Z"),
+          word_count: 5,
+          react_count: 1,
+        });
+        // Day 3: one message (day 2 will be a gap)
+        yield* insertMessage(sql, {
+          guild_id: guildId,
+          author_id: userId,
+          channel_id: "chan-2",
+          channel_category: "React General",
+          sent_at: dateMs("2024-01-03T09:00:00Z"),
+          word_count: 20,
+          react_count: 0,
+        });
+        // channel_info
+        yield* sql.unsafe(
+          `INSERT INTO channel_info (id, name) VALUES ('chan-1', 'help-channel')`,
+        );
+        yield* sql.unsafe(
+          `INSERT INTO channel_info (id, name) VALUES ('chan-2', 'react-general')`,
+        );
+      }),
+    );
+
+    const result = await runTest(
+      getUserMessageAnalyticsEffect(guildId, userId, start, end),
+    );
+
+    // dailyBreakdown should have 3 entries (gap-filled)
+    expect(result.dailyBreakdown).toHaveLength(3);
+    const day1 = result.dailyBreakdown.find((d) => d.date === "2024-01-01");
+    const day2 = result.dailyBreakdown.find((d) => d.date === "2024-01-02");
+    const day3 = result.dailyBreakdown.find((d) => d.date === "2024-01-03");
+
+    expect(day1).toBeDefined();
+    expect(Number(day1!.messages)).toBe(2);
+    expect(Number(day1!.word_count)).toBe(15);
+    expect(Number(day1!.react_count)).toBe(3);
+
+    // Day 2 is a zero-fill
+    expect(day2).toBeDefined();
+    expect(Number(day2!.messages)).toBe(0);
+
+    expect(day3).toBeDefined();
+    expect(Number(day3!.messages)).toBe(1);
+
+    // categoryBreakdown
+    const needHelp = result.categoryBreakdown.find(
+      (c) => c.channel_category === "Need Help",
+    );
+    expect(needHelp).toBeDefined();
+    expect(Number(needHelp!.messages)).toBe(2);
+
+    // channelBreakdown includes channel name from join
+    const chan1 = result.channelBreakdown.find(
+      (c) => c.channel_id === "chan-1",
+    );
+    expect(chan1).toBeDefined();
+    // The name field is aliased as "channel.name" — check it's present
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((chan1 as any).name).toBe("help-channel");
+
+    // userInfo is from the mock
+    expect(result.userInfo).toBeDefined();
+  });
+
+  it("returns all-zero dailyBreakdown for an empty date range", async () => {
+    const result = await runTest(
+      getUserMessageAnalyticsEffect(
+        "guild-1",
+        "user-1",
+        "2024-02-01",
+        "2024-02-03",
+      ),
+    );
+    expect(result.dailyBreakdown).toHaveLength(3);
+    result.dailyBreakdown.forEach((d) => {
+      expect(Number(d.messages)).toBe(0);
+    });
+    expect(result.categoryBreakdown).toHaveLength(0);
+    expect(result.channelBreakdown).toHaveLength(0);
+  });
+
+  it("excludes rows not in ALLOWED_CATEGORIES or ALLOWED_CHANNELS", async () => {
+    const guildId = "guild-filter";
+    const userId = "user-filter";
+    await runTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        // This row should be excluded (category not in allowed list)
+        yield* insertMessage(sql, {
+          guild_id: guildId,
+          author_id: userId,
+          channel_id: "chan-bad",
+          channel_category: "Off Topic",
+          sent_at: dateMs("2024-03-01T10:00:00Z"),
+          word_count: 100,
+        });
+        // This row should be included (allowed category)
+        yield* insertMessage(sql, {
+          guild_id: guildId,
+          author_id: userId,
+          channel_id: "chan-good",
+          channel_category: "Advanced Topics",
+          sent_at: dateMs("2024-03-01T11:00:00Z"),
+          word_count: 50,
+        });
+      }),
+    );
+
+    const result = await runTest(
+      getUserMessageAnalyticsEffect(
+        guildId,
+        userId,
+        "2024-03-01",
+        "2024-03-01",
+      ),
+    );
+
+    // Only 1 message (the allowed one)
+    const day = result.dailyBreakdown.find((d) => d.date === "2024-03-01");
+    expect(day).toBeDefined();
+    expect(Number(day!.messages)).toBe(1);
+    expect(Number(day!.word_count)).toBe(50);
+  });
+
+  it("surfaces AnalyticsFetchError when getOrFetchUser rejects", async () => {
+    const { getOrFetchUser } = await import("#~/helpers/userInfoCache");
+    vi.mocked(getOrFetchUser).mockRejectedValueOnce(new Error("network fail"));
+
+    const exit = await testRuntime.runPromiseExit(
+      getUserMessageAnalyticsEffect(
+        "guild-1",
+        "user-err",
+        "2024-01-01",
+        "2024-01-01",
+      ),
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      const cause = exit.cause;
+      // The failure cause has _tag "Fail" with an .error property
+      expect((cause as { _tag: string })._tag).toBe("Fail");
+      // Walk to the error
+      const err = (cause as { _tag: string; error: unknown }).error;
+      expect(err).toBeInstanceOf(AnalyticsFetchError);
+      expect((err as AnalyticsFetchError).operation).toBe("getOrFetchUser");
+    }
+  });
+});
+
+describe("getTopParticipantsEffect", () => {
+  it("returns only users meeting message or word threshold, with score and metadata", async () => {
+    const guildId = "guild-top";
+    const start = "2024-04-01";
+    const end = "2024-04-30";
+
+    // messageThreshold = 250, wordThreshold = 2200
+    // user-above: 300 messages, 3000 words → qualifies
+    // user-below: 10 messages, 100 words → excluded
+
+    await runTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        // Insert 300 messages for user-above spread across 3 days
+        for (let i = 0; i < 300; i++) {
+          const day = (i % 3) + 1;
+          yield* insertMessage(sql, {
+            guild_id: guildId,
+            author_id: "user-above",
+            channel_id: "chan-1",
+            channel_category: "Need Help",
+            sent_at: dateMs(`2024-04-0${day}T10:00:00Z`),
+            word_count: 10, // 300*10=3000 words total
+            react_count: 1,
+          });
+        }
+        // Insert 10 messages for user-below (doesn't qualify)
+        for (let i = 0; i < 10; i++) {
+          yield* insertMessage(sql, {
+            guild_id: guildId,
+            author_id: "user-below",
+            channel_id: "chan-2",
+            channel_category: "React General",
+            sent_at: dateMs(`2024-04-01T10:00:00Z`),
+            word_count: 10,
+            react_count: 0,
+          });
+        }
+      }),
+    );
+
+    const results = await runTest(
+      getTopParticipantsEffect(guildId, start, end),
+    );
+
+    // Only user-above should appear
+    expect(results.length).toBe(1);
+    const top = results[0];
+    expect(top.data.member.author_id).toBe("user-above");
+
+    // Score fields present
+    expect(typeof top.score.messageScore).toBe("number");
+    expect(typeof top.score.wordScore).toBe("number");
+    expect(typeof top.score.channelScore).toBe("number");
+    expect(typeof top.score.consistencyScore).toBe("number");
+
+    // Metadata present
+    expect(typeof top.metadata.percentZeroDays).toBe("number");
+
+    // Username from mock
+    expect(top.data.member.username).toBe("Test User");
+  });
+
+  it("returns empty array when no users meet the threshold", async () => {
+    const results = await runTest(
+      getTopParticipantsEffect("guild-empty", "2024-05-01", "2024-05-31"),
+    );
+    expect(results).toHaveLength(0);
+  });
+});

--- a/app/models/activity.server.ts
+++ b/app/models/activity.server.ts
@@ -1,8 +1,13 @@
+import { Data, Effect } from "effect";
 import { sql } from "kysely";
 
-import { db, run } from "#~/AppRuntime";
-import { type DB } from "#~/Database";
-import { getUserCohortAnalysis } from "#~/helpers/cohortAnalysis";
+import {
+  DatabaseService,
+  type DB,
+  type EffectKysely,
+  type SqlError,
+} from "#~/Database";
+import { logEffect } from "#~/effects/observability";
 import { fillDateGaps } from "#~/helpers/dateUtils";
 import { getOrFetchUser } from "#~/helpers/userInfoCache";
 
@@ -19,9 +24,27 @@ const ALLOWED_CATEGORIES: string[] = [
 const ALLOWED_CHANNELS: string[] = [];
 
 /**
- * Creates a base query for message_stats filtered by guild, date range, and optionally user
+ * Tagged error for wrapping non-Effect Promise dependency failures
+ * (getOrFetchUser, getUserCohortAnalysis). We pass `cause: unknown` through
+ * and never stringify it — satisfies local/no-error-string-cast.
+ */
+export class AnalyticsFetchError extends Data.TaggedError(
+  "AnalyticsFetchError",
+)<{
+  readonly operation: string;
+  readonly userId?: string;
+  readonly cause: unknown;
+}> {}
+
+export type ActivityError = SqlError | AnalyticsFetchError;
+
+/**
+ * Creates a base query for message_stats filtered by guild, date range, and optionally user.
+ * Takes db as an explicit parameter so this builder can be used from both
+ * Effect-native callers (service methods) and legacy async callers (cohortAnalysis.ts).
  */
 export function createMessageStatsQuery(
+  db: EffectKysely,
   guildId: MessageStats["guild_id"],
   start: string,
   end: string,
@@ -40,251 +63,156 @@ export function createMessageStatsQuery(
   return query;
 }
 
-/**
- * Gets complete user message analytics using composed queries
- */
-export async function getUserMessageAnalytics(
-  guildId: string,
-  userId: string,
-  start: string,
-  end: string,
-) {
-  // Build daily stats query
-  const dailyQuery = createMessageStatsQuery(guildId, start, end, userId)
-    .select(({ fn, eb, lit }) => [
-      fn.countAll<number>().as("messages"),
-      fn.sum<number>("word_count").as("word_count"),
-      fn.sum<number>("react_count").as("react_count"),
-      fn("round", [fn.avg("word_count"), lit(3)]).as("avg_words"),
-      eb
-        .fn("date", [eb("sent_at", "/", lit(1000)), sql.lit("unixepoch")])
-        .as("date"),
-    ])
-    .where((eb) =>
-      eb.or([
-        eb("channel_id", "in", ALLOWED_CHANNELS),
-        eb("channel_category", "in", ALLOWED_CATEGORIES),
-      ]),
-    )
-    .orderBy("date", "asc")
-    .groupBy("date");
+interface DailyBreakdown {
+  messages: number;
+  word_count: number;
+  react_count: number;
+  avg_words: number;
+  date: string;
+}
 
-  // Build category stats query
-  const categoryQuery = createMessageStatsQuery(guildId, start, end, userId)
-    .select(({ fn }) => [
-      fn.count<number>("channel_category").as("messages"),
-      "channel_category",
-    ])
-    .where((eb) =>
-      eb.or([
-        eb("channel_id", "in", ALLOWED_CHANNELS),
-        eb("channel_category", "in", ALLOWED_CATEGORIES),
-      ]),
-    )
-    .groupBy("channel_category");
-
-  // Build channel stats query
-  const channelQuery = createMessageStatsQuery(guildId, start, end, userId)
-    // @ts-expect-error - Kysely selector typing is complex
-    .select(({ fn }) => [
-      fn.count<number>("channel_id").as("messages"),
-      "channel_id",
-      "channel.name",
-    ])
-    .leftJoin(
-      "channel_info as channel",
-      "channel.id",
-      "message_stats.channel_id",
-    )
-    .where((eb) =>
-      eb.or([
-        eb("channel_id", "in", ALLOWED_CHANNELS),
-        eb("channel_category", "in", ALLOWED_CATEGORIES),
-      ]),
-    )
-    .orderBy("messages", "desc")
-    .groupBy("channel_id");
-
-  console.log("sql:", { compiled: dailyQuery.compile() });
-
-  const [dailyResults, categoryBreakdown, channelBreakdown, userInfo] =
-    await Promise.all([
-      run(dailyQuery),
-      run(categoryQuery),
-      run(channelQuery),
-      getOrFetchUser(userId),
-    ]);
-
-  interface DailyBreakdown {
+export interface UserMessageAnalytics {
+  dailyBreakdown: DailyBreakdown[];
+  categoryBreakdown: { messages: number; channel_category: string | null }[];
+  channelBreakdown: {
     messages: number;
-    word_count: number;
-    react_count: number;
-    avg_words: number;
-    date: string;
-  }
-  // Only daily breakdown needs date gap filling
-  const dailyBreakdown = fillDateGaps<DailyBreakdown>(
-    dailyResults as DailyBreakdown[],
-    start,
-    end,
-    {
-      messages: 0,
-      word_count: 0,
-      react_count: 0,
-      avg_words: 0,
-    },
-  );
-
-  return { dailyBreakdown, categoryBreakdown, channelBreakdown, userInfo };
+    channel_id: string;
+    name: string | null;
+  }[];
+  userInfo: Awaited<ReturnType<typeof getOrFetchUser>>;
 }
 
-export async function getEnhancedUserAnalytics(
+/**
+ * Free Effect function: gets complete user message analytics using composed queries.
+ * Requires DatabaseService in context (provided by AppLayer/TestLayer).
+ */
+export const getUserMessageAnalyticsEffect = (
   guildId: string,
   userId: string,
   start: string,
   end: string,
-) {
-  const [basicAnalytics, cohortComparison] = await Promise.all([
-    getUserMessageAnalytics(guildId, userId, start, end),
-    getUserCohortAnalysis(guildId, userId, start, end),
-  ]);
+): Effect.Effect<UserMessageAnalytics, ActivityError, DatabaseService> =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
 
-  return {
-    ...basicAnalytics,
-    cohortComparison,
-  };
-}
+    yield* logEffect("debug", "Activity", "getUserMessageAnalytics started", {
+      guildId,
+      userId,
+      start,
+      end,
+    });
 
-export async function getTopParticipants(
-  guildId: MessageStats["guild_id"],
-  intervalStart: string,
-  intervalEnd: string,
-) {
-  const config = {
-    count: 100,
-    messageThreshold: 250,
-    wordThreshold: 2200,
-  };
+    // Build daily stats query
+    const dailyQuery = createMessageStatsQuery(db, guildId, start, end, userId)
+      .select(({ fn, eb, lit }) => [
+        fn.countAll<number>().as("messages"),
+        fn.sum<number>("word_count").as("word_count"),
+        fn.sum<number>("react_count").as("react_count"),
+        fn("round", [fn.avg("word_count"), lit(3)]).as("avg_words"),
+        eb
+          .fn("date", [eb("sent_at", "/", lit(1000)), sql.lit("unixepoch")])
+          .as("date"),
+      ])
+      .where((eb) =>
+        eb.or([
+          eb("channel_id", "in", ALLOWED_CHANNELS),
+          eb("channel_category", "in", ALLOWED_CATEGORIES),
+        ]),
+      )
+      .orderBy("date", "asc")
+      .groupBy("date");
 
-  const baseQuery = createMessageStatsQuery(guildId, intervalStart, intervalEnd)
-    .selectAll()
-    .select(({ fn, eb, lit }) => [
-      fn("date", [eb("sent_at", "/", lit(1000)), sql.lit("unixepoch")]).as(
-        "date",
-      ),
-    ]);
-
-  // Apply channel filtering inline
-  const filteredQuery = baseQuery.where((eb) =>
-    eb.or([
-      eb("channel_id", "in", ALLOWED_CHANNELS),
-      eb("channel_category", "in", ALLOWED_CATEGORIES),
-    ]),
-  );
-
-  // get shortlist using inline selectors
-  const topMembersQuery = db
-    .with("interval_message_stats", () => filteredQuery)
-    // .with("interval_message_stats", () => baseQuery)
-    .selectFrom("interval_message_stats")
-    .select(({ fn }) => [
-      "author_id",
-      fn.sum<number>("word_count").as("total_word_count"),
-      fn.count<number>("author_id").as("message_count"),
-      fn.sum<number>("react_count").as("total_reaction_count"),
-      fn.count<number>("channel_category").distinct().as("category_count"),
-      fn.count<number>("channel_id").distinct().as("channel_count"),
-    ])
-    .orderBy("message_count desc")
-    .groupBy("author_id")
-    .having(({ eb, or, fn }) =>
-      or([
-        eb(fn.count<number>("author_id"), ">=", config.messageThreshold),
-        eb(fn.sum<number>("word_count"), ">=", config.wordThreshold),
-      ]),
+    // Build category stats query
+    const categoryQuery = createMessageStatsQuery(
+      db,
+      guildId,
+      start,
+      end,
+      userId,
     )
-    .limit(config.count);
-  console.log(topMembersQuery.compile().sql);
-  const topMembers = await run(topMembersQuery);
+      .select(({ fn }) => [
+        fn.count<number>("channel_category").as("messages"),
+        "channel_category",
+      ])
+      .where((eb) =>
+        eb.or([
+          eb("channel_id", "in", ALLOWED_CHANNELS),
+          eb("channel_category", "in", ALLOWED_CATEGORIES),
+        ]),
+      )
+      .groupBy("channel_category");
 
-  const dailyParticipationQuery = db
-    .with("interval_message_stats", () => filteredQuery)
-    // .with("interval_message_stats", () => baseQuery)
-    .selectFrom("interval_message_stats")
-    .select(({ fn }) => [
-      "author_id",
-      "date",
-      fn.count<number>("author_id").as("message_count"),
-      fn.sum<number>("word_count").as("word_count"),
-      fn.count<number>("channel_id").distinct().as("channel_count"),
-      fn.count<number>("channel_category").distinct().as("category_count"),
-    ])
-    .distinct()
-    .groupBy("date")
-    .groupBy("author_id")
-    .where(
-      "author_id",
-      "in",
-      topMembers.map((m) => m.author_id),
+    // Build channel stats query
+    const channelQuery = createMessageStatsQuery(
+      db,
+      guildId,
+      start,
+      end,
+      userId,
+    )
+      // @ts-expect-error - Kysely selector typing is complex
+      .select(({ fn }) => [
+        fn.count<number>("channel_id").as("messages"),
+        "channel_id",
+        "channel.name",
+      ])
+      .leftJoin(
+        "channel_info as channel",
+        "channel.id",
+        "message_stats.channel_id",
+      )
+      .where((eb) =>
+        eb.or([
+          eb("channel_id", "in", ALLOWED_CHANNELS),
+          eb("channel_category", "in", ALLOWED_CATEGORIES),
+        ]),
+      )
+      .orderBy("messages", "desc")
+      .groupBy("channel_id");
+
+    const [dailyResults, categoryBreakdown, channelBreakdown] =
+      yield* Effect.all([dailyQuery, categoryQuery, channelQuery], {
+        concurrency: "unbounded",
+      });
+
+    const userInfo = yield* Effect.tryPromise({
+      try: () => getOrFetchUser(userId),
+      catch: (cause) =>
+        new AnalyticsFetchError({ operation: "getOrFetchUser", userId, cause }),
+    });
+
+    // Only daily breakdown needs date gap filling
+    const dailyBreakdown = fillDateGaps<DailyBreakdown>(
+      dailyResults as DailyBreakdown[],
+      start,
+      end,
+      {
+        messages: 0,
+        word_count: 0,
+        react_count: 0,
+        avg_words: 0,
+      },
     );
-  console.log(dailyParticipationQuery.compile().sql);
-  const rawDailyParticipation = await run(dailyParticipationQuery);
-  // Group by author and fill date gaps inline
-  const groupedData = rawDailyParticipation.reduce((acc, record) => {
-    const { author_id, date } = record;
-    if (!acc[author_id]) acc[author_id] = [];
-    acc[author_id].push({ ...record, date: date as string });
-    return acc;
-  }, {} as GroupedResult);
 
-  const dailyParticipation: GroupedResult = {};
-  for (const authorId in groupedData) {
-    dailyParticipation[authorId] = fillDateGaps(
-      groupedData[authorId],
-      intervalStart,
-      intervalEnd,
-      { message_count: 0, word_count: 0, channel_count: 0, category_count: 0 },
-    );
-  }
-
-  const scores = topMembers.map((m) => {
-    const member = m as MemberData;
-    const participation = dailyParticipation[member.author_id];
-    const categoryCounts = participation
-      .map((p) => p.category_count)
-      .sort((a, b) => a - b);
-    const zeroDays = participation.filter((p) => p.message_count === 0).length;
+    yield* logEffect("debug", "Activity", "getUserMessageAnalytics complete", {
+      guildId,
+      userId,
+      dailyRows: dailyBreakdown.length,
+    });
 
     return {
-      score: {
-        channelScore: scoreValue(member.channel_count, scoreLookups.channels),
-        messageScore: scoreValue(member.message_count, scoreLookups.messages),
-        wordScore: scoreValue(member.total_word_count, scoreLookups.words),
-        consistencyScore: Math.ceil(
-          categoryCounts[Math.floor(categoryCounts.length / 2)],
-        ),
-      },
-      metadata: {
-        percentZeroDays: zeroDays / participation.length,
-      },
-      data: { participation, member },
+      dailyBreakdown,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      categoryBreakdown: categoryBreakdown as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      channelBreakdown: channelBreakdown as any,
+      userInfo,
     };
-  });
-
-  const withUsernames = await Promise.all(
-    scores.map(async (scores) => {
-      const user = await getOrFetchUser(scores.data.member.author_id);
-      return {
-        ...scores,
-        data: {
-          ...scores.data,
-          member: { ...scores.data.member, username: user?.global_name },
-        },
-      };
+  }).pipe(
+    Effect.withSpan("Activity.getUserMessageAnalytics", {
+      attributes: { guildId, userId },
     }),
   );
-  return withUsernames;
-}
 
 // copy-pasted out of TopMembers query result
 interface MemberData {
@@ -295,12 +223,14 @@ interface MemberData {
   category_count: number;
   channel_count: number;
 }
+
 function scoreValue(test: number, lookup: [number, number][]) {
   return lookup.reduce((score, [min, value], i, list) => {
     const max = list[i + 1]?.[0] ?? Infinity;
     return test >= min && test < max ? value : score;
   }, 0);
 }
+
 // prettier-ignore
 const scoreLookups = {
   words: [ [0, 0], [2000, 1], [5000, 2], [7500, 3], [20000, 4], ],
@@ -317,3 +247,197 @@ interface ParticipationData {
 }
 
 type GroupedResult = Record<string, ParticipationData[]>;
+
+export interface TopParticipant {
+  score: {
+    channelScore: number;
+    messageScore: number;
+    wordScore: number;
+    consistencyScore: number;
+  };
+  metadata: {
+    percentZeroDays: number;
+  };
+  data: {
+    participation: ParticipationData[];
+    member: MemberData & { username: string | null | undefined };
+  };
+}
+
+/**
+ * Free Effect function: gets top participants for a guild/interval.
+ * Requires DatabaseService in context.
+ */
+export const getTopParticipantsEffect = (
+  guildId: MessageStats["guild_id"],
+  intervalStart: string,
+  intervalEnd: string,
+): Effect.Effect<TopParticipant[], ActivityError, DatabaseService> =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
+
+    yield* logEffect("debug", "Activity", "getTopParticipants started", {
+      guildId,
+      intervalStart,
+      intervalEnd,
+    });
+
+    const config = {
+      count: 100,
+      messageThreshold: 250,
+      wordThreshold: 2200,
+    };
+
+    // Build top members query directly (avoid CTE which conflicts with EffectKysely proxy)
+    const topMembersQuery = createMessageStatsQuery(
+      db,
+      guildId,
+      intervalStart,
+      intervalEnd,
+    )
+      .select(({ fn }) => [
+        "author_id",
+        fn.sum<number>("word_count").as("total_word_count"),
+        fn.count<number>("author_id").as("message_count"),
+        fn.sum<number>("react_count").as("total_reaction_count"),
+        fn.count<number>("channel_category").distinct().as("category_count"),
+        fn.count<number>("channel_id").distinct().as("channel_count"),
+      ])
+      .where((eb) =>
+        eb.or([
+          eb("channel_id", "in", ALLOWED_CHANNELS),
+          eb("channel_category", "in", ALLOWED_CATEGORIES),
+        ]),
+      )
+      .orderBy("message_count", "desc")
+      .groupBy("author_id")
+      .having(({ eb, or, fn }) =>
+        or([
+          eb(fn.count<number>("author_id"), ">=", config.messageThreshold),
+          eb(fn.sum<number>("word_count"), ">=", config.wordThreshold),
+        ]),
+      )
+      .limit(config.count);
+
+    const topMembers = yield* topMembersQuery;
+
+    if (topMembers.length === 0) {
+      return [];
+    }
+
+    const dailyParticipationQuery = createMessageStatsQuery(
+      db,
+      guildId,
+      intervalStart,
+      intervalEnd,
+    )
+      .select(({ fn, eb, lit }) => [
+        "author_id",
+        fn.count<number>("author_id").as("message_count"),
+        fn.sum<number>("word_count").as("word_count"),
+        fn.count<number>("channel_id").distinct().as("channel_count"),
+        fn.count<number>("channel_category").distinct().as("category_count"),
+        eb
+          .fn("date", [eb("sent_at", "/", lit(1000)), sql.lit("unixepoch")])
+          .as("date"),
+      ])
+      .where((eb) =>
+        eb.or([
+          eb("channel_id", "in", ALLOWED_CHANNELS),
+          eb("channel_category", "in", ALLOWED_CATEGORIES),
+        ]),
+      )
+      .distinct()
+      .groupBy("date")
+      .groupBy("author_id")
+      .where(
+        "author_id",
+        "in",
+        topMembers.map((m) => m.author_id),
+      );
+
+    const rawDailyParticipation = yield* dailyParticipationQuery;
+
+    // Group by author and fill date gaps inline
+    const groupedData = rawDailyParticipation.reduce((acc, record) => {
+      const { author_id, date } = record;
+      if (!acc[author_id]) acc[author_id] = [];
+      acc[author_id].push({ ...record, date: date as string });
+      return acc;
+    }, {} as GroupedResult);
+
+    const dailyParticipation: GroupedResult = {};
+    for (const authorId in groupedData) {
+      dailyParticipation[authorId] = fillDateGaps(
+        groupedData[authorId],
+        intervalStart,
+        intervalEnd,
+        {
+          message_count: 0,
+          word_count: 0,
+          channel_count: 0,
+          category_count: 0,
+        },
+      );
+    }
+
+    const scores = topMembers.map((m) => {
+      const member = m as MemberData;
+      const participation = dailyParticipation[member.author_id];
+      const categoryCounts = participation
+        .map((p) => p.category_count)
+        .sort((a, b) => a - b);
+      const zeroDays = participation.filter(
+        (p) => p.message_count === 0,
+      ).length;
+
+      return {
+        score: {
+          channelScore: scoreValue(member.channel_count, scoreLookups.channels),
+          messageScore: scoreValue(member.message_count, scoreLookups.messages),
+          wordScore: scoreValue(member.total_word_count, scoreLookups.words),
+          consistencyScore: Math.ceil(
+            categoryCounts[Math.floor(categoryCounts.length / 2)],
+          ),
+        },
+        metadata: {
+          percentZeroDays: zeroDays / participation.length,
+        },
+        data: { participation, member },
+      };
+    });
+
+    const withUsernames = yield* Effect.forEach(
+      scores,
+      (s) =>
+        Effect.tryPromise({
+          try: () => getOrFetchUser(s.data.member.author_id),
+          catch: (cause) =>
+            new AnalyticsFetchError({
+              operation: "getOrFetchUser",
+              userId: s.data.member.author_id,
+              cause,
+            }),
+        }).pipe(
+          Effect.map((user) => ({
+            ...s,
+            data: {
+              ...s.data,
+              member: { ...s.data.member, username: user?.global_name },
+            },
+          })),
+        ),
+      { concurrency: "unbounded" },
+    );
+
+    yield* logEffect("debug", "Activity", "getTopParticipants complete", {
+      guildId,
+      count: withUsernames.length,
+    });
+
+    return withUsernames;
+  }).pipe(
+    Effect.withSpan("Activity.getTopParticipants", {
+      attributes: { guildId: guildId },
+    }),
+  );

--- a/app/models/activity.server.ts
+++ b/app/models/activity.server.ts
@@ -438,6 +438,6 @@ export const getTopParticipantsEffect = (
     return withUsernames;
   }).pipe(
     Effect.withSpan("Activity.getTopParticipants", {
-      attributes: { guildId: guildId },
+      attributes: { guildId },
     }),
   );

--- a/app/models/deletionLogThreads.ts
+++ b/app/models/deletionLogThreads.ts
@@ -18,7 +18,7 @@ import {
   type NotFoundError,
 } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 
 type ThreadError = DiscordError | SqlError | NotFoundError;
 
@@ -189,10 +189,9 @@ const doGetOrCreateDeletionLogThread = (guild: Guild, user: User) =>
       }
     }
 
-    const { deletionLog: deletionLogId } = yield* fetchSettingsEffect(
-      guild.id,
-      [SETTINGS.deletionLog],
-    );
+    const { deletionLog: deletionLogId } = yield* fetchSettings(guild.id, [
+      SETTINGS.deletionLog,
+    ]);
 
     if (!deletionLogId) {
       return yield* Effect.fail(

--- a/app/models/discord.server.ts
+++ b/app/models/discord.server.ts
@@ -4,10 +4,13 @@ import {
   type APIGuild,
 } from "discord-api-types/v10";
 import { type GuildMember } from "discord.js";
+import { Effect, Layer } from "effect";
 import type { AccessToken } from "simple-oauth2";
 
 import type { REST } from "@discordjs/rest";
 
+import { db } from "#~/AppRuntime";
+import { DatabaseService } from "#~/Database";
 import { trackPerformance } from "#~/helpers/observability.js";
 import { complement, intersection } from "#~/helpers/sets.js";
 import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
@@ -69,9 +72,15 @@ export const applyRestriction = async (member: GuildMember | null) => {
     return;
   }
 
-  const { restricted } = await fetchSettings(member.guild.id, [
-    SETTINGS.restricted,
-  ]);
+  // Provide DatabaseService via the lazy AppRuntime db handle rather than
+  // runEffect(...): this module sits inside the AppLayer import graph (via
+  // spamResponseHandler), so importing runEffect — whose signature mentions
+  // RuntimeContext — would create a circular type reference.
+  const { restricted } = await Effect.runPromise(
+    fetchSettings(member.guild.id, [SETTINGS.restricted]).pipe(
+      Effect.provide(Layer.succeed(DatabaseService, db)),
+    ),
+  );
   if (!restricted) {
     throw new Error(
       "Tried to restrict with no restricted role configured. This is likely a development error.",

--- a/app/models/guilds.server.test.ts
+++ b/app/models/guilds.server.test.ts
@@ -1,124 +1,140 @@
-import BetterSqlite3 from "better-sqlite3";
-import { Kysely, SqliteDialect } from "kysely";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { Effect, Either, Layer, ManagedRuntime } from "effect";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
-import type { DB } from "#~/db";
+import * as Reactivity from "@effect/experimental/Reactivity";
+import { SqlClient } from "@effect/sql";
+import * as Sqlite from "@effect/sql-kysely/Sqlite";
+import { SqliteClient } from "@effect/sql-sqlite-node";
 
-// The global setup mock only stubs `log`; guilds.server also uses trackPerformance
-vi.mock("#~/helpers/observability", () => ({
-  log: () => {
-    /* noop */
-  },
-  trackPerformance: (_op: string, fn: () => unknown) => fn(),
-}));
+import { DatabaseService, type DB } from "#~/Database";
+import {
+  fetchGuild,
+  fetchSettings,
+  registerGuild,
+  setSettings,
+  SETTINGS,
+} from "#~/models/guilds.server";
 
-// We build a real in-memory Kysely instance and wire it into the mocked
-// AppRuntime so that `guilds.server.ts` runs its queries against our test db.
-// The real AppRuntime uses @effect/sql-kysely which patches query builders to
-// also be Effect instances; the `run` helpers call Effect.runPromise on them.
-// In tests we skip the Effect layer and call `.execute()` directly.
-let testDb: Kysely<DB>;
-let rawDb: InstanceType<typeof BetterSqlite3>;
+// In-memory SQLite test layer (mirrors user.server.test.ts / subscriptions.server.test.ts)
+const TestSqliteLive = Layer.scoped(
+  SqlClient.SqlClient,
+  SqliteClient.make({ filename: ":memory:" }),
+).pipe(Layer.provide(Reactivity.layer));
 
-// Intentional: stubs run/runTakeFirst/runTakeFirstOrThrow to execute Kysely queries against the in-memory test DB.
-vi.mock("#~/AppRuntime", () => {
-  return {
-    get db() {
-      return testDb;
-    },
-    // The real `run` calls Effect.runPromise on an EffectKysely query builder.
-    // A plain Kysely query builder is a thenable that resolves via .execute(),
-    // so we just await it.
-    run: async (qb: { execute: () => Promise<unknown> }) => qb.execute(),
-    runTakeFirst: async (qb: { execute: () => Promise<unknown[]> }) => {
-      const rows = await qb.execute();
-      return rows[0];
-    },
-    runTakeFirstOrThrow: async (qb: { execute: () => Promise<unknown[]> }) => {
-      const rows = await qb.execute();
-      if (rows[0] === undefined) throw new Error("No rows returned");
-      return rows[0];
-    },
-  };
+const TestKyselyLive = Layer.effect(DatabaseService, Sqlite.make<DB>()).pipe(
+  Layer.provide(TestSqliteLive),
+);
+
+// provideMerge keeps a single memoized in-memory connection.
+const TestLayer = Layer.mergeAll(TestSqliteLive, TestKyselyLive);
+
+const testRuntime = ManagedRuntime.make(TestLayer);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const runTest = <A>(effect: Effect.Effect<A, any, any>) =>
+  testRuntime.runPromise(effect);
+
+beforeAll(async () => {
+  await runTest(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql.unsafe(`
+        CREATE TABLE IF NOT EXISTS guilds (
+          id TEXT PRIMARY KEY NOT NULL,
+          settings TEXT
+        )
+      `);
+    }),
+  );
 });
 
-beforeEach(() => {
-  rawDb = new BetterSqlite3(":memory:");
-  rawDb.exec(`
-    CREATE TABLE guilds (
-      id TEXT PRIMARY KEY,
-      settings TEXT
-    )
-  `);
-
-  testDb = new Kysely<DB>({
-    dialect: new SqliteDialect({ database: rawDb }),
-  });
+beforeEach(async () => {
+  await runTest(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql.unsafe("DELETE FROM guilds");
+    }),
+  );
 });
 
-afterEach(async () => {
-  await testDb.destroy();
+afterAll(async () => {
+  await testRuntime.dispose();
 });
 
-// Dynamic import so that the mock is in place before the module loads.
-const loadModule = () => import("#~/models/guilds.server");
+// Read the raw settings JSON for a guild via SqlClient (bypasses the model fns).
+const rawSettings = (guildId: string) =>
+  runTest(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const rows = yield* sql<{ settings: string | null }>`
+        SELECT settings FROM guilds WHERE id = ${guildId}
+      `;
+      return rows[0]?.settings ?? null;
+    }),
+  );
 
 describe("setSettings coalesce fix", () => {
-  test("persists settings when existing settings column is NULL", async () => {
+  it("persists settings when existing settings column is NULL", async () => {
     // Simulate a guild row where settings is NULL (the bug scenario from #335)
-    rawDb.exec(`INSERT INTO guilds (id, settings) VALUES ('guild-null', NULL)`);
+    await runTest(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient;
+        yield* sql.unsafe(
+          `INSERT INTO guilds (id, settings) VALUES ('guild-null', NULL)`,
+        );
+      }),
+    );
 
-    const { setSettings, fetchGuild } = await loadModule();
+    await runTest(
+      setSettings("guild-null", {
+        modLog: "channel-123",
+        moderator: "role-456",
+      }),
+    );
 
-    await setSettings("guild-null", {
-      modLog: "channel-123",
-      moderator: "role-456",
-    });
-
-    const guild = await fetchGuild("guild-null");
-    expect(guild).toBeDefined();
-    expect(guild!.settings).not.toBeNull();
-    const settings = JSON.parse(guild!.settings!);
+    const raw = await rawSettings("guild-null");
+    expect(raw).not.toBeNull();
+    const settings = JSON.parse(raw!);
     expect(settings.modLog).toBe("channel-123");
     expect(settings.moderator).toBe("role-456");
   });
 
-  test("persists settings when guild was registered normally", async () => {
-    const { registerGuild, setSettings, fetchGuild } = await loadModule();
+  it("persists settings when guild was registered normally", async () => {
+    await runTest(registerGuild("guild-normal"));
+    await runTest(
+      setSettings("guild-normal", {
+        modLog: "channel-abc",
+        moderator: "role-def",
+      }),
+    );
 
-    await registerGuild("guild-normal");
-    await setSettings("guild-normal", {
-      modLog: "channel-abc",
-      moderator: "role-def",
-    });
-
-    const guild = await fetchGuild("guild-normal");
-    expect(guild).toBeDefined();
-    const settings = JSON.parse(guild!.settings!);
+    const raw = await rawSettings("guild-normal");
+    const settings = JSON.parse(raw!);
     expect(settings.modLog).toBe("channel-abc");
     expect(settings.moderator).toBe("role-def");
   });
 
-  test("successive calls merge without overwriting unrelated keys", async () => {
-    const { registerGuild, setSettings, fetchGuild } = await loadModule();
+  it("successive calls merge without overwriting unrelated keys", async () => {
+    await runTest(registerGuild("guild-merge"));
 
-    await registerGuild("guild-merge");
-
-    await setSettings("guild-merge", {
-      modLog: "channel-1",
-      moderator: "role-1",
-    });
+    await runTest(
+      setSettings("guild-merge", {
+        modLog: "channel-1",
+        moderator: "role-1",
+      }),
+    );
 
     // Second call adds quorum; existing keys should be preserved
-    await setSettings("guild-merge", {
-      modLog: "channel-1",
-      moderator: "role-1",
-      quorum: 5,
-    });
+    await runTest(
+      setSettings("guild-merge", {
+        modLog: "channel-1",
+        moderator: "role-1",
+        quorum: 5,
+      }),
+    );
 
-    const guild = await fetchGuild("guild-merge");
-    expect(guild).toBeDefined();
-    const settings = JSON.parse(guild!.settings!);
+    const raw = await rawSettings("guild-merge");
+    const settings = JSON.parse(raw!);
     expect(settings.modLog).toBe("channel-1");
     expect(settings.moderator).toBe("role-1");
     expect(settings.quorum).toBe(5);
@@ -126,100 +142,96 @@ describe("setSettings coalesce fix", () => {
 });
 
 describe("registerGuild", () => {
-  test("registers a new guild with settings = '{}'", async () => {
-    const { registerGuild } = await loadModule();
+  it("registers a new guild with settings = '{}'", async () => {
+    await runTest(registerGuild("guild-new"));
 
-    await registerGuild("guild-new");
-
-    const row = rawDb
-      .prepare("SELECT id, settings FROM guilds WHERE id = ?")
-      .get("guild-new") as { id: string; settings: string };
-    expect(row).toBeDefined();
-    expect(row.id).toBe("guild-new");
-    expect(row.settings).toBe("{}");
+    const raw = await rawSettings("guild-new");
+    expect(raw).toBe("{}");
   });
 
-  test("calling registerGuild twice with the same ID doesn't error", async () => {
-    const { registerGuild } = await loadModule();
-
-    await registerGuild("guild-dup");
-    await expect(registerGuild("guild-dup")).resolves.not.toThrow();
+  it("calling registerGuild twice with the same ID doesn't error", async () => {
+    await runTest(registerGuild("guild-dup"));
+    await expect(runTest(registerGuild("guild-dup"))).resolves.not.toThrow();
   });
 
-  test("second registerGuild doesn't overwrite existing settings", async () => {
-    const { registerGuild, setSettings, fetchGuild } = await loadModule();
-
-    await registerGuild("guild-keep");
-    await setSettings("guild-keep", {
-      modLog: "ch-keep",
-      moderator: "role-keep",
-    });
+  it("second registerGuild doesn't overwrite existing settings", async () => {
+    await runTest(registerGuild("guild-keep"));
+    await runTest(
+      setSettings("guild-keep", {
+        modLog: "ch-keep",
+        moderator: "role-keep",
+      }),
+    );
 
     // Re-register the same guild
-    await registerGuild("guild-keep");
+    await runTest(registerGuild("guild-keep"));
 
-    const guild = await fetchGuild("guild-keep");
-    expect(guild).toBeDefined();
-    const settings = JSON.parse(guild!.settings!);
+    const raw = await rawSettings("guild-keep");
+    const settings = JSON.parse(raw!);
     expect(settings.modLog).toBe("ch-keep");
     expect(settings.moderator).toBe("role-keep");
   });
 });
 
 describe("fetchGuild", () => {
-  test("returns the guild with correct id and settings after registration", async () => {
-    const { registerGuild, fetchGuild } = await loadModule();
+  it("returns the guild with correct id and settings after registration", async () => {
+    await runTest(registerGuild("guild-fetch"));
 
-    await registerGuild("guild-fetch");
-
-    const guild = await fetchGuild("guild-fetch");
+    const guild = await runTest(fetchGuild("guild-fetch"));
     expect(guild).toBeDefined();
     expect(guild!.id).toBe("guild-fetch");
     expect(guild!.settings).toBe("{}");
   });
 
-  test("returns undefined for a non-existent guild", async () => {
-    const { fetchGuild } = await loadModule();
-
-    const guild = await fetchGuild("guild-nonexistent");
+  it("returns undefined for a non-existent guild", async () => {
+    const guild = await runTest(fetchGuild("guild-nonexistent"));
     expect(guild).toBeUndefined();
   });
 });
 
 describe("fetchSettings key extraction", () => {
-  test("returns correct values for requested keys", async () => {
-    const { registerGuild, setSettings, fetchSettings, SETTINGS } =
-      await loadModule();
+  it("returns correct values for requested keys", async () => {
+    await runTest(registerGuild("guild-settings"));
+    await runTest(
+      setSettings("guild-settings", {
+        modLog: "ch-1",
+        moderator: "role-1",
+      }),
+    );
 
-    await registerGuild("guild-settings");
-    await setSettings("guild-settings", {
-      modLog: "ch-1",
-      moderator: "role-1",
-    });
-
-    const result = await fetchSettings("guild-settings", [
-      SETTINGS.moderator,
-      SETTINGS.modLog,
-    ]);
+    const result = await runTest(
+      fetchSettings("guild-settings", [SETTINGS.moderator, SETTINGS.modLog]),
+    );
     expect(result.moderator).toBe("role-1");
     expect(result.modLog).toBe("ch-1");
   });
 
-  test("returns null for a key that wasn't set", async () => {
-    const { registerGuild, setSettings, fetchSettings, SETTINGS } =
-      await loadModule();
+  it("returns null for a key that wasn't set", async () => {
+    await runTest(registerGuild("guild-partial"));
+    await runTest(
+      setSettings("guild-partial", {
+        modLog: "ch-2",
+        moderator: "role-2",
+      }),
+    );
 
-    await registerGuild("guild-partial");
-    await setSettings("guild-partial", {
-      modLog: "ch-2",
-      moderator: "role-2",
-    });
-
-    const result = await fetchSettings("guild-partial", [
-      SETTINGS.moderator,
-      SETTINGS.deletionLog,
-    ]);
+    const result = await runTest(
+      fetchSettings("guild-partial", [
+        SETTINGS.moderator,
+        SETTINGS.deletionLog,
+      ]),
+    );
     expect(result.moderator).toBe("role-2");
     expect(result.deletionLog).toBeNull();
+  });
+
+  it("fails with NotFoundError when the guild row is missing", async () => {
+    const result = await runTest(
+      fetchSettings("guild-missing", [SETTINGS.modLog]).pipe(Effect.either),
+    );
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left._tag).toBe("NotFoundError");
+    }
   });
 });

--- a/app/models/guilds.server.test.ts
+++ b/app/models/guilds.server.test.ts
@@ -20,6 +20,7 @@ vi.mock("#~/helpers/observability", () => ({
 let testDb: Kysely<DB>;
 let rawDb: InstanceType<typeof BetterSqlite3>;
 
+// Intentional: stubs run/runTakeFirst/runTakeFirstOrThrow to execute Kysely queries against the in-memory test DB.
 vi.mock("#~/AppRuntime", () => {
   return {
     get db() {

--- a/app/models/guilds.server.ts
+++ b/app/models/guilds.server.ts
@@ -1,9 +1,9 @@
 import { Effect } from "effect";
+import type { Selectable } from "kysely";
 
-import { db, run, runTakeFirst, runTakeFirstOrThrow } from "#~/AppRuntime";
-import { DatabaseService, type DB } from "#~/Database";
+import { DatabaseService, type DB, type SqlError } from "#~/Database";
 import { NotFoundError } from "#~/effects/errors.ts";
-import { log, trackPerformance } from "#~/helpers/observability";
+import { logEffect } from "#~/effects/observability";
 
 export type Guild = DB["guilds"];
 
@@ -31,56 +31,74 @@ interface SettingsRecord {
   [SETTINGS.applicationChannel]?: string;
 }
 
-export const fetchGuild = async (guildId: string) => {
-  return trackPerformance(
-    "fetchGuild",
-    async () => {
-      log("debug", "Guild", "Fetching guild", { guildId });
+// --- Free Effect functions ---
+// Each requires DatabaseService in context (provided by AppLayer / test layers).
+// Effect callers:    yield* fetchSettings(...)
+// Web-async callers: await runEffect(setSettings(...))
 
-      const guild = await runTakeFirst(
-        db.selectFrom("guilds").selectAll().where("id", "=", guildId),
-      );
+export const fetchGuild = (
+  guildId: string,
+): Effect.Effect<
+  Selectable<DB["guilds"]> | undefined,
+  SqlError,
+  DatabaseService
+> =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
 
-      log("debug", "Guild", guild ? "Guild found" : "Guild not found", {
+    yield* logEffect("debug", "Guild", "Fetching guild", { guildId });
+
+    const rows = yield* db
+      .selectFrom("guilds")
+      .selectAll()
+      .where("id", "=", guildId);
+    const guild = rows[0];
+
+    yield* logEffect(
+      "debug",
+      "Guild",
+      guild ? "Guild found" : "Guild not found",
+      {
         guildId,
         guildExists: !!guild,
         hasSettings: !!guild?.settings,
-      });
+      },
+    );
 
-      return guild;
-    },
-    { guildId },
-  );
-};
+    return guild;
+  }).pipe(Effect.withSpan("Guild.fetchGuild", { attributes: { guildId } }));
 
-export const registerGuild = async (guildId: string) => {
-  return trackPerformance(
-    "registerGuild",
-    async () => {
-      log("info", "Guild", "Registering guild", { guildId });
+export const registerGuild = (
+  guildId: string,
+): Effect.Effect<void, SqlError, DatabaseService> =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
 
-      await run(
-        db
-          .insertInto("guilds")
-          .values({
-            id: guildId,
-            settings: JSON.stringify({}),
-          })
-          .onConflict((oc) => oc.column("id").doNothing()),
-      );
+    yield* logEffect("info", "Guild", "Registering guild", { guildId });
 
-      log("info", "Guild", "Guild registered successfully", { guildId });
-    },
-    { guildId },
-  );
-};
+    yield* db
+      .insertInto("guilds")
+      .values({
+        id: guildId,
+        settings: JSON.stringify({}),
+      })
+      .onConflict((oc) => oc.column("id").doNothing());
 
-export const setSettings = async (
+    yield* logEffect("info", "Guild", "Guild registered successfully", {
+      guildId,
+    });
+  }).pipe(Effect.withSpan("Guild.registerGuild", { attributes: { guildId } }));
+
+export const setSettings = (
   guildId: string,
   settings: SettingsRecord,
-) => {
-  await run(
-    db
+): Effect.Effect<void, SqlError, DatabaseService> =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
+
+    // PRESERVE VERBATIM (#335 NULL-coalesce fix): merge new settings into the
+    // existing JSON, treating a NULL settings column as an empty object.
+    yield* db
       .updateTable("guilds")
       .set("settings", (eb) =>
         eb.fn("json_patch", [
@@ -88,35 +106,17 @@ export const setSettings = async (
           eb.val(JSON.stringify(settings)),
         ]),
       )
-      .where("id", "=", guildId),
-  );
-};
+      .where("id", "=", guildId);
+  }).pipe(Effect.withSpan("Guild.setSettings", { attributes: { guildId } }));
 
-export const fetchSettings = async <T extends keyof typeof SETTINGS>(
+export const fetchSettings = <T extends keyof typeof SETTINGS>(
   guildId: string,
   keys: T[],
-) => {
-  const result = Object.entries(
-    await runTakeFirstOrThrow(
-      db
-        .selectFrom("guilds")
-        // @ts-expect-error This is broken because of a migration from knex and
-        // old/bad use of jsonb for storing settings. The type is guaranteed here
-        // not by the codegen
-        .select<DB, "guilds", SettingsRecord>((eb) =>
-          keys.map((k) => eb.ref("settings", "->>").key(k).as(k)),
-        )
-        .where("id", "=", guildId),
-      // This cast is also evidence of the pattern being broken
-    ),
-  ) as [T, string][];
-  return Object.fromEntries(result) as Pick<SettingsRecord, T>;
-};
-
-export const fetchSettingsEffect = <T extends keyof typeof SETTINGS>(
-  guildId: string,
-  keys: T[],
-) =>
+): Effect.Effect<
+  Pick<SettingsRecord, T>,
+  SqlError | NotFoundError,
+  DatabaseService
+> =>
   Effect.gen(function* () {
     const db = yield* DatabaseService;
     const rows = yield* db
@@ -136,7 +136,7 @@ export const fetchSettingsEffect = <T extends keyof typeof SETTINGS>(
     }
     return Object.fromEntries(result) as Pick<SettingsRecord, T>;
   }).pipe(
-    Effect.withSpan("fetchSettingsEffect", {
+    Effect.withSpan("Guild.fetchSettings", {
       attributes: { guildId, keys: keys.join(",") },
     }),
   );

--- a/app/models/session.server.ts
+++ b/app/models/session.server.ts
@@ -346,7 +346,7 @@ export async function completeOauthLogin(request: Request) {
   // Handle bot installation flows
   if (flow !== "user" && guildId) {
     // Initialize free subscription for the guild
-    await SubscriptionService.initializeFreeSubscription(guildId);
+    await runEffect(SubscriptionService.initializeFreeSubscription(guildId));
   }
 
   // dbState already checked earlier

--- a/app/models/subscriptions.server.test.ts
+++ b/app/models/subscriptions.server.test.ts
@@ -1,0 +1,258 @@
+import { Effect, Either, Layer, ManagedRuntime } from "effect";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import * as Reactivity from "@effect/experimental/Reactivity";
+import { SqlClient } from "@effect/sql";
+import * as Sqlite from "@effect/sql-kysely/Sqlite";
+import { SqliteClient } from "@effect/sql-sqlite-node";
+
+import { DatabaseService, type DB } from "#~/Database";
+import { SubscriptionService } from "#~/models/subscriptions.server";
+
+// In-memory SQLite test layer (mirrors user.server.test.ts)
+const TestSqliteLive = Layer.scoped(
+  SqlClient.SqlClient,
+  SqliteClient.make({ filename: ":memory:" }),
+).pipe(Layer.provide(Reactivity.layer));
+
+const TestKyselyLive = Layer.effect(DatabaseService, Sqlite.make<DB>()).pipe(
+  Layer.provide(TestSqliteLive),
+);
+
+// Provide both SqlClient (for schema setup) and DatabaseService (for service methods).
+// provideMerge keeps a single memoized in-memory connection.
+const TestLayer = Layer.mergeAll(TestSqliteLive, TestKyselyLive);
+
+const testRuntime = ManagedRuntime.make(TestLayer);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const runTest = <A>(effect: Effect.Effect<A, any, any>) =>
+  testRuntime.runPromise(effect);
+
+beforeAll(async () => {
+  await runTest(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql.unsafe(`
+        CREATE TABLE IF NOT EXISTS guild_subscriptions (
+          guild_id TEXT PRIMARY KEY,
+          stripe_customer_id TEXT,
+          stripe_subscription_id TEXT,
+          product_tier TEXT NOT NULL DEFAULT 'free',
+          status TEXT NOT NULL DEFAULT 'active',
+          current_period_end TEXT,
+          created_at TEXT,
+          updated_at TEXT
+        )
+      `);
+    }),
+  );
+});
+
+beforeEach(async () => {
+  await runTest(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql.unsafe("DELETE FROM guild_subscriptions");
+    }),
+  );
+});
+
+afterAll(async () => {
+  await testRuntime.dispose();
+});
+
+describe("SubscriptionService", () => {
+  it("getGuildSubscription returns null for unknown guild", async () => {
+    const result = await runTest(
+      SubscriptionService.getGuildSubscription("unknown-guild"),
+    );
+    expect(result).toBeNull();
+  });
+
+  it("createOrUpdateSubscription inserts; getGuildSubscription reads it back", async () => {
+    await runTest(
+      SubscriptionService.createOrUpdateSubscription({
+        guild_id: "guild-1",
+        product_tier: "paid",
+        status: "active",
+        stripe_customer_id: "cus_123",
+      }),
+    );
+
+    const sub = await runTest(
+      SubscriptionService.getGuildSubscription("guild-1"),
+    );
+    expect(sub).toMatchObject({
+      guild_id: "guild-1",
+      product_tier: "paid",
+      status: "active",
+      stripe_customer_id: "cus_123",
+    });
+  });
+
+  it("createOrUpdateSubscription upserts on conflict (same guild_id updates, not duplicates)", async () => {
+    await runTest(
+      SubscriptionService.createOrUpdateSubscription({
+        guild_id: "guild-2",
+        product_tier: "free",
+        status: "active",
+      }),
+    );
+    await runTest(
+      SubscriptionService.createOrUpdateSubscription({
+        guild_id: "guild-2",
+        product_tier: "paid",
+        status: "active",
+        stripe_customer_id: "cus_456",
+      }),
+    );
+
+    const sub = await runTest(
+      SubscriptionService.getGuildSubscription("guild-2"),
+    );
+    expect(sub).toMatchObject({
+      product_tier: "paid",
+      stripe_customer_id: "cus_456",
+    });
+
+    // Verify we only have one row for this guild
+    const all = await runTest(SubscriptionService.getAllSubscriptions());
+    expect(all.filter((s) => s.guild_id === "guild-2").length).toBe(1);
+  });
+
+  it("getProductTier: no sub → 'free'", async () => {
+    const tier = await runTest(
+      SubscriptionService.getProductTier("guild-no-sub"),
+    );
+    expect(tier).toBe("free");
+  });
+
+  it("getProductTier: inactive status → 'free'", async () => {
+    await runTest(
+      SubscriptionService.createOrUpdateSubscription({
+        guild_id: "guild-3",
+        product_tier: "paid",
+        status: "inactive",
+      }),
+    );
+    const tier = await runTest(SubscriptionService.getProductTier("guild-3"));
+    expect(tier).toBe("free");
+  });
+
+  it("getProductTier: past current_period_end → 'free'", async () => {
+    const pastDate = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    await runTest(
+      SubscriptionService.createOrUpdateSubscription({
+        guild_id: "guild-4",
+        product_tier: "paid",
+        status: "active",
+        current_period_end: pastDate,
+      }),
+    );
+    const tier = await runTest(SubscriptionService.getProductTier("guild-4"));
+    expect(tier).toBe("free");
+  });
+
+  it("getProductTier: active + future period_end → returns stored tier", async () => {
+    const futureDate = new Date(
+      Date.now() + 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    await runTest(
+      SubscriptionService.createOrUpdateSubscription({
+        guild_id: "guild-5",
+        product_tier: "paid",
+        status: "active",
+        current_period_end: futureDate,
+      }),
+    );
+    const tier = await runTest(SubscriptionService.getProductTier("guild-5"));
+    expect(tier).toBe("paid");
+  });
+
+  it("updateSubscriptionStatus on existing sub → updates status", async () => {
+    await runTest(
+      SubscriptionService.createOrUpdateSubscription({
+        guild_id: "guild-6",
+        product_tier: "paid",
+        status: "active",
+      }),
+    );
+    await runTest(
+      SubscriptionService.updateSubscriptionStatus("guild-6", "cancelled"),
+    );
+    const sub = await runTest(
+      SubscriptionService.getGuildSubscription("guild-6"),
+    );
+    expect(sub?.status).toBe("cancelled");
+  });
+
+  it("updateSubscriptionStatus on missing guild → fails with SubscriptionNotFoundError", async () => {
+    const result = await runTest(
+      SubscriptionService.updateSubscriptionStatus(
+        "no-such-guild",
+        "cancelled",
+      ).pipe(Effect.either),
+    );
+    expect(Either.isLeft(result)).toBe(true);
+    if (Either.isLeft(result)) {
+      expect(result.left._tag).toBe("SubscriptionNotFoundError");
+    }
+  });
+
+  it("initializeFreeSubscription creates free sub when absent", async () => {
+    await runTest(SubscriptionService.initializeFreeSubscription("guild-7"));
+    const sub = await runTest(
+      SubscriptionService.getGuildSubscription("guild-7"),
+    );
+    expect(sub).toMatchObject({ guild_id: "guild-7", product_tier: "free" });
+  });
+
+  it("initializeFreeSubscription is a no-op when subscription already exists", async () => {
+    await runTest(
+      SubscriptionService.createOrUpdateSubscription({
+        guild_id: "guild-8",
+        product_tier: "paid",
+        status: "active",
+      }),
+    );
+    await runTest(SubscriptionService.initializeFreeSubscription("guild-8"));
+    // Tier should remain paid — the init did not overwrite it
+    const sub = await runTest(
+      SubscriptionService.getGuildSubscription("guild-8"),
+    );
+    expect(sub?.product_tier).toBe("paid");
+  });
+
+  it("getAllSubscriptions returns all seeded rows", async () => {
+    await runTest(
+      Effect.all([
+        SubscriptionService.createOrUpdateSubscription({
+          guild_id: "guild-9a",
+          product_tier: "free",
+        }),
+        SubscriptionService.createOrUpdateSubscription({
+          guild_id: "guild-9b",
+          product_tier: "paid",
+        }),
+      ]),
+    );
+    const all = await runTest(SubscriptionService.getAllSubscriptions());
+    expect(all.length).toBe(2);
+  });
+
+  it("auditSubscriptionChanges returns void without throwing", async () => {
+    // Sentry breadcrumb is a no-op in test env; just confirm no defect
+    await expect(
+      runTest(
+        SubscriptionService.auditSubscriptionChanges(
+          "guild-audit",
+          "test_event",
+          {
+            key: "value",
+          },
+        ),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/app/models/subscriptions.server.ts
+++ b/app/models/subscriptions.server.ts
@@ -1,5 +1,9 @@
-import { db, run, runTakeFirst } from "#~/AppRuntime";
-import { log, trackPerformance } from "#~/helpers/observability";
+import { Effect } from "effect";
+import type { Selectable } from "kysely";
+
+import { DatabaseService, type DB, type SqlError } from "#~/Database";
+import { SubscriptionNotFoundError } from "#~/effects/errors";
+import { logEffect } from "#~/effects/observability";
 import Sentry from "#~/helpers/sentry.server";
 
 export type ProductTier = "free" | "paid" | "custom";
@@ -8,392 +12,404 @@ export type PaidVariants = "standard_annual";
 
 export type AccountStatus = "active" | "inactive";
 
-export const SubscriptionService = {
-  async getGuildSubscription(guildId: string) {
-    return trackPerformance(
-      "getGuildSubscription",
-      async () => {
-        log("debug", "Subscription", "Fetching guild subscription", {
-          guildId,
-        });
+export type GuildSubscription = Selectable<DB["guild_subscriptions"]>;
 
-        const result = await runTakeFirst(
-          db
-            .selectFrom("guild_subscriptions")
-            .selectAll()
-            .where("guild_id", "=", guildId),
-        );
+// --- Free Effect functions ---
+// Each function requires DatabaseService in context (provided by AppLayer / test layers).
+// Call sites: yield* SubscriptionService.method(...) in Effects,
+// or await runEffect(SubscriptionService.method(...)) in async/await routes.
 
-        if (result) {
-          log("debug", "Subscription", "Found existing subscription", {
-            guildId,
-            productTier: result.product_tier,
-            status: result.status,
-            hasStripeCustomer: !!result.stripe_customer_id,
-            hasStripeSubscription: !!result.stripe_subscription_id,
-          });
-        } else {
-          log("debug", "Subscription", "No subscription found for guild", {
-            guildId,
-          });
-        }
+const getGuildSubscription = (
+  guildId: string,
+): Effect.Effect<GuildSubscription | null, SqlError, DatabaseService> =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
 
-        return result ?? null;
+    yield* logEffect(
+      "debug",
+      "SubscriptionService",
+      "Fetching guild subscription",
+      {
+        guildId,
       },
-      { guildId },
     );
-  },
 
-  async createOrUpdateSubscription(data: {
-    guild_id: string;
-    stripe_customer_id?: string;
-    stripe_subscription_id?: string;
-    product_tier: ProductTier;
-    status?: string;
-    current_period_end?: string;
-  }): Promise<void> {
-    return trackPerformance(
-      "createOrUpdateSubscription",
-      async () => {
-        log("info", "Subscription", "Creating or updating subscription", {
-          guildId: data.guild_id,
-          productTier: data.product_tier,
+    const [result] = yield* db
+      .selectFrom("guild_subscriptions")
+      .selectAll()
+      .where("guild_id", "=", guildId);
+
+    if (result) {
+      yield* logEffect(
+        "debug",
+        "SubscriptionService",
+        "Found existing subscription",
+        {
+          guildId,
+          productTier: result.product_tier,
+          status: result.status,
+          hasStripeCustomer: !!result.stripe_customer_id,
+          hasStripeSubscription: !!result.stripe_subscription_id,
+        },
+      );
+    } else {
+      yield* logEffect(
+        "debug",
+        "SubscriptionService",
+        "No subscription found for guild",
+        {
+          guildId,
+        },
+      );
+    }
+
+    return result ?? null;
+  }).pipe(
+    Effect.withSpan("SubscriptionService.getGuildSubscription", {
+      attributes: { guildId },
+    }),
+  );
+
+const createOrUpdateSubscription = (data: {
+  guild_id: string;
+  stripe_customer_id?: string;
+  stripe_subscription_id?: string;
+  product_tier: ProductTier;
+  status?: string;
+  current_period_end?: string;
+}): Effect.Effect<void, SqlError, DatabaseService> =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
+
+    yield* logEffect(
+      "info",
+      "SubscriptionService",
+      "Creating or updating subscription",
+      {
+        guildId: data.guild_id,
+        productTier: data.product_tier,
+        status: data.status ?? "active",
+        hasStripeCustomer: !!data.stripe_customer_id,
+        hasStripeSubscription: !!data.stripe_subscription_id,
+        currentPeriodEnd: data.current_period_end,
+      },
+    );
+
+    // Check if subscription already exists for audit trail
+    const existing = yield* getGuildSubscription(data.guild_id);
+    const isUpdate = !!existing;
+
+    yield* db
+      .insertInto("guild_subscriptions")
+      .values({
+        guild_id: data.guild_id,
+        stripe_customer_id: data.stripe_customer_id ?? null,
+        stripe_subscription_id: data.stripe_subscription_id ?? null,
+        product_tier: data.product_tier,
+        status: data.status ?? "active",
+        current_period_end: data.current_period_end ?? null,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .onConflict((oc) =>
+        oc.column("guild_id").doUpdateSet({
+          stripe_customer_id: data.stripe_customer_id ?? null,
+          stripe_subscription_id: data.stripe_subscription_id ?? null,
+          product_tier: data.product_tier,
           status: data.status ?? "active",
-          hasStripeCustomer: !!data.stripe_customer_id,
-          hasStripeSubscription: !!data.stripe_subscription_id,
-          currentPeriodEnd: data.current_period_end,
-        });
+          current_period_end: data.current_period_end ?? null,
+          updated_at: new Date().toISOString(),
+        }),
+      );
 
-        // Check if subscription already exists for audit trail
-        const existing = await this.getGuildSubscription(data.guild_id);
-        const isUpdate = !!existing;
-
-        await run(
-          db
-            .insertInto("guild_subscriptions")
-            .values({
-              guild_id: data.guild_id,
-              stripe_customer_id: data.stripe_customer_id ?? null,
-              stripe_subscription_id: data.stripe_subscription_id ?? null,
-              product_tier: data.product_tier,
-              status: data.status ?? "active",
-              current_period_end: data.current_period_end ?? null,
-              created_at: new Date().toISOString(),
-              updated_at: new Date().toISOString(),
-            })
-            .onConflict((oc) =>
-              oc.column("guild_id").doUpdateSet({
-                stripe_customer_id: data.stripe_customer_id ?? null,
-                stripe_subscription_id: data.stripe_subscription_id ?? null,
-                product_tier: data.product_tier,
-                status: data.status ?? "active",
-                current_period_end: data.current_period_end ?? null,
-                updated_at: new Date().toISOString(),
-              }),
-            ),
-        );
-
-        log(
-          "info",
-          "Subscription",
-          `${isUpdate ? "updated" : "created"} successfully`,
-          {
-            guildId: data.guild_id,
-            operation: isUpdate ? "update" : "create",
-            previousTier: existing?.product_tier,
-            newTier: data.product_tier,
-            previousStatus: existing?.status,
-            newStatus: data.status ?? "active",
-          },
-        );
+    yield* logEffect(
+      "info",
+      "SubscriptionService",
+      `${isUpdate ? "updated" : "created"} successfully`,
+      {
+        guildId: data.guild_id,
+        operation: isUpdate ? "update" : "create",
+        previousTier: existing?.product_tier,
+        newTier: data.product_tier,
+        previousStatus: existing?.status,
+        newStatus: data.status ?? "active",
       },
-      { guildId: data.guild_id, productTier: data.product_tier },
     );
-  },
+  }).pipe(
+    Effect.withSpan("SubscriptionService.createOrUpdateSubscription", {
+      attributes: { guildId: data.guild_id, productTier: data.product_tier },
+    }),
+  );
 
-  async updateSubscriptionStatus(
-    guildId: string,
-    status: string,
-    currentPeriodEnd?: string,
-  ): Promise<void> {
-    return trackPerformance(
-      "updateSubscriptionStatus",
-      async () => {
-        log("info", "Subscription", "Updating subscription status", {
-          guildId,
-          newStatus: status,
-          currentPeriodEnd,
-        });
+const updateSubscriptionStatus = (
+  guildId: string,
+  status: string,
+  currentPeriodEnd?: string,
+): Effect.Effect<void, SqlError | SubscriptionNotFoundError, DatabaseService> =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
 
-        // Get current state for audit trail
-        const current = await this.getGuildSubscription(guildId);
-        if (!current) {
-          log(
-            "warn",
-            "Subscription",
-            "Attempted to update status for non-existent subscription",
-            {
-              guildId,
-              status,
-            },
-          );
-          throw new Error(`No subscription found for guild ${guildId}`);
-        }
-
-        await run(
-          db
-            .updateTable("guild_subscriptions")
-            .set({
-              status,
-              current_period_end: currentPeriodEnd ?? null,
-              updated_at: new Date().toISOString(),
-            })
-            .where("guild_id", "=", guildId),
-        );
-
-        log(
-          "info",
-          "Subscription",
-          "Subscription status updated successfully",
-          {
-            guildId,
-            previousStatus: current.status,
-            newStatus: status,
-            previousPeriodEnd: current.current_period_end,
-            newPeriodEnd: currentPeriodEnd,
-          },
-        );
+    yield* logEffect(
+      "info",
+      "SubscriptionService",
+      "Updating subscription status",
+      {
+        guildId,
+        newStatus: status,
+        currentPeriodEnd,
       },
-      { guildId, status },
     );
-  },
 
-  async getProductTier(guildId: string): Promise<ProductTier> {
-    return trackPerformance(
-      "getProductTier",
-      async () => {
-        log("debug", "Subscription", "Determining product tier for guild", {
+    // Get current state for audit trail
+    const current = yield* getGuildSubscription(guildId);
+    if (!current) {
+      yield* logEffect(
+        "warn",
+        "SubscriptionService",
+        "Attempted to update status for non-existent subscription",
+        { guildId, status },
+      );
+      return yield* Effect.fail(new SubscriptionNotFoundError({ guildId }));
+    }
+
+    yield* db
+      .updateTable("guild_subscriptions")
+      .set({
+        status,
+        current_period_end: currentPeriodEnd ?? null,
+        updated_at: new Date().toISOString(),
+      })
+      .where("guild_id", "=", guildId);
+
+    yield* logEffect(
+      "info",
+      "SubscriptionService",
+      "Subscription status updated successfully",
+      {
+        guildId,
+        previousStatus: current.status,
+        newStatus: status,
+        previousPeriodEnd: current.current_period_end,
+        newPeriodEnd: currentPeriodEnd,
+      },
+    );
+  }).pipe(
+    Effect.withSpan("SubscriptionService.updateSubscriptionStatus", {
+      attributes: { guildId, status },
+    }),
+  );
+
+const getProductTier = (
+  guildId: string,
+): Effect.Effect<ProductTier, SqlError, DatabaseService> =>
+  Effect.gen(function* () {
+    yield* logEffect(
+      "debug",
+      "SubscriptionService",
+      "Determining product tier for guild",
+      {
+        guildId,
+      },
+    );
+
+    const subscription = yield* getGuildSubscription(guildId);
+
+    // If no subscription exists, default to free
+    if (!subscription) {
+      yield* logEffect(
+        "debug",
+        "SubscriptionService",
+        "No subscription found, defaulting to free tier",
+        { guildId },
+      );
+      return "free" as const;
+    }
+
+    // If subscription is not active, downgrade to free
+    if (subscription.status !== "active") {
+      yield* logEffect(
+        "info",
+        "SubscriptionService",
+        "Subscription not active, downgrading to free tier",
+        {
           guildId,
-        });
+          subscriptionStatus: subscription.status,
+          subscriptionTier: subscription.product_tier,
+        },
+      );
+      return "free" as const;
+    }
 
-        const subscription = await this.getGuildSubscription(guildId);
-
-        // If no subscription exists, default to free
-        if (!subscription) {
-          log(
-            "debug",
-            "Subscription",
-            "No subscription found, defaulting to free tier",
-            {
-              guildId,
-            },
-          );
-          return "free";
-        }
-
-        // If subscription is not active, downgrade to free
-        if (subscription.status !== "active") {
-          log(
-            "info",
-            "Subscription",
-            "Subscription not active, downgrading to free tier",
-            {
-              guildId,
-              subscriptionStatus: subscription.status,
-              subscriptionTier: subscription.product_tier,
-            },
-          );
-          return "free";
-        }
-
-        // If subscription is past due, check if grace period has expired
-        if (
-          subscription.current_period_end &&
-          new Date() > new Date(subscription.current_period_end)
-        ) {
-          log(
-            "info",
-            "Subscription",
-            "Subscription past due, downgrading to free tier",
-            {
-              guildId,
-              currentPeriodEnd: subscription.current_period_end,
-              currentDate: new Date().toISOString(),
-              subscriptionTier: subscription.product_tier,
-            },
-          );
-          return "free";
-        }
-
-        log("debug", "Subscription", "Returning active subscription tier", {
+    // If subscription is past due, check if grace period has expired
+    if (
+      subscription.current_period_end &&
+      new Date() > new Date(subscription.current_period_end)
+    ) {
+      yield* logEffect(
+        "info",
+        "SubscriptionService",
+        "Subscription past due, downgrading to free tier",
+        {
           guildId,
-          tier: subscription.product_tier,
-          status: subscription.status,
           currentPeriodEnd: subscription.current_period_end,
-        });
+          currentDate: new Date().toISOString(),
+          subscriptionTier: subscription.product_tier,
+        },
+      );
+      return "free" as const;
+    }
 
-        // Type assertion since we control the values
-        return subscription.product_tier as unknown as ProductTier;
+    yield* logEffect(
+      "debug",
+      "SubscriptionService",
+      "Returning active subscription tier",
+      {
+        guildId,
+        tier: subscription.product_tier,
+        status: subscription.status,
+        currentPeriodEnd: subscription.current_period_end,
       },
+    );
+
+    // Type assertion since we control the values
+    return subscription.product_tier as unknown as ProductTier;
+  }).pipe(
+    Effect.withSpan("SubscriptionService.getProductTier", {
+      attributes: { guildId },
+    }),
+  );
+
+// Initialize free tier for new guilds
+const initializeFreeSubscription = (
+  guildId: string,
+): Effect.Effect<void, SqlError, DatabaseService> =>
+  Effect.gen(function* () {
+    yield* logEffect(
+      "info",
+      "SubscriptionService",
+      "Initializing free subscription for new guild",
       { guildId },
     );
-  },
 
-  // Initialize free tier for new guilds
-  async initializeFreeSubscription(guildId: string): Promise<void> {
-    return trackPerformance(
-      "initializeFreeSubscription",
-      async () => {
-        log(
-          "info",
-          "Subscription",
-          "Initializing free subscription for new guild",
-          {
-            guildId,
-          },
-        );
+    const existing = yield* getGuildSubscription(guildId);
+    if (!existing) {
+      yield* logEffect(
+        "info",
+        "SubscriptionService",
+        "Creating new free subscription",
+        {
+          guildId,
+        },
+      );
 
-        const existing = await this.getGuildSubscription(guildId);
-        if (!existing) {
-          log("info", "Subscription", "Creating new free subscription", {
-            guildId,
-          });
+      yield* createOrUpdateSubscription({
+        guild_id: guildId,
+        product_tier: "free",
+      });
 
-          await this.createOrUpdateSubscription({
-            guild_id: guildId,
-            product_tier: "free",
-          });
+      yield* logEffect(
+        "info",
+        "SubscriptionService",
+        "Free subscription initialized successfully",
+        { guildId },
+      );
+    } else {
+      yield* logEffect(
+        "debug",
+        "SubscriptionService",
+        "Subscription already exists, skipping initialization",
+        {
+          guildId,
+          existingTier: existing.product_tier,
+          existingStatus: existing.status,
+        },
+      );
+    }
+  }).pipe(
+    Effect.withSpan("SubscriptionService.initializeFreeSubscription", {
+      attributes: { guildId },
+    }),
+  );
 
-          log(
-            "info",
-            "Subscription",
-            "Free subscription initialized successfully",
-            {
-              guildId,
-            },
-          );
-        } else {
-          log(
-            "debug",
-            "Subscription",
-            "Subscription already exists, skipping initialization",
-            {
-              guildId,
-              existingTier: existing.product_tier,
-              existingStatus: existing.status,
-            },
-          );
-        }
-      },
-      { guildId },
+// Additional observability methods
+const getAllSubscriptions = (): Effect.Effect<
+  readonly GuildSubscription[],
+  SqlError,
+  DatabaseService
+> =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
+
+    yield* logEffect(
+      "debug",
+      "SubscriptionService",
+      "Fetching all guild subscriptions",
     );
-  },
 
-  // Additional observability methods
-  async getSubscriptionMetrics(): Promise<{
-    totalSubscriptions: number;
-    activeSubscriptions: number;
-    freeSubscriptions: number;
-    paidSubscriptions: number;
-    inactiveSubscriptions: number;
-  }> {
-    return trackPerformance(
-      "getSubscriptionMetrics",
-      async () => {
-        log("debug", "Subscription", "Fetching subscription metrics");
+    const results = yield* db.selectFrom("guild_subscriptions").selectAll();
 
-        const [total, active, free, paid, inactive] = await Promise.all([
-          runTakeFirst(
-            db
-              .selectFrom("guild_subscriptions")
-              .select((eb) => eb.fn.countAll<number>().as("count")),
-          ),
-          runTakeFirst(
-            db
-              .selectFrom("guild_subscriptions")
-              .select((eb) => eb.fn.countAll<number>().as("count"))
-              .where("status", "=", "active"),
-          ),
-          runTakeFirst(
-            db
-              .selectFrom("guild_subscriptions")
-              .select((eb) => eb.fn.countAll<number>().as("count"))
-              .where("product_tier", "=", "free"),
-          ),
-          runTakeFirst(
-            db
-              .selectFrom("guild_subscriptions")
-              .select((eb) => eb.fn.countAll<number>().as("count"))
-              .where("product_tier", "=", "paid"),
-          ),
-          runTakeFirst(
-            db
-              .selectFrom("guild_subscriptions")
-              .select((eb) => eb.fn.countAll<number>().as("count"))
-              .where("status", "=", "inactive"),
-          ),
-        ]);
-
-        const metrics = {
-          totalSubscriptions: total?.count ?? 0,
-          activeSubscriptions: active?.count ?? 0,
-          freeSubscriptions: free?.count ?? 0,
-          paidSubscriptions: paid?.count ?? 0,
-          inactiveSubscriptions: inactive?.count ?? 0,
-        };
-
-        log("info", "Subscription", "Subscription metrics retrieved", metrics);
-
-        return metrics;
+    yield* logEffect(
+      "debug",
+      "SubscriptionService",
+      "Fetched all subscriptions",
+      {
+        count: results.length,
       },
-      {},
     );
-  },
 
-  async getAllSubscriptions() {
-    return trackPerformance(
-      "getAllSubscriptions",
-      async () => {
-        log("debug", "Subscription", "Fetching all guild subscriptions");
+    return results;
+  }).pipe(
+    Effect.withSpan("SubscriptionService.getAllSubscriptions", {
+      attributes: {},
+    }),
+  );
 
-        const results = await run(
-          db.selectFrom("guild_subscriptions").selectAll(),
-        );
-
-        log("debug", "Subscription", "Fetched all subscriptions", {
-          count: results.length,
-        });
-
-        return results;
+const auditSubscriptionChanges = (
+  guildId: string,
+  action: string,
+  details: Record<string, unknown>,
+): Effect.Effect<void, never, never> =>
+  Effect.gen(function* () {
+    yield* logEffect(
+      "info",
+      "SubscriptionService",
+      "Subscription audit event",
+      {
+        guildId,
+        action,
+        timestamp: new Date().toISOString(),
+        ...details,
       },
-      {},
     );
-  },
-
-  async auditSubscriptionChanges(
-    guildId: string,
-    action: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    details: Record<string, any>,
-  ): Promise<void> {
-    log("info", "Subscription", "Subscription audit event", {
-      guildId,
-      action,
-      timestamp: new Date().toISOString(),
-      ...details,
-    });
 
     // In a production environment, you might want to store audit logs in a separate table
     // For now, we'll just log to console and Sentry
-    Sentry.addBreadcrumb({
-      category: "audit",
-      message: `Subscription ${action}`,
-      level: "info",
-      data: {
-        guildId,
-        action,
-        ...details,
-      },
-    });
-  },
+    yield* Effect.sync(() =>
+      Sentry.addBreadcrumb({
+        category: "audit",
+        message: `Subscription ${action}`,
+        level: "info",
+        data: {
+          guildId,
+          action,
+          ...details,
+        },
+      }),
+    );
+  });
+
+/**
+ * Subscription service: each method is a free Effect function requiring DatabaseService.
+ *
+ * Web-async callers: await runEffect(SubscriptionService.method(...))
+ * Effect callers:    yield* SubscriptionService.method(...)
+ */
+export const SubscriptionService = {
+  getGuildSubscription,
+  createOrUpdateSubscription,
+  updateSubscriptionStatus,
+  getProductTier,
+  initializeFreeSubscription,
+  getAllSubscriptions,
+  auditSubscriptionChanges,
 };

--- a/app/models/userThreads.ts
+++ b/app/models/userThreads.ts
@@ -19,7 +19,7 @@ import {
 } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import { escalationControls } from "#~/helpers/escalate";
-import { fetchSettingsEffect, SETTINGS } from "#~/models/guilds.server";
+import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 
 type ThreadError = DiscordError | SqlError | NotFoundError;
 
@@ -194,7 +194,7 @@ const doGetOrCreateUserThread = (guild: Guild, user: User) =>
     }
 
     // Create new thread and store in database
-    const { modLog: modLogId } = yield* fetchSettingsEffect(guild.id, [
+    const { modLog: modLogId } = yield* fetchSettings(guild.id, [
       SETTINGS.modLog,
     ]);
 

--- a/app/routes/__auth/admin.$guildId.tsx
+++ b/app/routes/__auth/admin.$guildId.tsx
@@ -1,6 +1,7 @@
 import { Routes, type APIGuild } from "discord-api-types/v10";
 import { Link } from "react-router";
 
+import { runEffect } from "#~/AppRuntime";
 import { Page } from "#~/basics/page.js";
 import { ssrDiscordSdk } from "#~/discord/api.js";
 import {
@@ -29,7 +30,9 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   await requireAdmin(request);
   const { guildId } = params;
 
-  const subscription = await SubscriptionService.getGuildSubscription(guildId);
+  const subscription = await runEffect(
+    SubscriptionService.getGuildSubscription(guildId),
+  );
 
   // Fetch guild info from Discord
   let guildInfo: { name: string; icon: string | null; memberCount: number } = {

--- a/app/routes/__auth/admin.tsx
+++ b/app/routes/__auth/admin.tsx
@@ -1,6 +1,7 @@
 import { Routes, type APIGuild } from "discord-api-types/v10";
 import { Link, useFetcher, useSearchParams } from "react-router";
 
+import { runEffect } from "#~/AppRuntime";
 import { Page } from "#~/basics/page.js";
 import { ssrDiscordSdk } from "#~/discord/api.js";
 import {
@@ -37,7 +38,7 @@ export async function loader({ request }: Route.LoaderArgs) {
   // Fetch bot guilds and all subscriptions in parallel
   const [rawBotGuilds, subscriptions] = await Promise.all([
     ssrDiscordSdk.get(Routes.userGuilds()) as Promise<APIGuild[]>,
-    SubscriptionService.getAllSubscriptions(),
+    runEffect(SubscriptionService.getAllSubscriptions()),
   ]);
 
   const subscriptionsByGuildId = new Map(

--- a/app/routes/__auth/app.tsx
+++ b/app/routes/__auth/app.tsx
@@ -1,6 +1,6 @@
 import { useLoaderData } from "react-router";
 
-import { db, run } from "#~/AppRuntime";
+import { db, run, runEffect } from "#~/AppRuntime";
 import { AddEunoCard } from "#~/components/AddEunoCard";
 import { ServerCard } from "#~/components/ServerCard";
 import { ssrDiscordSdk, userDiscordSdkFromRequest } from "#~/discord/api";
@@ -96,7 +96,7 @@ export async function loader({ request }: Route.LoaderArgs) {
       ),
 
       // 4. All subscriptions
-      SubscriptionService.getAllSubscriptions(),
+      runEffect(SubscriptionService.getAllSubscriptions()),
     ]);
 
   // Build sparkline arrays (30 days, zero-filled)

--- a/app/routes/__auth/dashboard.tsx
+++ b/app/routes/__auth/dashboard.tsx
@@ -1,13 +1,14 @@
 import type { PropsWithChildren } from "react";
 import { data, Link, useSearchParams } from "react-router";
 
+import { runEffect } from "#~/AppRuntime";
 import { RangeForm, type PresetKey } from "#~/features/StarHunter/RangeForm.js";
 import {
   calculateCohortBenchmarks,
   getCohortMetrics,
 } from "#~/helpers/cohortAnalysis";
 import { log, trackPerformance } from "#~/helpers/observability";
-import { getTopParticipants } from "#~/models/activity.server";
+import { getTopParticipantsEffect } from "#~/models/activity.server";
 
 import type { Route } from "./+types/dashboard";
 
@@ -48,7 +49,9 @@ export async function loader({ params, request }: Route.LoaderArgs) {
         return data(null, { status: 400 });
       }
 
-      const userResults = await getTopParticipants(guildId, start, end);
+      const userResults = await runEffect(
+        getTopParticipantsEffect(guildId, start, end),
+      );
 
       // Return full cohort metrics and benchmarks
       const cohortMetrics = await getCohortMetrics(

--- a/app/routes/__auth/guild.tsx
+++ b/app/routes/__auth/guild.tsx
@@ -1,6 +1,6 @@
 import { data, Link, useLoaderData } from "react-router";
 
-import { db, run } from "#~/AppRuntime";
+import { db, run, runEffect } from "#~/AppRuntime";
 import { Sparkline } from "#~/components/Sparkline";
 import { ssrDiscordSdk, userDiscordSdkFromRequest } from "#~/discord/api";
 import { getCachedGuilds } from "#~/helpers/guildCache.server";
@@ -106,7 +106,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     ),
 
     // Subscription tier
-    SubscriptionService.getProductTier(guildId),
+    runEffect(SubscriptionService.getProductTier(guildId)),
   ]);
 
   // Build sparkline array (30 days, zero-filled)

--- a/app/routes/__auth/settings.tsx
+++ b/app/routes/__auth/settings.tsx
@@ -1,5 +1,6 @@
 import { data, Link } from "react-router";
 
+import { runEffect } from "#~/AppRuntime";
 import { GuildSettingsForm } from "#~/components/GuildSettingsForm";
 import { fetchGuildData, type GuildData } from "#~/helpers/guildData.server";
 import { log, trackPerformance } from "#~/helpers/observability";
@@ -20,11 +21,13 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 
   // Fetch current guild settings
   const [currentSettings, { roles, channels }] = await Promise.all([
-    fetchSettings(guildId, [
-      SETTINGS.modLog,
-      SETTINGS.moderator,
-      SETTINGS.restricted,
-    ]).catch(() => undefined),
+    runEffect(
+      fetchSettings(guildId, [
+        SETTINGS.modLog,
+        SETTINGS.moderator,
+        SETTINGS.restricted,
+      ]),
+    ).catch(() => undefined),
     fetchGuildData(guildId).catch(
       () =>
         ({
@@ -104,11 +107,13 @@ export async function action({ request }: Route.ActionArgs) {
 
   try {
     await trackPerformance("guilds.setSettings", () =>
-      setSettings(guildId, {
-        [SETTINGS.modLog]: modLogChannel,
-        [SETTINGS.moderator]: moderatorRole,
-        [SETTINGS.restricted]: restrictedRole || undefined,
-      }),
+      runEffect(
+        setSettings(guildId, {
+          [SETTINGS.modLog]: modLogChannel,
+          [SETTINGS.moderator]: moderatorRole,
+          [SETTINGS.restricted]: restrictedRole || undefined,
+        }),
+      ),
     );
 
     log("info", "settings", "Settings updated successfully", {

--- a/app/routes/__auth/sh-user.tsx
+++ b/app/routes/__auth/sh-user.tsx
@@ -19,8 +19,9 @@ import {
   YAxis,
 } from "recharts";
 
+import { runEffect } from "#~/AppRuntime";
 import { getUserCohortAnalysis } from "#~/helpers/cohortAnalysis.js";
-import { getUserMessageAnalytics } from "#~/models/activity.server";
+import { getUserMessageAnalyticsEffect } from "#~/models/activity.server";
 
 import type { Route } from "./+types/sh-user";
 
@@ -47,7 +48,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   const [analysis, data] = await Promise.all([
     getUserCohortAnalysis(guildId, userId, start, end, minThreshold),
-    getUserMessageAnalytics(guildId, userId, start, end),
+    runEffect(getUserMessageAnalyticsEffect(guildId, userId, start, end)),
   ]);
 
   return {

--- a/app/routes/__auth/upgrade.tsx
+++ b/app/routes/__auth/upgrade.tsx
@@ -7,6 +7,7 @@ import {
   useSearchParams,
 } from "react-router";
 
+import { runEffect } from "#~/AppRuntime";
 import { log } from "#~/helpers/observability";
 import { requestOrigin } from "#~/helpers/request.server";
 import { requireUser } from "#~/models/session.server";
@@ -27,8 +28,12 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     throw data({ message: "Guild ID is required" }, { status: 400 });
   }
 
-  const subscription = await SubscriptionService.getGuildSubscription(guildId);
-  const currentTier = await SubscriptionService.getProductTier(guildId);
+  const subscription = await runEffect(
+    SubscriptionService.getGuildSubscription(guildId),
+  );
+  const currentTier = await runEffect(
+    SubscriptionService.getProductTier(guildId),
+  );
 
   return {
     guildId,
@@ -55,8 +60,9 @@ export async function action({ request }: Route.ActionArgs) {
       userId: user.id,
     });
 
-    const subscription =
-      await SubscriptionService.getGuildSubscription(guildId);
+    const subscription = await runEffect(
+      SubscriptionService.getGuildSubscription(guildId),
+    );
 
     if (!subscription?.stripe_subscription_id) {
       return {
@@ -80,7 +86,9 @@ export async function action({ request }: Route.ActionArgs) {
       };
     }
 
-    await SubscriptionService.updateSubscriptionStatus(guildId, "cancelled");
+    await runEffect(
+      SubscriptionService.updateSubscriptionStatus(guildId, "cancelled"),
+    );
 
     log("info", "Upgrade", "Subscription cancelled successfully", {
       guildId,

--- a/app/routes/export-data.tsx
+++ b/app/routes/export-data.tsx
@@ -1,4 +1,10 @@
-import { db, isFeatureEnabled, run, runTakeFirst } from "#~/AppRuntime";
+import {
+  db,
+  isFeatureEnabled,
+  run,
+  runEffect,
+  runTakeFirst,
+} from "#~/AppRuntime";
 import { log, trackPerformance } from "#~/helpers/observability";
 import { requireUser } from "#~/models/session.server";
 import { SubscriptionService } from "#~/models/subscriptions.server";
@@ -71,8 +77,9 @@ export async function loader({ request }: Route.LoaderArgs) {
         }
 
         // Get subscription data
-        const subscription =
-          await SubscriptionService.getGuildSubscription(guildId);
+        const subscription = await runEffect(
+          SubscriptionService.getGuildSubscription(guildId),
+        );
 
         if (subscription) {
           exportData.subscription = {

--- a/app/routes/onboard.tsx
+++ b/app/routes/onboard.tsx
@@ -105,15 +105,17 @@ export async function action({ request }: Route.ActionArgs) {
   try {
     // Register the guild and set up configuration
     await trackPerformance("guilds.registerGuild", () =>
-      registerGuild(guildId),
+      runEffect(registerGuild(guildId)),
     );
 
     await trackPerformance("guilds.setSettings", () =>
-      setSettings(guildId, {
-        [SETTINGS.modLog]: modLogChannel,
-        [SETTINGS.moderator]: moderatorRole,
-        [SETTINGS.restricted]: restrictedRole || undefined,
-      }),
+      runEffect(
+        setSettings(guildId, {
+          [SETTINGS.modLog]: modLogChannel,
+          [SETTINGS.moderator]: moderatorRole,
+          [SETTINGS.restricted]: restrictedRole || undefined,
+        }),
+      ),
     );
 
     // Initialize free subscription for new guilds

--- a/app/routes/onboard.tsx
+++ b/app/routes/onboard.tsx
@@ -1,5 +1,6 @@
 import { data } from "react-router";
 
+import { runEffect } from "#~/AppRuntime";
 import { Page } from "#~/basics/page.js";
 import { GuildSettingsForm } from "#~/components/GuildSettingsForm";
 import { fetchGuildData } from "#~/helpers/guildData.server";
@@ -21,13 +22,10 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   log("info", "onboarding", "Onboarding page accessed", { guildId });
 
   // Get subscription info for the guild
-  const subscription = await trackPerformance(
-    "subscriptions.getGuildSubscription",
-    () => SubscriptionService.getGuildSubscription(guildId),
+  const subscription = await runEffect(
+    SubscriptionService.getGuildSubscription(guildId),
   );
-  const tier = await trackPerformance("subscriptions.getProductTier", () =>
-    SubscriptionService.getProductTier(guildId),
-  );
+  const tier = await runEffect(SubscriptionService.getProductTier(guildId));
 
   // Fetch guild data using the reusable service
   const { roles, channels } = await fetchGuildData(guildId);
@@ -119,9 +117,7 @@ export async function action({ request }: Route.ActionArgs) {
     );
 
     // Initialize free subscription for new guilds
-    await trackPerformance("subscriptions.initializeFreeSubscription", () =>
-      SubscriptionService.initializeFreeSubscription(guildId),
-    );
+    await runEffect(SubscriptionService.initializeFreeSubscription(guildId));
 
     log("info", "onboarding", "Onboarding completed successfully", {
       guildId,

--- a/app/routes/payment.success.tsx
+++ b/app/routes/payment.success.tsx
@@ -31,14 +31,16 @@ export async function loader({ request }: Route.LoaderArgs) {
   const currentPeriodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
   // Update subscription to paid tier with real Stripe data
-  await SubscriptionService.createOrUpdateSubscription({
-    guild_id: guildId,
-    stripe_customer_id: stripeSession.customer ?? undefined,
-    stripe_subscription_id: stripeSession.subscription ?? undefined,
-    product_tier: "paid",
-    status: "active",
-    current_period_end: currentPeriodEnd.toISOString(),
-  });
+  await runEffect(
+    SubscriptionService.createOrUpdateSubscription({
+      guild_id: guildId,
+      stripe_customer_id: stripeSession.customer ?? undefined,
+      stripe_subscription_id: stripeSession.subscription ?? undefined,
+      product_tier: "paid",
+      status: "active",
+      current_period_end: currentPeriodEnd.toISOString(),
+    }),
+  );
   await runEffect(syncGuildGroup(guildId));
 
   return redirect(`/app/${guildId}/settings/upgrade?success`);

--- a/app/routes/webhooks.stripe.tsx
+++ b/app/routes/webhooks.stripe.tsx
@@ -119,18 +119,20 @@ async function handleCheckoutSessionCompleted(
   // Get subscription details to calculate period end
   const currentPeriodEnd = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
 
-  await SubscriptionService.createOrUpdateSubscription({
-    guild_id: guildId,
-    stripe_customer_id:
-      typeof session.customer === "string" ? session.customer : undefined,
-    stripe_subscription_id:
-      typeof session.subscription === "string"
-        ? session.subscription
-        : undefined,
-    product_tier: "paid",
-    status: "active",
-    current_period_end: currentPeriodEnd.toISOString(),
-  });
+  await runEffect(
+    SubscriptionService.createOrUpdateSubscription({
+      guild_id: guildId,
+      stripe_customer_id:
+        typeof session.customer === "string" ? session.customer : undefined,
+      stripe_subscription_id:
+        typeof session.subscription === "string"
+          ? session.subscription
+          : undefined,
+      product_tier: "paid",
+      status: "active",
+      current_period_end: currentPeriodEnd.toISOString(),
+    }),
+  );
   await runEffect(syncGuildGroup(guildId));
 
   log("info", "Webhook", "Checkout session processed successfully", {
@@ -172,17 +174,19 @@ async function handleSubscriptionUpdated(subscription: Stripe.Subscription) {
     ? new Date(currentPeriodEndTimestamp * 1000).toISOString()
     : null;
 
-  await SubscriptionService.createOrUpdateSubscription({
-    guild_id: guildId,
-    stripe_customer_id:
-      typeof subscription.customer === "string"
-        ? subscription.customer
-        : undefined,
-    stripe_subscription_id: subscription.id,
-    product_tier: subscription.status === "active" ? "paid" : "free",
-    status,
-    current_period_end: currentPeriodEnd ?? undefined,
-  });
+  await runEffect(
+    SubscriptionService.createOrUpdateSubscription({
+      guild_id: guildId,
+      stripe_customer_id:
+        typeof subscription.customer === "string"
+          ? subscription.customer
+          : undefined,
+      stripe_subscription_id: subscription.id,
+      product_tier: subscription.status === "active" ? "paid" : "free",
+      status,
+      current_period_end: currentPeriodEnd ?? undefined,
+    }),
+  );
   await runEffect(syncGuildGroup(guildId));
 
   log("info", "Webhook", "Subscription update processed successfully", {
@@ -212,17 +216,19 @@ async function handleSubscriptionDeleted(subscription: Stripe.Subscription) {
   });
 
   // Downgrade to free tier
-  await SubscriptionService.createOrUpdateSubscription({
-    guild_id: guildId,
-    stripe_customer_id:
-      typeof subscription.customer === "string"
-        ? subscription.customer
-        : undefined,
-    stripe_subscription_id: subscription.id,
-    product_tier: "free",
-    status: "inactive",
-    current_period_end: new Date().toISOString(),
-  });
+  await runEffect(
+    SubscriptionService.createOrUpdateSubscription({
+      guild_id: guildId,
+      stripe_customer_id:
+        typeof subscription.customer === "string"
+          ? subscription.customer
+          : undefined,
+      stripe_subscription_id: subscription.id,
+      product_tier: "free",
+      status: "inactive",
+      current_period_end: new Date().toISOString(),
+    }),
+  );
   await runEffect(syncGuildGroup(guildId));
 
   log("info", "Webhook", "Subscription deletion processed successfully", {
@@ -257,14 +263,16 @@ async function handleInvoicePaymentSucceeded(invoice: Stripe.Invoice) {
 
   // Payment succeeded - subscription should already be updated via subscription.updated event
   // This is mainly for logging/monitoring purposes
-  await SubscriptionService.auditSubscriptionChanges(
-    subscriptionId,
-    "payment_succeeded",
-    {
-      invoiceId: invoice.id,
-      amountPaid: invoice.amount_paid,
-      currency: invoice.currency,
-    },
+  await runEffect(
+    SubscriptionService.auditSubscriptionChanges(
+      subscriptionId,
+      "payment_succeeded",
+      {
+        invoiceId: invoice.id,
+        amountPaid: invoice.amount_paid,
+        currency: invoice.currency,
+      },
+    ),
   );
 
   log("info", "Webhook", "Payment success processed", {
@@ -300,14 +308,16 @@ async function handleInvoicePaymentFailed(invoice: Stripe.Invoice) {
 
   // Payment failed - log for monitoring
   // Stripe will automatically retry and update subscription status if needed
-  await SubscriptionService.auditSubscriptionChanges(
-    subscriptionId,
-    "payment_failed",
-    {
-      invoiceId: invoice.id,
-      attemptCount: invoice.attempt_count,
-      amountDue: invoice.amount_due,
-    },
+  await runEffect(
+    SubscriptionService.auditSubscriptionChanges(
+      subscriptionId,
+      "payment_failed",
+      {
+        invoiceId: invoice.id,
+        attemptCount: invoice.attempt_count,
+        amountDue: invoice.amount_due,
+      },
+    ),
   );
 
   log("warn", "Webhook", "Payment failure logged", {

--- a/app/server.ts
+++ b/app/server.ts
@@ -44,7 +44,7 @@ import "#~/jobs/bulkRoleAssignment";
 
 import { runJobRunner } from "#~/jobs/jobRunner";
 
-import { runEffect, runtime } from "./AppRuntime";
+import { runEffect, runtime, warmRuntime } from "./AppRuntime";
 import { checkpointWal, runIntegrityCheck } from "./Database";
 import { tryDiscord } from "./effects/classifyDiscordError";
 import { logEffect } from "./effects/observability";
@@ -226,4 +226,5 @@ const startup = Effect.gen(function* () {
 });
 
 console.log("running program");
+await warmRuntime();
 runtime.runCallback(startup);


### PR DESCRIPTION
## What & why

Removes `app/AppRuntime.ts`'s import-time side effect — the module-top-level `await Promise.all([runtime.runPromise(PostHogService), runtime.runPromise(DatabaseService)])` that opened the real on-disk SQLite DB on **any** import of `AppRuntime` (directly or transitively, ~31 files). That import-time DB open is the root cause behind the recurring test fragility (busy_timeout contention under parallel vitest) and the defensive `vi.mock("#~/AppRuntime")` shims scattered across the suite.

`runtime = ManagedRuntime.make(AppLayer)` was already lazy; only that `await` ran at import. This PR relocates *when* the runtime warms — to the single process entry point — without changing the deprecated `db`/`run`/`runTakeFirst` bridges (models migrate to Effect on their own #386 schedule).

> **Scope note:** this PR has grown to two stacked pieces — the lazy-export groundwork (below) and, on top of it, the #386 model-layer migration of the three remaining data models (added section near the end).

## Changes

1. **`refactor(runtime)`** — `db` is now a lazy `Proxy<EffectKysely>` (same name/type, consumers unchanged) and `posthogClient` is replaced by a `getPosthog(): PostHog | null` accessor. Both are resolved once by a new idempotent `warmRuntime()`, awaited as a top-level `await` in `app/server.ts` (the single entry point, never imported by tests) before `runtime.runCallback(startup)`. `runGatedFeature`, `helpers/metrics.ts`, and `features/Admin/helpers.server.ts` switch to `getPosthog()`. Using `db`/`getPosthog()` before warmup throws a clear `NOT_WARMED` error. New contract test `app/AppRuntime.test.ts` locks that importing `AppRuntime` is side-effect-free and the handles throw before warmup.
2. **`refactor(discord)`** — `getOrFetchChannel` converted from a legacy-bridge `async` function to an `Effect` that yields `DatabaseService`; `activityTrackerHandlers.ts` + its test updated. This removes both files from `AppRuntime` entirely and, as a bonus, makes DB errors flow as a catchable `SqlError` instead of an uncaught defect.
3. **`test`** — drops 4 now-vestigial `vi.mock("#~/AppRuntime")` shims (imports are side-effect-free now); keeps one (`guilds.server.test.ts`) that genuinely drives the legacy `run` bridges, with an explanatory comment.
4. **`docs(runtime)`** — documents `warmRuntime`'s single-caller concurrency contract.

## Added: model-layer Effect migration (#386 phase 2)

Builds on the lazy-export groundwork above to migrate the three remaining legacy **data models** from Promise/`run`-bridge contracts to **free Effect functions** that `yield* DatabaseService` — the same idiom already used by `userThreads`/`deletionLogThreads` and the existing `fetchSettingsEffect`. (Deliberately *not* `Context.Tag` services: free functions match the surrounding model precedent, need no `AppLayer` wiring, and keep call-site churn minimal. Bot callers `yield*`; web loaders/actions bridge via `runEffect(fn(...))`.) `session.server` (auth) and the `discord`/`stripe` side-effect wrappers are out of scope.

- **`refactor(models)` activity.server** — `getUserMessageAnalytics`/`getTopParticipants` → free Effect fns; deleted dead `getEnhancedUserAnalytics`; added `AnalyticsFetchError`. The `getTopParticipants` CTE was inlined onto `createMessageStatsQuery` (the EffectKysely Proxy can't wrap CTE subquery builders) — reviewed semantically equivalent.
- **`feat(models)` subscriptions.server** — kept the `SubscriptionService` object surface (callers unchanged) but every method is now a free Effect fn; deleted dead `getSubscriptionMetrics`; added `SubscriptionNotFoundError` to the `AppError` union (replacing a raw `throw`). Observability mapped with **zero loss**: `trackPerformance`→`Effect.withSpan`, `log`→`logEffect`, the lone Sentry breadcrumb kept via `Effect.sync`, nested spans preserved. Dropped the `#~/AppRuntime` import (reduces the posthog→subscriptions→AppRuntime cycle). `getGuildSubscription` still returns `null` on miss (loader-shape parity). `session.server` gets only a 1-line `runEffect` bridge — not otherwise migrated.
- **`refactor(models)` guilds.server** — finished the half-done migration: `fetchSettingsEffect` folded into a unified `fetchSettings` (`NotFoundError` on missing row), legacy `fetchGuild`/`registerGuild`/`setSettings`/`fetchSettings` converted off the `run` bridge (import removed), ~29 bot call sites renamed, web callers bridged. The `setSettings` `json_patch(coalesce(...))` NULL-merge (#335) is preserved **byte-for-byte**. Two reviewed-sound deviations to avoid a `RuntimeContext` type cycle: `discord.server.ts` (out of scope) uses `Effect.runPromise + Layer.succeed(DatabaseService, db)` for one settings read (degraded observability on that single read only); `spam/service.ts` `catchAll`s the new typed errors to `null` (matches prior swallow-to-null) and discharges `DatabaseService` locally via the real captured `db` handle (tracer/logger intact).

## Validation

- `npm run typecheck`, `npm run lint` (`--max-warnings=0`), and the full suite (**480 tests, 45 files**) are clean — verified at HEAD.
- Each model migration went through an independent per-task review (spec + quality); a final whole-branch review over the model phase returned **READY TO MERGE** with no Critical/Important findings.
- Lazy-export groundwork: final whole-branch review **READY TO MERGE** — verified warm-ordering across both dev (`ssrLoadModule`) and prod (`build/server/index.js` import) entry paths, that every real `db` consumer uses `db.<method>(...)` (Proxy-safe), and that no dropped mock turns a test into a silent no-op.

### Notes for reviewers
- **CI/test flake (pre-existing, not from this PR):** `app/commands/memberApplications.test.ts` can flake under full-suite parallel load (a module-init/test-isolation race). It reproduces identically on `main` and passes in isolation; #387 already deflakes it. CI is the gate.
- **Trivial overlap with #387:** both touch `AppRuntime.ts` in different regions (the eager-await block here vs. the `AppLayer` `UserServiceLive` wiring there); resolve at merge/rebase.
- **Deferred (accepted, non-blocking):** `warmRuntime`'s `if (_warmed) return;` is not concurrency-safe but latent (single serial caller; now documented). Minor: `{} as EffectKysely` proxy-target cast. Minor (model phase): a stale `provideMerge` comment in the new model tests (harness uses `Layer.mergeAll`); `setupHandlers.test.ts` `fetchGuild` mock is a bare `vi.fn()` (latent — path not exercised); `insertMessage` test helper uses raw string interpolation (test-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
