### PR TITLE
refactor: complete server-side Effect-TS migration (#386)

### DIFF
--- a/app/commands/escalate/directActions.ts
+++ b/app/commands/escalate/directActions.ts
@@ -4,7 +4,6 @@ import {
 } from "discord.js";
 import { Effect } from "effect";
 
-import { tryDiscord } from "#~/effects/classifyDiscordError";
 import { fetchMember } from "#~/effects/discordSdk";
 import { NotAuthorizedError } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
@@ -99,9 +98,7 @@ export const kickUser = (interaction: MessageComponentInteraction) =>
     );
 
     // Execute kick
-    yield* tryDiscord("kick", () =>
-      kick(reportedMember, "single moderator decision"),
-    );
+    yield* kick(reportedMember, "single moderator decision");
 
     yield* logEffect("info", "DirectActions", "Kicked user", {
       reportedUserId,
@@ -150,9 +147,7 @@ export const banUser = (interaction: MessageComponentInteraction) =>
     );
 
     // Execute ban
-    yield* tryDiscord("ban", () =>
-      ban(reportedMember, "single moderator decision"),
-    );
+    yield* ban(reportedMember, "single moderator decision");
 
     yield* logEffect("info", "DirectActions", "Banned user", {
       reportedUserId,
@@ -205,8 +200,10 @@ export const banUserAndDeleteMessages = (
     );
 
     // Execute ban with message deletion
-    yield* tryDiscord("ban", () =>
-      ban(reportedMember, "single moderator decision", DELETE_MESSAGE_SECONDS),
+    yield* ban(
+      reportedMember,
+      "single moderator decision",
+      DELETE_MESSAGE_SECONDS,
     ).pipe(
       Effect.withSpan("discord.ban", {
         attributes: {
@@ -269,9 +266,7 @@ export const restrictUser = (interaction: MessageComponentInteraction) =>
     );
 
     // Execute restriction
-    yield* tryDiscord("applyRestriction", () =>
-      applyRestriction(reportedMember),
-    );
+    yield* applyRestriction(reportedMember);
 
     yield* logEffect("info", "DirectActions", "Restricted user", {
       reportedUserId,
@@ -320,9 +315,7 @@ export const timeoutUser = (interaction: MessageComponentInteraction) =>
     );
 
     // Execute timeout
-    yield* tryDiscord("timeout", () =>
-      timeout(reportedMember, "single moderator decision"),
-    );
+    yield* timeout(reportedMember, "single moderator decision");
 
     yield* logEffect("info", "DirectActions", "Timed out user", {
       reportedUserId,

--- a/app/commands/escalate/service.ts
+++ b/app/commands/escalate/service.ts
@@ -333,36 +333,45 @@ export const EscalationServiceLive = Layer.effect(
             return;
           }
 
-          yield* Effect.tryPromise({
-            try: async () => {
-              switch (resolution) {
-                case "track":
-                  // No action needed
-                  break;
-                case "timeout":
-                  await timeout(reportedMember, "voted resolution");
-                  break;
-                case "restrict":
-                  await applyRestriction(reportedMember);
-                  break;
-                case "kick":
-                  await kick(reportedMember, "voted resolution");
-                  break;
-                case "ban":
-                  await ban(reportedMember, "voted resolution");
-                  break;
-              }
-            },
-            catch: (caught) =>
-              new ResolutionExecutionError({
-                escalationId: escalation.id,
-                resolution,
-                cause:
-                  caught instanceof Error
-                    ? caught
-                    : new Error(formatError(caught)),
-              }),
+          const action = Effect.gen(function* () {
+            switch (resolution) {
+              case "track":
+                // No action needed
+                break;
+              case "timeout":
+                yield* timeout(reportedMember, "voted resolution");
+                break;
+              case "restrict":
+                yield* applyRestriction(reportedMember);
+                break;
+              case "kick":
+                yield* kick(reportedMember, "voted resolution");
+                break;
+              case "ban":
+                yield* ban(reportedMember, "voted resolution");
+                break;
+            }
           });
+
+          // Fold the typed DiscordError/SqlError/NotFoundError failures of the
+          // action Effects into the public ResolutionExecutionError contract.
+          // applyRestriction requires DatabaseService — satisfy it from the
+          // `db` captured in this Layer's closure so executeResolution keeps a
+          // `never` Requirements channel per IEscalationService.
+          yield* action.pipe(
+            Effect.provideService(DatabaseService, db),
+            Effect.mapError(
+              (caught) =>
+                new ResolutionExecutionError({
+                  escalationId: escalation.id,
+                  resolution,
+                  cause:
+                    caught instanceof Error
+                      ? caught
+                      : new Error(formatError(caught)),
+                }),
+            ),
+          );
 
           yield* logEffect("info", "EscalationService", "Resolution executed");
         }).pipe(

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -978,22 +978,20 @@ export const SetupComponentCommands: MessageComponentCommand[] = [
         pendingSetups.delete(key);
         yield* interactionDeferUpdate(interaction);
 
-        const result = yield* Effect.tryPromise(() =>
-          setupAll({
-            guildId,
-            moderatorRoleId: state.modRoleId!,
-            restrictedRoleId: state.restrictedRoleId,
-            modLogChannel: state.modLogChannel,
-            deletionLogChannel: state.deletionLogChannel ?? undefined,
-            honeypotChannel: state.honeypotChannel ?? undefined,
-            ticketChannel: state.ticketChannel ?? undefined,
-            applicationChannel: state.applicationChannel ?? undefined,
-            memberRoleId:
-              state.applicationChannel !== null && !state.memberRoleId
-                ? CREATE_SENTINEL
-                : state.memberRoleId,
-          }),
-        );
+        const result = yield* setupAll({
+          guildId,
+          moderatorRoleId: state.modRoleId!,
+          restrictedRoleId: state.restrictedRoleId,
+          modLogChannel: state.modLogChannel,
+          deletionLogChannel: state.deletionLogChannel ?? undefined,
+          honeypotChannel: state.honeypotChannel ?? undefined,
+          ticketChannel: state.ticketChannel ?? undefined,
+          applicationChannel: state.applicationChannel ?? undefined,
+          memberRoleId:
+            state.applicationChannel !== null && !state.memberRoleId
+              ? CREATE_SENTINEL
+              : state.memberRoleId,
+        });
 
         yield* logEffect(
           "info",

--- a/app/discord/api.ts
+++ b/app/discord/api.ts
@@ -1,6 +1,7 @@
 import { REST } from "discord.js";
 import { redirect } from "react-router";
 
+import { runEffect } from "#~/AppRuntime";
 import { discordToken } from "#~/helpers/env.server";
 import { log } from "#~/helpers/observability";
 import {
@@ -11,7 +12,7 @@ import {
 export const ssrDiscordSdk = new REST({ version: "10" }).setToken(discordToken);
 
 export async function userDiscordSdkFromRequest(request: Request) {
-  const userToken = await retrieveDiscordToken(request);
+  const userToken = await runEffect(retrieveDiscordToken(request));
 
   if (userToken.expired()) {
     log(
@@ -23,7 +24,9 @@ export async function userDiscordSdkFromRequest(request: Request) {
       // Persist the refreshed token to the DB session and get the new cookie.
       // We redirect back to the same URL so the next request reads the new token
       // from the session instead of finding the expired one again.
-      const refreshCookie = await refreshAndPersistDiscordSession(request);
+      const refreshCookie = await runEffect(
+        refreshAndPersistDiscordSession(request),
+      );
       const url = new URL(request.url);
       throw redirect(url.pathname + url.search, {
         headers: { "Set-Cookie": refreshCookie },

--- a/app/effects/errorHandling.ts
+++ b/app/effects/errorHandling.ts
@@ -90,6 +90,12 @@ export const toUserResponse = (
           "Discord is having trouble right now — please try again shortly.",
         ephemeral: true,
       };
+    case "OAuthFetchError":
+      return {
+        content:
+          "We couldn't verify your Discord login — please try signing in again.",
+        ephemeral: true,
+      };
     // ClientError, ServerError, ConfigError, SqlError, DatabaseCorruptionError,
     // NotFoundError, AlreadyResolvedError, NoLeaderError, ResolutionExecutionError
     default:

--- a/app/effects/errorHandling.ts
+++ b/app/effects/errorHandling.ts
@@ -96,6 +96,12 @@ export const toUserResponse = (
           "We couldn't verify your Discord login — please try signing in again.",
         ephemeral: true,
       };
+    case "StripeError":
+      return {
+        content:
+          "We hit a billing error — please try again shortly or contact support if it persists.",
+        ephemeral: true,
+      };
     // ClientError, ServerError, ConfigError, SqlError, DatabaseCorruptionError,
     // NotFoundError, AlreadyResolvedError, NoLeaderError, ResolutionExecutionError
     default:

--- a/app/effects/errors.ts
+++ b/app/effects/errors.ts
@@ -67,6 +67,16 @@ export class SubscriptionNotFoundError extends Data.TaggedError(
 )<{ guildId: string }> {}
 
 /**
+ * A Stripe SDK call rejected. `operation` names the StripeService method, and
+ * `cause` carries the raw Stripe error (never stringified here — the user-facing
+ * mapping in `toUserResponse` returns generic billing copy).
+ */
+export class StripeError extends Data.TaggedError("StripeError")<{
+  operation: string;
+  cause: unknown;
+}> {}
+
+/**
  * Raw `fetch` to a Discord OAuth endpoint (e.g. `/users/@me`) failed: either the
  * request rejected (network) or returned a non-2xx status. This is distinct from
  * the `DiscordError` taxonomy, which classifies `@discordjs/rest` SDK rejection
@@ -163,6 +173,7 @@ export type AppError =
   | ResolutionExecutionError
   | FeatureDisabledError
   | SubscriptionNotFoundError
+  | StripeError
   | OAuthFetchError
   | SqlErrorType
   /** Effect.tryPromise wraps thrown exceptions in UnknownException; command-level

--- a/app/effects/errors.ts
+++ b/app/effects/errors.ts
@@ -66,6 +66,20 @@ export class SubscriptionNotFoundError extends Data.TaggedError(
   "SubscriptionNotFoundError",
 )<{ guildId: string }> {}
 
+/**
+ * Raw `fetch` to a Discord OAuth endpoint (e.g. `/users/@me`) failed: either the
+ * request rejected (network) or returned a non-2xx status. This is distinct from
+ * the `DiscordError` taxonomy, which classifies `@discordjs/rest` SDK rejection
+ * shapes — the OAuth user-info call is a bare `fetch` with an OAuth access token,
+ * not an SDK call, so it never produces those shapes. `status` is absent on a
+ * network-level rejection.
+ */
+export class OAuthFetchError extends Data.TaggedError("OAuthFetchError")<{
+  operation: string;
+  status?: number;
+  cause: Error;
+}> {}
+
 // --- Infra error taxonomy (named by the decision each drives) -------------
 // `cause` is always a serializable Error (narrowed at the classifier boundary).
 
@@ -149,6 +163,7 @@ export type AppError =
   | ResolutionExecutionError
   | FeatureDisabledError
   | SubscriptionNotFoundError
+  | OAuthFetchError
   | SqlErrorType
   /** Effect.tryPromise wraps thrown exceptions in UnknownException; command-level
    *  catchAll blocks see this whenever a raw promise rejects with an untyped error. */

--- a/app/features/Admin/helpers.server.ts
+++ b/app/features/Admin/helpers.server.ts
@@ -1,6 +1,7 @@
+import type { Effect } from "effect";
 import { data } from "react-router";
 
-import { getPosthog } from "#~/AppRuntime";
+import { getPosthog, runEffect } from "#~/AppRuntime";
 import { requireUser } from "#~/models/session.server";
 import { StripeService } from "#~/models/stripe.server";
 
@@ -21,14 +22,18 @@ export async function fetchFeatureFlags(guildId: string) {
 }
 
 export async function fetchStripeDetails(stripeCustomerId: string) {
+  // StripeService methods now return Effects; bridge each via runEffect to keep
+  // this Promise-based file compiling until it is migrated in Task 7.
   const [paymentMethods, invoices] = await Promise.all([
-    StripeService.listPaymentMethods(stripeCustomerId),
-    StripeService.listInvoices(stripeCustomerId),
+    runEffect(StripeService.listPaymentMethods(stripeCustomerId)),
+    runEffect(StripeService.listInvoices(stripeCustomerId)),
   ]);
   return { paymentMethods, invoices };
 }
 
-export type PaymentMethods = Awaited<
+export type PaymentMethods = Effect.Effect.Success<
   ReturnType<typeof StripeService.listPaymentMethods>
 >;
-export type Invoices = Awaited<ReturnType<typeof StripeService.listInvoices>>;
+export type Invoices = Effect.Effect.Success<
+  ReturnType<typeof StripeService.listInvoices>
+>;

--- a/app/features/Admin/helpers.server.ts
+++ b/app/features/Admin/helpers.server.ts
@@ -1,10 +1,14 @@
-import type { Effect } from "effect";
+import { Effect } from "effect";
 import { data } from "react-router";
 
-import { getPosthog, runEffect } from "#~/AppRuntime";
+import { getPosthog } from "#~/AppRuntime";
+import type { StripeError } from "#~/effects/errors.ts";
 import { requireUser } from "#~/models/session.server";
 import { StripeService } from "#~/models/stripe.server";
 
+// requireAdmin throws redirect()/logout() Responses (via requireUser) and a
+// `data(..., { status: 403 })` Response for non-admins. Thrown Responses are
+// React-Router control flow that runEffect cannot carry, so this stays async.
 export async function requireAdmin(request: Request) {
   const user = await requireUser(request);
   if (!user.email?.endsWith("@reactiflux.com")) {
@@ -13,23 +17,33 @@ export async function requireAdmin(request: Request) {
   return user;
 }
 
-export async function fetchFeatureFlags(guildId: string) {
+export const fetchFeatureFlags = (
+  guildId: string,
+): Effect.Effect<Record<string, string | boolean> | null, never, never> => {
   const posthog = getPosthog();
-  if (!posthog) return null;
-  return (await posthog.getAllFlags(guildId, {
-    groups: { guild: guildId },
-  })) as Record<string, string | boolean>;
-}
+  if (!posthog) return Effect.succeed(null);
+  return Effect.promise(
+    () =>
+      posthog.getAllFlags(guildId, {
+        groups: { guild: guildId },
+      }) as Promise<Record<string, string | boolean>>,
+  );
+};
 
-export async function fetchStripeDetails(stripeCustomerId: string) {
-  // StripeService methods now return Effects; bridge each via runEffect to keep
-  // this Promise-based file compiling until it is migrated in Task 7.
-  const [paymentMethods, invoices] = await Promise.all([
-    runEffect(StripeService.listPaymentMethods(stripeCustomerId)),
-    runEffect(StripeService.listInvoices(stripeCustomerId)),
-  ]);
-  return { paymentMethods, invoices };
-}
+export const fetchStripeDetails = (
+  stripeCustomerId: string,
+): Effect.Effect<
+  { paymentMethods: PaymentMethods; invoices: Invoices },
+  StripeError,
+  never
+> =>
+  Effect.gen(function* () {
+    const [paymentMethods, invoices] = yield* Effect.all([
+      StripeService.listPaymentMethods(stripeCustomerId),
+      StripeService.listInvoices(stripeCustomerId),
+    ]);
+    return { paymentMethods, invoices };
+  });
 
 export type PaymentMethods = Effect.Effect.Success<
   ReturnType<typeof StripeService.listPaymentMethods>

--- a/app/features/Admin/jobHelpers.server.ts
+++ b/app/features/Admin/jobHelpers.server.ts
@@ -1,7 +1,6 @@
 import { Effect } from "effect";
 
-import { runEffect } from "#~/AppRuntime";
-import { DatabaseService } from "#~/Database";
+import { DatabaseService, type SqlError } from "#~/Database";
 import { SupervisorService, type ActiveJobMeta } from "#~/effects/supervisor";
 import type { Job } from "#~/jobs/jobRunner";
 
@@ -13,30 +12,32 @@ export interface AdminJob extends Job {
 }
 
 /** Fetch all jobs from the DB, annotated with fiber liveness from Supervisor. */
-export async function fetchAdminJobs(): Promise<AdminJob[]> {
-  return runEffect(
-    Effect.gen(function* () {
-      const db = yield* DatabaseService;
-      const supervisor = yield* SupervisorService;
+export function fetchAdminJobs(): Effect.Effect<
+  AdminJob[],
+  SqlError,
+  DatabaseService | SupervisorService
+> {
+  return Effect.gen(function* () {
+    const db = yield* DatabaseService;
+    const supervisor = yield* SupervisorService;
 
-      // Query DB and Supervisor in parallel
-      const [jobs, activeMetas] = yield* Effect.all([
-        Effect.gen(function* () {
-          return yield* db
-            .selectFrom("background_jobs")
-            .selectAll()
-            .orderBy("created_at", "desc");
-        }),
-        supervisor.getActiveJobMeta(),
-      ]);
+    // Query DB and Supervisor in parallel
+    const [jobs, activeMetas] = yield* Effect.all([
+      Effect.gen(function* () {
+        return yield* db
+          .selectFrom("background_jobs")
+          .selectAll()
+          .orderBy("created_at", "desc");
+      }),
+      supervisor.getActiveJobMeta(),
+    ]);
 
-      const activeByJobId = new Map(activeMetas.map((m) => [m.jobId, m]));
+    const activeByJobId = new Map(activeMetas.map((m) => [m.jobId, m]));
 
-      return (jobs as Job[]).map((job) => ({
-        ...job,
-        fiberActive: activeByJobId.has(job.id),
-        fiberMeta: activeByJobId.get(job.id) ?? null,
-      }));
-    }).pipe(Effect.withSpan("fetchAdminJobs")),
-  );
+    return (jobs as Job[]).map((job) => ({
+      ...job,
+      fiberActive: activeByJobId.has(job.id),
+      fiberMeta: activeByJobId.get(job.id) ?? null,
+    }));
+  }).pipe(Effect.withSpan("AdminJobs.fetch"));
 }

--- a/app/features/spam/spamResponseHandler.ts
+++ b/app/features/spam/spamResponseHandler.ts
@@ -83,7 +83,7 @@ export const executeResponse = (
 
     if (verdict.tier === "medium") {
       // Apply restricted role
-      yield* Effect.tryPromise(() => applyRestriction(member)).pipe(
+      yield* applyRestriction(member).pipe(
         Effect.catchAll((error) =>
           logEffect("warn", "SpamResponse", "Failed to apply restriction", {
             error,
@@ -95,9 +95,7 @@ export const executeResponse = (
 
     if (verdict.tier === "high") {
       // Timeout user in the originating guild
-      yield* Effect.tryPromise(() =>
-        timeout(member, "Automated spam detection"),
-      ).pipe(
+      yield* timeout(member, "Automated spam detection").pipe(
         Effect.catchAll((error) =>
           logEffect("warn", "SpamResponse", "Failed to timeout user", {
             error,

--- a/app/helpers/guildCache.server.ts
+++ b/app/helpers/guildCache.server.ts
@@ -1,8 +1,10 @@
+import { Effect } from "effect";
+
 import type { REST } from "@discordjs/rest";
 import TTLCache from "@isaacs/ttlcache";
 
-import { runEffect } from "#~/AppRuntime";
-import { log } from "#~/helpers/observability";
+import type { DiscordError } from "#~/effects/errors";
+import { logEffect } from "#~/effects/observability";
 import { fetchGuilds, type Guild } from "#~/models/discord.server";
 
 export interface CachedGuild {
@@ -29,23 +31,26 @@ function toCachedGuild(g: Guild): CachedGuild {
   };
 }
 
-export async function getCachedGuilds(
+export const getCachedGuilds = (
   userId: string,
   userRest: REST,
   botRest: REST,
-): Promise<CachedGuild[]> {
-  const cached = guildCache.get(userId);
-  if (cached) return cached;
+): Effect.Effect<CachedGuild[], DiscordError, never> =>
+  Effect.gen(function* () {
+    const cached = guildCache.get(userId);
+    if (cached) return cached;
 
-  const guilds = await runEffect(fetchGuilds(userRest, botRest));
-  const result = guilds.map(toCachedGuild);
-  guildCache.set(userId, result);
+    const guilds = yield* fetchGuilds(userRest, botRest);
+    const result = guilds.map(toCachedGuild);
+    guildCache.set(userId, result);
 
-  log("info", "guildCache", "Guilds fetched and cached", {
-    userId,
-    totalGuilds: result.length,
-    manageableGuilds: result.filter((g) => g.hasBot).length,
-  });
+    yield* logEffect("info", "guildCache", "Guilds fetched and cached", {
+      userId,
+      totalGuilds: result.length,
+      manageableGuilds: result.filter((g) => g.hasBot).length,
+    });
 
-  return result;
-}
+    return result;
+  }).pipe(
+    Effect.withSpan("guildCache.getCachedGuilds", { attributes: { userId } }),
+  );

--- a/app/helpers/guildCache.server.ts
+++ b/app/helpers/guildCache.server.ts
@@ -1,6 +1,7 @@
 import type { REST } from "@discordjs/rest";
 import TTLCache from "@isaacs/ttlcache";
 
+import { runEffect } from "#~/AppRuntime";
 import { log } from "#~/helpers/observability";
 import { fetchGuilds, type Guild } from "#~/models/discord.server";
 
@@ -36,7 +37,7 @@ export async function getCachedGuilds(
   const cached = guildCache.get(userId);
   if (cached) return cached;
 
-  const guilds = await fetchGuilds(userRest, botRest);
+  const guilds = await runEffect(fetchGuilds(userRest, botRest));
   const result = guilds.map(toCachedGuild);
   guildCache.set(userId, result);
 

--- a/app/helpers/guildData.server.ts
+++ b/app/helpers/guildData.server.ts
@@ -4,9 +4,11 @@ import {
   type APIChannel,
   type APIRole,
 } from "discord-api-types/v10";
+import { Effect } from "effect";
 
 import { ssrDiscordSdk } from "#~/discord/api";
-import { log, trackPerformance } from "#~/helpers/observability";
+import { tryDiscord } from "#~/effects/classifyDiscordError";
+import { logEffect } from "#~/effects/observability";
 
 export interface GuildRole {
   id: string;
@@ -44,18 +46,26 @@ function toGuildChannel(ch: APIChannel): GuildChannel {
   };
 }
 
-export async function fetchGuildData(guildId: string): Promise<GuildData> {
-  try {
-    const [apiRoles, apiChannels] = await trackPerformance(
-      "discord.fetchGuildData",
-      () =>
-        Promise.all([
+const EMPTY_RESULT: GuildData = { roles: [], channels: [] };
+
+export function fetchGuildData(
+  guildId: string,
+): Effect.Effect<GuildData, never, never> {
+  return Effect.gen(function* () {
+    const [apiRoles, apiChannels] = yield* Effect.all([
+      tryDiscord(
+        "fetchGuildRoles",
+        () =>
           ssrDiscordSdk.get(Routes.guildRoles(guildId)) as Promise<APIRole[]>,
+      ),
+      tryDiscord(
+        "fetchGuildChannels",
+        () =>
           ssrDiscordSdk.get(Routes.guildChannels(guildId)) as Promise<
             APIChannel[]
           >,
-        ]),
-    );
+      ),
+    ]);
 
     const roles = apiRoles
       .filter((role) => role.name !== "@everyone")
@@ -83,7 +93,7 @@ export async function fetchGuildData(guildId: string): Promise<GuildData> {
           ("position" in b ? (b.position ?? 0) : 0),
       );
 
-    log("info", "guildData", "Guild data fetched successfully", {
+    yield* logEffect("info", "guildData", "Guild data fetched successfully", {
       guildId,
       rolesCount: roles.length,
       channelsCount: textChannels.length,
@@ -115,11 +125,13 @@ export async function fetchGuildData(guildId: string): Promise<GuildData> {
     ];
 
     return { roles, channels };
-  } catch (error) {
-    log("error", "guildData", "Failed to fetch guild data", {
-      guildId,
-      error,
-    });
-    return { roles: [], channels: [] };
-  }
+  }).pipe(
+    Effect.withSpan("guildData.fetch", { attributes: { guildId } }),
+    Effect.catchAll((e) =>
+      logEffect("error", "guildData", "Failed to fetch guild data", {
+        guildId,
+        error: e,
+      }).pipe(Effect.as(EMPTY_RESULT)),
+    ),
+  );
 }

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -10,17 +10,15 @@ import {
   type APIRole,
   type RESTPostAPIGuildChannelJSONBody,
 } from "discord-api-types/v10";
+import { Effect } from "effect";
 
-import {
-  db,
-  isFeatureEnabled,
-  run,
-  runEffect,
-  runTakeFirst,
-} from "#~/AppRuntime";
+import { isFeatureEnabled } from "#~/AppRuntime";
+import { DatabaseService, type SqlError } from "#~/Database";
 import { ssrDiscordSdk } from "#~/discord/api";
+import { toError, tryDiscord } from "#~/effects/classifyDiscordError";
+import { TransientError, type DiscordError } from "#~/effects/errors";
+import { logEffect } from "#~/effects/observability";
 import { applicationId } from "#~/helpers/env.server";
-import { log } from "#~/helpers/observability";
 import {
   DEFAULT_BUTTON_TEXT,
   DEFAULT_MESSAGE_TEXT,
@@ -76,213 +74,231 @@ function logsCategoryOverwrites(guildId: string, modRoleId: string) {
   ];
 }
 
-async function createGuildChannel(
+/** Discord REST: create a guild channel, wrapped as a typed Effect. */
+const createGuildChannel = (
   guildId: string,
   body: RESTPostAPIGuildChannelJSONBody,
-) {
-  return ssrDiscordSdk.post(Routes.guildChannels(guildId), {
-    body,
-  }) as Promise<APIChannel>;
-}
+): Effect.Effect<APIChannel, DiscordError> =>
+  tryDiscord(
+    "createGuildChannel",
+    () =>
+      ssrDiscordSdk.post(Routes.guildChannels(guildId), {
+        body,
+      }) as Promise<APIChannel>,
+  );
 
-async function sendChannelMessage(
+/** Discord REST: post a message to a channel, wrapped as a typed Effect. */
+const sendChannelMessage = (
   channelId: string,
   body: Record<string, unknown>,
-) {
-  return ssrDiscordSdk.post(Routes.channelMessages(channelId), {
-    body,
-  }) as Promise<APIMessage>;
-}
+): Effect.Effect<APIMessage, DiscordError> =>
+  tryDiscord(
+    "sendChannelMessage",
+    () =>
+      ssrDiscordSdk.post(Routes.channelMessages(channelId), {
+        body,
+      }) as Promise<APIMessage>,
+  );
 
-export async function setupAll(
+export const setupAll = (
   options: SetupAllOptions,
-): Promise<SetupAllResult> {
-  const {
-    guildId,
-    moderatorRoleId,
-    restrictedRoleId,
-    modLogChannel,
-    deletionLogChannel,
-    honeypotChannel,
-    ticketChannel,
-    applicationChannel,
-    memberRoleId,
-  } = options;
+): Effect.Effect<SetupAllResult, DiscordError | SqlError, DatabaseService> =>
+  Effect.gen(function* () {
+    const {
+      guildId,
+      moderatorRoleId,
+      restrictedRoleId,
+      modLogChannel,
+      deletionLogChannel,
+      honeypotChannel,
+      ticketChannel,
+      applicationChannel,
+      memberRoleId,
+    } = options;
 
-  const created: string[] = [];
+    const db = yield* DatabaseService;
 
-  // Register guild (idempotent)
-  await runEffect(registerGuild(guildId));
+    const created: string[] = [];
 
-  // --- Load existing config to skip unchanged values ---
-  const existingAppConfig = await runTakeFirst(
-    db
+    // Register guild (idempotent)
+    yield* registerGuild(guildId);
+
+    // --- Load existing config to skip unchanged values ---
+    const existingAppConfigRows = yield* db
       .selectFrom("application_config")
       .select(["channel_id", "role_id"])
-      .where("guild_id", "=", guildId),
-  );
-  const existingTicket = await runTakeFirst(
-    db.selectFrom("tickets_config").select("channel_id"),
-  );
+      .where("guild_id", "=", guildId);
+    const existingAppConfig = existingAppConfigRows[0];
 
-  // --- Logs category (created if mod-log or deletion-log needs creation) ---
-  let logsCategoryId: string | undefined;
-  const needsLogsCategory =
-    modLogChannel === CREATE_SENTINEL || deletionLogChannel === CREATE_SENTINEL;
+    const existingTicketRows = yield* db
+      .selectFrom("tickets_config")
+      .select("channel_id");
+    const existingTicket = existingTicketRows[0];
 
-  if (needsLogsCategory) {
-    const category = await createGuildChannel(guildId, {
-      name: "Euno Logs",
-      type: ChannelType.GuildCategory,
-      permission_overwrites: logsCategoryOverwrites(guildId, moderatorRoleId),
-    });
-    logsCategoryId = category.id;
-  }
+    // --- Logs category (created if mod-log or deletion-log needs creation) ---
+    let logsCategoryId: string | undefined;
+    const needsLogsCategory =
+      modLogChannel === CREATE_SENTINEL ||
+      deletionLogChannel === CREATE_SENTINEL;
 
-  // --- Mod-log channel ---
-  let modLogChannelId: string;
-  if (modLogChannel === CREATE_SENTINEL) {
-    const ch = await createGuildChannel(guildId, {
-      name: "mod-log",
-      type: ChannelType.GuildText,
-      parent_id: logsCategoryId,
-    });
-    modLogChannelId = ch.id;
-    created.push("mod-log");
-  } else {
-    modLogChannelId = modLogChannel;
-  }
-
-  // --- Deletion-log channel (optional) ---
-  let deletionLogChannelId: string | undefined;
-  if (deletionLogChannel === CREATE_SENTINEL) {
-    const ch = await createGuildChannel(guildId, {
-      name: "deletion-log",
-      type: ChannelType.GuildText,
-      parent_id: logsCategoryId,
-    });
-    deletionLogChannelId = ch.id;
-    created.push("deletion-log");
-  } else if (deletionLogChannel !== undefined) {
-    deletionLogChannelId = deletionLogChannel;
-  }
-
-  // --- Member application channel (optional) ---
-  let applicationChannelId: string | undefined;
-  let resolvedMemberRoleId: string | undefined;
-
-  // Check if application config is unchanged (skip re-sending message + bulk job)
-  const appChannelUnchanged =
-    applicationChannel !== undefined &&
-    applicationChannel !== CREATE_SENTINEL &&
-    memberRoleId !== undefined &&
-    memberRoleId !== CREATE_SENTINEL &&
-    existingAppConfig?.channel_id === applicationChannel &&
-    existingAppConfig?.role_id === memberRoleId;
-
-  if (appChannelUnchanged) {
-    // Application config unchanged — just set IDs for settings save, skip all API calls
-    applicationChannelId = applicationChannel;
-    resolvedMemberRoleId = memberRoleId;
-    log(
-      "info",
-      "setupAll",
-      "Application config unchanged, skipping message + bulk job",
-      { guildId, applicationChannelId, resolvedMemberRoleId },
-    );
-  } else if (applicationChannel !== undefined && memberRoleId !== undefined) {
-    // Step 1: Resolve @member role
-    if (memberRoleId === CREATE_SENTINEL) {
-      const role = (await ssrDiscordSdk.post(Routes.guildRoles(guildId), {
-        body: { name: "Member", permissions: "0" },
-      })) as APIRole;
-      resolvedMemberRoleId = role.id;
-      created.push("Member role");
-    } else {
-      resolvedMemberRoleId = memberRoleId;
+    if (needsLogsCategory) {
+      const category = yield* createGuildChannel(guildId, {
+        name: "Euno Logs",
+        type: ChannelType.GuildCategory,
+        permission_overwrites: logsCategoryOverwrites(guildId, moderatorRoleId),
+      });
+      logsCategoryId = category.id;
     }
 
-    // Step 2: Fetch current @everyone role permissions
-    const roles = (await ssrDiscordSdk.get(
-      Routes.guildRoles(guildId),
-    )) as APIRole[];
-    const everyoneRole = roles.find((r) => r.id === guildId);
-    const everyonePerms = BigInt(everyoneRole?.permissions ?? "0");
-
-    // Step 3: Fetch current @member role permissions
-    const memberRole = roles.find((r) => r.id === resolvedMemberRoleId);
-    const memberPerms = BigInt(memberRole?.permissions ?? "0");
-
-    // Step 4: Create #apply-here channel (before permission changes so bot still has access)
-    if (applicationChannel === CREATE_SENTINEL) {
-      const botUserId = applicationId;
-      const ch = await createGuildChannel(guildId, {
-        name: "apply-here",
+    // --- Mod-log channel ---
+    let modLogChannelId: string;
+    if (modLogChannel === CREATE_SENTINEL) {
+      const ch = yield* createGuildChannel(guildId, {
+        name: "mod-log",
         type: ChannelType.GuildText,
-        permission_overwrites: [
+        parent_id: logsCategoryId,
+      });
+      modLogChannelId = ch.id;
+      created.push("mod-log");
+    } else {
+      modLogChannelId = modLogChannel;
+    }
+
+    // --- Deletion-log channel (optional) ---
+    let deletionLogChannelId: string | undefined;
+    if (deletionLogChannel === CREATE_SENTINEL) {
+      const ch = yield* createGuildChannel(guildId, {
+        name: "deletion-log",
+        type: ChannelType.GuildText,
+        parent_id: logsCategoryId,
+      });
+      deletionLogChannelId = ch.id;
+      created.push("deletion-log");
+    } else if (deletionLogChannel !== undefined) {
+      deletionLogChannelId = deletionLogChannel;
+    }
+
+    // --- Member application channel (optional) ---
+    let applicationChannelId: string | undefined;
+    let resolvedMemberRoleId: string | undefined;
+
+    // Check if application config is unchanged (skip re-sending message + bulk job)
+    const appChannelUnchanged =
+      applicationChannel !== undefined &&
+      applicationChannel !== CREATE_SENTINEL &&
+      memberRoleId !== undefined &&
+      memberRoleId !== CREATE_SENTINEL &&
+      existingAppConfig?.channel_id === applicationChannel &&
+      existingAppConfig?.role_id === memberRoleId;
+
+    if (appChannelUnchanged) {
+      // Application config unchanged — just set IDs for settings save, skip all API calls
+      applicationChannelId = applicationChannel;
+      resolvedMemberRoleId = memberRoleId;
+      yield* logEffect(
+        "info",
+        "setupAll",
+        "Application config unchanged, skipping message + bulk job",
+        { guildId, applicationChannelId, resolvedMemberRoleId },
+      );
+    } else if (applicationChannel !== undefined && memberRoleId !== undefined) {
+      // Step 1: Resolve @member role
+      if (memberRoleId === CREATE_SENTINEL) {
+        const role = yield* tryDiscord(
+          "createMemberRole",
+          () =>
+            ssrDiscordSdk.post(Routes.guildRoles(guildId), {
+              body: { name: "Member", permissions: "0" },
+            }) as Promise<APIRole>,
+        );
+        resolvedMemberRoleId = role.id;
+        created.push("Member role");
+      } else {
+        resolvedMemberRoleId = memberRoleId;
+      }
+
+      // Step 2: Fetch current @everyone role permissions
+      const roles = yield* tryDiscord(
+        "fetchGuildRoles",
+        () =>
+          ssrDiscordSdk.get(Routes.guildRoles(guildId)) as Promise<APIRole[]>,
+      );
+      const everyoneRole = roles.find((r) => r.id === guildId);
+      const everyonePerms = BigInt(everyoneRole?.permissions ?? "0");
+
+      // Step 3: Fetch current @member role permissions
+      const memberRole = roles.find((r) => r.id === resolvedMemberRoleId);
+      const memberPerms = BigInt(memberRole?.permissions ?? "0");
+
+      // Step 4: Create #apply-here channel (before permission changes so bot still has access)
+      if (applicationChannel === CREATE_SENTINEL) {
+        const botUserId = applicationId;
+        const ch = yield* createGuildChannel(guildId, {
+          name: "apply-here",
+          type: ChannelType.GuildText,
+          permission_overwrites: [
+            {
+              id: guildId,
+              type: OverwriteType.Role,
+              deny: String(
+                PermissionFlagsBits.ViewChannel |
+                  PermissionFlagsBits.SendMessages |
+                  PermissionFlagsBits.CreatePublicThreads |
+                  PermissionFlagsBits.CreatePrivateThreads,
+              ),
+            },
+            {
+              id: moderatorRoleId,
+              type: OverwriteType.Role,
+              allow: String(
+                PermissionFlagsBits.ViewChannel |
+                  PermissionFlagsBits.ReadMessageHistory,
+              ),
+            },
+            {
+              id: resolvedMemberRoleId,
+              type: OverwriteType.Role,
+              deny: String(PermissionFlagsBits.ViewChannel),
+            },
+            {
+              id: botUserId,
+              type: OverwriteType.Member,
+              allow: String(
+                PermissionFlagsBits.ViewChannel |
+                  PermissionFlagsBits.SendMessages |
+                  PermissionFlagsBits.CreatePrivateThreads |
+                  PermissionFlagsBits.ManageThreads,
+              ),
+            },
+          ],
+        });
+        applicationChannelId = ch.id;
+        created.push("apply-here");
+      } else {
+        applicationChannelId = applicationChannel;
+      }
+
+      // Step 5: Post "Apply to Join" button
+      const appMessage = yield* sendChannelMessage(applicationChannelId, {
+        content:
+          "Welcome! To gain access to this server, please submit an application. A moderator will review it shortly.",
+        components: [
           {
-            id: guildId,
-            type: OverwriteType.Role,
-            deny: String(
-              PermissionFlagsBits.ViewChannel |
-                PermissionFlagsBits.SendMessages |
-                PermissionFlagsBits.CreatePublicThreads |
-                PermissionFlagsBits.CreatePrivateThreads,
-            ),
-          },
-          {
-            id: moderatorRoleId,
-            type: OverwriteType.Role,
-            allow: String(
-              PermissionFlagsBits.ViewChannel |
-                PermissionFlagsBits.ReadMessageHistory,
-            ),
-          },
-          {
-            id: resolvedMemberRoleId,
-            type: OverwriteType.Role,
-            deny: String(PermissionFlagsBits.ViewChannel),
-          },
-          {
-            id: botUserId,
-            type: OverwriteType.Member,
-            allow: String(
-              PermissionFlagsBits.ViewChannel |
-                PermissionFlagsBits.SendMessages |
-                PermissionFlagsBits.CreatePrivateThreads |
-                PermissionFlagsBits.ManageThreads,
-            ),
+            type: ComponentType.ActionRow,
+            components: [
+              {
+                type: ComponentType.Button,
+                label: "Apply to Join",
+                style: ButtonStyle.Primary,
+                custom_id: "apply-to-join",
+              },
+            ],
           },
         ],
       });
-      applicationChannelId = ch.id;
-      created.push("apply-here");
-    } else {
-      applicationChannelId = applicationChannel;
-    }
 
-    // Step 5: Post "Apply to Join" button
-    const appMessage = await sendChannelMessage(applicationChannelId, {
-      content:
-        "Welcome! To gain access to this server, please submit an application. A moderator will review it shortly.",
-      components: [
-        {
-          type: ComponentType.ActionRow,
-          components: [
-            {
-              type: ComponentType.Button,
-              label: "Apply to Join",
-              style: ButtonStyle.Primary,
-              custom_id: "apply-to-join",
-            },
-          ],
-        },
-      ],
-    });
-
-    // Step 6: Insert into application_config (upsert on re-setup)
-    await run(
-      db
+      // Step 6: Insert into application_config (upsert on re-setup)
+      yield* db
         .insertInto("application_config")
         .values({
           guild_id: guildId,
@@ -296,39 +312,46 @@ export async function setupAll(
             role_id: resolvedMemberRoleId,
             message_id: appMessage.id,
           }),
-        ),
-    );
+        );
 
-    // Create a persistent background job for bulk role assignment.
-    // The job will scan for the final cursor on first execution, then
-    // assign the role in batches with checkpointing, and finally update
-    // permissions once all members have the role.
-    const bulkRoleId = resolvedMemberRoleId;
-    await createJob({
-      guildId,
-      jobType: "bulk_role_assignment",
-      payload: {
-        roleId: bulkRoleId,
-        everyonePermissions: String(everyonePerms),
-        memberPermissions: String(memberPerms),
-      },
-      totalPhases: 1,
-      notifyChannelId: modLogChannelId,
-    });
+      // Create a persistent background job for bulk role assignment.
+      // The job will scan for the final cursor on first execution, then
+      // assign the role in batches with checkpointing, and finally update
+      // permissions once all members have the role.
+      const bulkRoleId = resolvedMemberRoleId;
+      yield* Effect.tryPromise({
+        try: () =>
+          createJob({
+            guildId,
+            jobType: "bulk_role_assignment",
+            payload: {
+              roleId: bulkRoleId,
+              everyonePermissions: String(everyonePerms),
+              memberPermissions: String(memberPerms),
+            },
+            totalPhases: 1,
+            notifyChannelId: modLogChannelId,
+          }),
+        catch: (rejection) =>
+          new TransientError({
+            source: "discord",
+            operation: "createJob",
+            cause: toError(rejection),
+          }),
+      });
 
-    log(
-      "info",
-      "setupAll",
-      "Created background job for member-role assignment",
-      {
-        guildId,
-      },
-    );
-  }
+      yield* logEffect(
+        "info",
+        "setupAll",
+        "Created background job for member-role assignment",
+        {
+          guildId,
+        },
+      );
+    }
 
-  // --- Save guild settings ---
-  await runEffect(
-    setSettings(guildId, {
+    // --- Save guild settings ---
+    yield* setSettings(guildId, {
       [SETTINGS.modLog]: modLogChannelId,
       [SETTINGS.moderator]: moderatorRoleId,
       [SETTINGS.restricted]: restrictedRoleId,
@@ -341,111 +364,129 @@ export async function setupAll(
       ...(applicationChannelId
         ? { [SETTINGS.applicationChannel]: applicationChannelId }
         : {}),
-    }),
-  );
-
-  // --- Honeypot channel (optional) ---
-  let honeypotChannelId: string | undefined;
-  if (honeypotChannel === CREATE_SENTINEL) {
-    const ch = await createGuildChannel(guildId, {
-      name: "honeypot",
-      type: ChannelType.GuildText,
-      position: 0,
     });
-    honeypotChannelId = ch.id;
-    created.push("honeypot");
 
-    await sendChannelMessage(honeypotChannelId, {
-      content: DEFAULT_MESSAGE_TEXT,
-    });
-  } else if (honeypotChannel !== undefined) {
-    honeypotChannelId = honeypotChannel;
-  }
+    // --- Honeypot channel (optional) ---
+    let honeypotChannelId: string | undefined;
+    if (honeypotChannel === CREATE_SENTINEL) {
+      const ch = yield* createGuildChannel(guildId, {
+        name: "honeypot",
+        type: ChannelType.GuildText,
+        position: 0,
+      });
+      honeypotChannelId = ch.id;
+      created.push("honeypot");
 
-  if (honeypotChannelId !== undefined) {
-    await run(
-      db
+      yield* sendChannelMessage(honeypotChannelId, {
+        content: DEFAULT_MESSAGE_TEXT,
+      });
+    } else if (honeypotChannel !== undefined) {
+      honeypotChannelId = honeypotChannel;
+    }
+
+    if (honeypotChannelId !== undefined) {
+      yield* db
         .insertInto("honeypot_config")
         .values({
           guild_id: guildId,
           channel_id: honeypotChannelId,
         })
-        .onConflict((c) => c.doNothing()),
-    );
-  }
+        .onConflict((c) => c.doNothing());
+    }
 
-  // --- Ticket channel (optional) ---
-  // Gate at setup, not at button-press: provisioning a ticket button while the
-  // `ticketing` flag is off gives a false success here and fails for the end
-  // user who later clicks it (#370). Skip the whole section when disabled.
-  let ticketChannelId: string | undefined;
-  const ticketRequested = ticketChannel !== undefined;
-  const ticketingEnabled = ticketRequested
-    ? await isFeatureEnabled("ticketing", guildId)
-    : false;
+    // --- Ticket channel (optional) ---
+    // Gate at setup, not at button-press: provisioning a ticket button while the
+    // `ticketing` flag is off gives a false success here and fails for the end
+    // user who later clicks it (#370). Skip the whole section when disabled.
+    let ticketChannelId: string | undefined;
+    const ticketRequested = ticketChannel !== undefined;
+    // isFeatureEnabled (AppRuntime) Promise-bridges a PostHog flag check through
+    // the ManagedRuntime, which provides FeatureFlagService itself — so the flag
+    // check does NOT add FeatureFlagService to this function's requirements.
+    const ticketingEnabled = ticketRequested
+      ? yield* Effect.tryPromise({
+          try: () => isFeatureEnabled("ticketing", guildId),
+          catch: (rejection) =>
+            new TransientError({
+              source: "discord",
+              operation: "isFeatureEnabled",
+              cause: toError(rejection),
+            }),
+        })
+      : false;
 
-  if (ticketRequested && !ticketingEnabled) {
-    log("warn", "setupAll", "Skipped ticket setup: ticketing flag disabled", {
-      guildId,
-    });
-  } else if (ticketChannel === CREATE_SENTINEL) {
-    const ch = await createGuildChannel(guildId, {
-      name: "contact-mods",
-      type: ChannelType.GuildText,
-    });
-    ticketChannelId = ch.id;
-    created.push("contact-mods");
-  } else if (ticketChannel !== undefined) {
-    ticketChannelId = ticketChannel;
-  }
-
-  const ticketUnchanged =
-    ticketChannelId !== undefined &&
-    ticketChannel !== CREATE_SENTINEL &&
-    existingTicket?.channel_id === ticketChannelId;
-
-  if (ticketChannelId !== undefined && !ticketUnchanged) {
-    const ticketMessage = await sendChannelMessage(ticketChannelId, {
-      components: [
+    if (ticketRequested && !ticketingEnabled) {
+      yield* logEffect(
+        "warn",
+        "setupAll",
+        "Skipped ticket setup: ticketing flag disabled",
         {
-          type: ComponentType.ActionRow,
-          components: [
-            {
-              type: ComponentType.Button,
-              label: DEFAULT_BUTTON_TEXT,
-              style: ButtonStyle.Primary,
-              custom_id: "open-ticket",
-            },
-          ],
+          guildId,
         },
-      ],
-    });
+      );
+    } else if (ticketChannel === CREATE_SENTINEL) {
+      const ch = yield* createGuildChannel(guildId, {
+        name: "contact-mods",
+        type: ChannelType.GuildText,
+      });
+      ticketChannelId = ch.id;
+      created.push("contact-mods");
+    } else if (ticketChannel !== undefined) {
+      ticketChannelId = ticketChannel;
+    }
 
-    await run(
-      db.insertInto("tickets_config").values({
+    const ticketUnchanged =
+      ticketChannelId !== undefined &&
+      ticketChannel !== CREATE_SENTINEL &&
+      existingTicket?.channel_id === ticketChannelId;
+
+    if (ticketChannelId !== undefined && !ticketUnchanged) {
+      const ticketMessage = yield* sendChannelMessage(ticketChannelId, {
+        components: [
+          {
+            type: ComponentType.ActionRow,
+            components: [
+              {
+                type: ComponentType.Button,
+                label: DEFAULT_BUTTON_TEXT,
+                style: ButtonStyle.Primary,
+                custom_id: "open-ticket",
+              },
+            ],
+          },
+        ],
+      });
+
+      yield* db.insertInto("tickets_config").values({
         message_id: ticketMessage.id,
         channel_id: ticketChannelId,
         role_id: moderatorRoleId,
-      }),
-    );
-  }
+      });
+    }
 
-  // --- Initialize free subscription ---
-  await runEffect(SubscriptionService.initializeFreeSubscription(guildId));
+    // --- Initialize free subscription ---
+    yield* SubscriptionService.initializeFreeSubscription(guildId);
 
-  log("info", "setupAll", "Setup-all completed via web", {
-    guildId,
-    moderatorRoleId,
-    created,
-  });
+    yield* logEffect("info", "setupAll", "Setup-all completed via web", {
+      guildId,
+      moderatorRoleId,
+      created,
+    });
 
-  return {
-    modLogChannelId,
-    deletionLogChannelId,
-    honeypotChannelId,
-    ticketChannelId,
-    applicationChannelId,
-    memberRoleId: resolvedMemberRoleId,
-    created,
-  };
-}
+    yield* Effect.annotateCurrentSpan({
+      createdCount: created.length,
+      created: created.join(","),
+    });
+
+    return {
+      modLogChannelId,
+      deletionLogChannelId,
+      honeypotChannelId,
+      ticketChannelId,
+      applicationChannelId,
+      memberRoleId: resolvedMemberRoleId,
+      created,
+    };
+  }).pipe(
+    Effect.withSpan("setupAll", { attributes: { guildId: options.guildId } }),
+  );

--- a/app/models/discord.server.ts
+++ b/app/models/discord.server.ts
@@ -3,15 +3,19 @@ import {
   Routes,
   type APIGuild,
 } from "discord-api-types/v10";
-import { type GuildMember } from "discord.js";
-import { Effect, Layer } from "effect";
+import { type GuildMember, type Role } from "discord.js";
+import { Effect } from "effect";
 import type { AccessToken } from "simple-oauth2";
 
 import type { REST } from "@discordjs/rest";
 
-import { db } from "#~/AppRuntime";
-import { DatabaseService } from "#~/Database";
-import { trackPerformance } from "#~/helpers/observability.js";
+import type { DatabaseService, SqlError } from "#~/Database";
+import { toError, tryDiscord } from "#~/effects/classifyDiscordError";
+import {
+  NotFoundError,
+  OAuthFetchError,
+  type DiscordError,
+} from "#~/effects/errors";
 import { complement, intersection } from "#~/helpers/sets.js";
 import { fetchSettings, SETTINGS } from "#~/models/guilds.server";
 
@@ -27,103 +31,147 @@ export interface DiscordUserInfo {
   avatar: string;
 }
 
-export async function fetchUser(access: AccessToken): Promise<DiscordUserInfo> {
-  const { token_type: tokenType, access_token: accessToken } = access.token as {
-    token_type: string;
-    access_token: string;
-  };
-  const res = await fetch("https://discord.com/api/users/@me", {
-    headers: { authorization: `${tokenType} ${accessToken}` },
-  });
+export const fetchUser = (
+  access: AccessToken,
+): Effect.Effect<DiscordUserInfo, OAuthFetchError, never> =>
+  Effect.tryPromise({
+    try: async () => {
+      const { token_type: tokenType, access_token: accessToken } =
+        access.token as {
+          token_type: string;
+          access_token: string;
+        };
+      const res = await fetch("https://discord.com/api/users/@me", {
+        headers: { authorization: `${tokenType} ${accessToken}` },
+      });
 
-  if (!res.ok) {
-    throw new Error(
-      `Discord API returned ${res.status} ${res.statusText} for /users/@me`,
+      if (!res.ok) {
+        throw new OAuthFetchError({
+          operation: "fetchUser",
+          status: res.status,
+          cause: new Error(
+            `Discord API returned ${res.status} ${res.statusText} for /users/@me`,
+          ),
+        });
+      }
+
+      const {
+        id,
+        username,
+        discriminator,
+        email,
+        verified,
+        locale,
+        mfa_enabled: has2FA,
+        avatar,
+      } = (await res.json()) as Record<string, string>;
+
+      return {
+        id,
+        username,
+        uniqueUsername: `${username}#${discriminator}`,
+        discriminator,
+        email,
+        verified,
+        locale,
+        has2FA: has2FA as unknown as boolean,
+        avatar,
+      } satisfies DiscordUserInfo;
+    },
+    // A thrown OAuthFetchError (non-2xx) passes through unchanged; a raw fetch
+    // rejection (network fault) is wrapped with no status.
+    catch: (rejection) =>
+      rejection instanceof OAuthFetchError
+        ? rejection
+        : new OAuthFetchError({
+            operation: "fetchUser",
+            cause: toError(rejection),
+          }),
+  }).pipe(Effect.withSpan("Discord.fetchUser"));
+
+export const applyRestriction = (
+  member: GuildMember | null,
+): Effect.Effect<
+  Role | undefined,
+  SqlError | NotFoundError | DiscordError,
+  DatabaseService
+> =>
+  Effect.gen(function* () {
+    if (!member) {
+      yield* Effect.logInfo("Tried to apply restriction to a null member");
+      return undefined;
+    }
+
+    // DatabaseService flows through the Requirements channel — provided by the
+    // ManagedRuntime / test layer at the call site — so we no longer need the
+    // old Effect.runPromise + Layer.succeed(DatabaseService, db) cycle hack.
+    const { restricted } = yield* fetchSettings(member.guild.id, [
+      SETTINGS.restricted,
+    ]);
+    if (!restricted) {
+      return yield* Effect.fail(
+        new NotFoundError({
+          resource: "restricted role setting",
+          id: member.guild.id,
+        }),
+      );
+    }
+    const restrictedRole = yield* tryDiscord("fetchRestrictedRole", () =>
+      member.guild.roles.fetch(restricted),
     );
-  }
+    if (!restrictedRole) {
+      return yield* Effect.fail(
+        new NotFoundError({ resource: "restricted role", id: restricted }),
+      );
+    }
+    // roles.add resolves to the GuildMember; return the Role that was applied
+    // so the success channel is the (more useful) Role, matching the signature.
+    yield* tryDiscord("addMemberRole", () => member.roles.add(restrictedRole));
+    return restrictedRole;
+  }).pipe(Effect.withSpan("Discord.applyRestriction"));
 
-  const {
-    id,
-    username,
-    discriminator,
-    email,
-    verified,
-    locale,
-    mfa_enabled: has2FA,
-    avatar,
-  } = (await res.json()) as Record<string, string>;
+export const kick = (
+  member: GuildMember | null,
+  reason: string,
+): Effect.Effect<void, DiscordError, never> =>
+  Effect.gen(function* () {
+    if (!member) {
+      yield* Effect.logInfo("Tried to kick a null member");
+      return;
+    }
+    yield* tryDiscord("kick", () => member.guild.members.kick(member, reason));
+  }).pipe(Effect.withSpan("Discord.kick"));
 
-  return {
-    id,
-    username,
-    uniqueUsername: `${username}#${discriminator}`,
-    discriminator,
-    email,
-    verified,
-    locale,
-    has2FA: has2FA as unknown as boolean,
-    avatar,
-  };
-}
-
-export const applyRestriction = async (member: GuildMember | null) => {
-  if (!member) {
-    console.log("Tried to apply restriction to a null member");
-    return;
-  }
-
-  // Provide DatabaseService via the lazy AppRuntime db handle rather than
-  // runEffect(...): this module sits inside the AppLayer import graph (via
-  // spamResponseHandler), so importing runEffect — whose signature mentions
-  // RuntimeContext — would create a circular type reference.
-  const { restricted } = await Effect.runPromise(
-    fetchSettings(member.guild.id, [SETTINGS.restricted]).pipe(
-      Effect.provide(Layer.succeed(DatabaseService, db)),
-    ),
-  );
-  if (!restricted) {
-    throw new Error(
-      "Tried to restrict with no restricted role configured. This is likely a development error.",
-    );
-  }
-  const restrictedRole = await member.guild.roles.fetch(restricted);
-  if (!restrictedRole) {
-    throw new Error("Couldn’t find restricted role");
-  }
-  return member.roles.add(restrictedRole);
-};
-
-export const kick = async (member: GuildMember | null, reason: string) => {
-  if (!member) {
-    console.log("Tried to kick a null member");
-    return;
-  }
-  return member.guild.members.kick(member, reason);
-};
-
-export const ban = async (
+export const ban = (
   member: GuildMember | null,
   reason: string,
   deleteMessageSeconds?: number,
-) => {
-  if (!member) {
-    console.log("Tried to ban a null member");
-    return;
-  }
-  return member.guild.bans.create(member, {
-    reason,
-    ...(deleteMessageSeconds !== undefined && { deleteMessageSeconds }),
-  });
-};
+): Effect.Effect<void, DiscordError, never> =>
+  Effect.gen(function* () {
+    if (!member) {
+      yield* Effect.logInfo("Tried to ban a null member");
+      return;
+    }
+    yield* tryDiscord("ban", () =>
+      member.guild.bans.create(member, {
+        reason,
+        ...(deleteMessageSeconds !== undefined && { deleteMessageSeconds }),
+      }),
+    );
+  }).pipe(Effect.withSpan("Discord.ban"));
 
 const OVERNIGHT = 1000 * 60 * 60 * 20;
-export const timeout = async (member: GuildMember | null, reason: string) => {
-  if (!member) {
-    console.log("Tried to timeout a null member");
-    return;
-  }
-  return member.timeout(OVERNIGHT, reason);
-};
+export const timeout = (
+  member: GuildMember | null,
+  reason: string,
+): Effect.Effect<void, DiscordError, never> =>
+  Effect.gen(function* () {
+    if (!member) {
+      yield* Effect.logInfo("Tried to timeout a null member");
+      return;
+    }
+    yield* tryDiscord("timeout", () => member.timeout(OVERNIGHT, reason));
+  }).pipe(Effect.withSpan("Discord.timeout"));
 
 const authzRoles = {
   mod: "MOD",
@@ -171,58 +219,55 @@ export interface Guild extends ReturnType<typeof processGuild> {
   hasBot: boolean;
 }
 
-export const fetchGuilds = async (
+export const fetchGuilds = (
   userRest: REST,
   botRest: REST,
-): Promise<Guild[]> => {
-  const [rawUserGuilds, rawBotGuilds] = (await trackPerformance(
-    "discord.fetchGuilds",
-    () =>
-      Promise.all([
-        userRest.get(Routes.userGuilds()),
-        botRest.get(Routes.userGuilds()),
-      ]),
-  )) as [APIGuild[], APIGuild[]];
+): Effect.Effect<Guild[], DiscordError, never> =>
+  Effect.gen(function* () {
+    const [rawUserGuilds, rawBotGuilds] = (yield* Effect.all([
+      tryDiscord("fetchUserGuilds", () => userRest.get(Routes.userGuilds())),
+      tryDiscord("fetchBotGuilds", () => botRest.get(Routes.userGuilds())),
+    ])) as [APIGuild[], APIGuild[]];
 
-  const botGuilds = new Map(
-    rawBotGuilds.reduce(
-      (accum, val) => {
-        const guild = processGuild(val);
-        if (guild.authz.length > 0) {
-          accum.push([val.id, guild]);
-        }
-        return accum;
-      },
-      [] as [string, Omit<Guild, "hasBot">][],
-    ),
-  );
-  const userGuilds = new Map(
-    rawUserGuilds.reduce(
-      (accum, val) => {
-        const guild = processGuild(val);
-        if (guild.authz.includes("MANAGER")) {
-          accum.push([val.id, guild]);
-        }
-        return accum;
-      },
-      [] as [string, Omit<Guild, "hasBot">][],
-    ),
-  );
+    const botGuilds = new Map(
+      rawBotGuilds.reduce(
+        (accum, val) => {
+          const guild = processGuild(val);
+          if (guild.authz.length > 0) {
+            accum.push([val.id, guild]);
+          }
+          return accum;
+        },
+        [] as [string, Omit<Guild, "hasBot">][],
+      ),
+    );
+    const userGuilds = new Map(
+      rawUserGuilds.reduce(
+        (accum, val) => {
+          const guild = processGuild(val);
+          if (guild.authz.includes("MANAGER")) {
+            accum.push([val.id, guild]);
+          }
+          return accum;
+        },
+        [] as [string, Omit<Guild, "hasBot">][],
+      ),
+    );
 
-  const botGuildIds = new Set(botGuilds.keys());
-  const userGuildIds = new Set(userGuilds.keys());
+    const botGuildIds = new Set(botGuilds.keys());
+    const userGuildIds = new Set(userGuilds.keys());
 
-  const manageableGuilds = intersection(userGuildIds, botGuildIds);
-  const invitableGuilds = complement(userGuildIds, botGuildIds);
+    const manageableGuilds = intersection(userGuildIds, botGuildIds);
+    const invitableGuilds = complement(userGuildIds, botGuildIds);
 
-  return [
-    ...[...manageableGuilds].map((gId) => {
-      const guild = botGuilds.get(gId);
-      return guild ? { ...guild, hasBot: true } : undefined;
-    }),
-    ...[...invitableGuilds].map((gId) => {
-      const guild = userGuilds.get(gId);
-      return guild ? { ...guild, hasBot: false } : undefined;
-    }),
-  ].filter((g) => !isUndefined(g));
-};
+    return [
+      ...[...manageableGuilds].map((gId) => {
+        const guild = botGuilds.get(gId);
+        return guild ? { ...guild, hasBot: true } : undefined;
+      }),
+      ...[...invitableGuilds].map((gId) => {
+        const guild = userGuilds.get(gId);
+        return guild ? { ...guild, hasBot: false } : undefined;
+      }),
+    ].filter((g) => !isUndefined(g));
+  }).pipe(Effect.withSpan("Discord.fetchGuilds"));

--- a/app/models/session.server.ts
+++ b/app/models/session.server.ts
@@ -150,6 +150,15 @@ function hasCookie(request: Request, cookieName: string): boolean {
   return regex.test(cookieHeader);
 }
 
+// `getUser`/`requireUser`/`requireUserId` (and the `getUserId` helper) stay
+// thin `async` functions BY DESIGN. They throw `redirect()`/`logout()`
+// `Response`s to signal React-Router control flow — that thrown Response is
+// framework glue, not a domain error, and must reach the route boundary as a
+// RAW `Response` so React Router treats it as a redirect. Running these through
+// `runEffect`/`runPromise` would wrap any failure in a `FiberFailure`, breaking
+// that contract. So the domain data lookups go through `UserService` via the
+// `userSvc` Effect bridge, while the Response-throwing remains in async land.
+
 async function getUserId(request: Request): Promise<string | undefined> {
   const session = await getDbSession(request.headers.get("Cookie"));
   const userId = session.get(CookieSessionKeys.userId) as string;
@@ -384,36 +393,42 @@ export async function completeOauthLogin(request: Request) {
   return redirect(finalRedirectTo, { headers });
 }
 
-export async function retrieveDiscordToken(request: Request) {
-  const dbSession = await getDbSession(request.headers.get("Cookie"));
-  const storedToken = dbSession.get(CookieSessionKeys.discordToken) as {
-    discordToken: string;
-    [k: string]: unknown;
-  };
-  const token = authorization.createToken(storedToken);
-  return token;
-}
-export async function refreshDiscordSession(request: Request) {
-  const dbSession = await getDbSession(request.headers.get("Cookie"));
-  const token = await retrieveDiscordToken(request);
-  const newToken = await token.refresh();
-  // @ts-expect-error token.toJSON() isn't in the types but it works
-  dbSession.set(CookieSessionKeys.discordToken, newToken.toJSON());
+export const retrieveDiscordToken = (request: Request) =>
+  Effect.gen(function* () {
+    const dbSession = yield* Effect.promise(() =>
+      getDbSession(request.headers.get("Cookie")),
+    );
+    const storedToken = dbSession.get(CookieSessionKeys.discordToken) as {
+      discordToken: string;
+      [k: string]: unknown;
+    };
+    const token = authorization.createToken(storedToken);
+    return token;
+  });
 
-  return dbSession;
-}
+export const refreshDiscordSession = (request: Request) =>
+  Effect.gen(function* () {
+    const dbSession = yield* Effect.promise(() =>
+      getDbSession(request.headers.get("Cookie")),
+    );
+    const token = yield* retrieveDiscordToken(request);
+    const newToken = yield* Effect.promise(() => token.refresh());
+    // @ts-expect-error token.toJSON() isn't in the types but it works
+    dbSession.set(CookieSessionKeys.discordToken, newToken.toJSON());
+
+    return dbSession;
+  });
 
 /**
  * Refresh the Discord OAuth token and persist the updated session to the DB.
  * Returns the `Set-Cookie` header value that must be sent back to the client so
  * future requests read the new token instead of the expired one.
  */
-export async function refreshAndPersistDiscordSession(
-  request: Request,
-): Promise<string> {
-  const session = await refreshDiscordSession(request);
-  return commitDbSession(session);
-}
+export const refreshAndPersistDiscordSession = (request: Request) =>
+  Effect.gen(function* () {
+    const session = yield* refreshDiscordSession(request);
+    return yield* Effect.promise(() => commitDbSession(session));
+  });
 
 export async function logout(request: Request) {
   const [cookieSession, dbSession] = await Promise.all([

--- a/app/models/session.server.ts
+++ b/app/models/session.server.ts
@@ -320,7 +320,7 @@ export async function completeOauthLogin(request: Request) {
     code,
     redirect_uri: `${origin}/${OAUTH_REDIRECT_ROUTE}`,
   });
-  const discordUser = await fetchUser(token);
+  const discordUser = await runEffect(fetchUser(token));
 
   // Retrieve our user from Discord ID
   let userId;

--- a/app/models/stripe.server.test.ts
+++ b/app/models/stripe.server.test.ts
@@ -1,0 +1,130 @@
+import { Effect, Exit } from "effect";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Stripe SDK so no real client is constructed and each method's
+// underlying call can be controlled per-test. The default export is a class
+// whose instance exposes the namespaces StripeService touches.
+const checkoutRetrieve = vi.fn();
+const customersSearch = vi.fn();
+const subscriptionsCancel = vi.fn();
+const invoicesList = vi.fn();
+const listPaymentMethods = vi.fn();
+
+vi.mock("stripe", () => ({
+  default: class {
+    checkout = { sessions: { retrieve: checkoutRetrieve, create: vi.fn() } };
+    customers = {
+      search: customersSearch,
+      create: vi.fn(),
+      listPaymentMethods,
+    };
+    subscriptions = { cancel: subscriptionsCancel };
+    invoices = { list: invoicesList };
+    prices = { list: vi.fn() };
+    webhooks = { constructEvent: vi.fn() };
+  },
+}));
+
+// Sentry side-effect is preserved on the error path; mock to assert it fires.
+const captureException = vi.fn();
+vi.mock("#~/helpers/sentry.server", () => ({
+  default: { captureException },
+}));
+
+vi.mock("#~/effects/observability", () => ({
+  logEffect: () => Effect.void,
+}));
+
+const { StripeService } = await import("./stripe.server");
+
+const run = <A, E>(eff: Effect.Effect<A, E, never>) =>
+  Effect.runPromiseExit(eff);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("StripeService recover-as-default branches", () => {
+  it("verifyCheckoutSession returns null on SDK error (no failure)", async () => {
+    checkoutRetrieve.mockRejectedValueOnce(new Error("boom"));
+    const exit = await run(StripeService.verifyCheckoutSession("sess_1"));
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) expect(exit.value).toBeNull();
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("verifyCheckoutSession returns mapped session on success", async () => {
+    checkoutRetrieve.mockResolvedValueOnce({
+      payment_status: "paid",
+      client_reference_id: "guild_1",
+      customer: "cus_1",
+      subscription: "sub_1",
+      amount_total: 1000,
+    });
+    const exit = await run(StripeService.verifyCheckoutSession("sess_1"));
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit))
+      expect(exit.value).toEqual({
+        payment_status: "paid",
+        client_reference_id: "guild_1",
+        customer: "cus_1",
+        subscription: "sub_1",
+        amount_total: 1000,
+      });
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("getCustomerByGuildId returns null on SDK error", async () => {
+    customersSearch.mockRejectedValueOnce(new Error("boom"));
+    const exit = await run(StripeService.getCustomerByGuildId("guild_1"));
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) expect(exit.value).toBeNull();
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("getCustomerByGuildId returns null when no match found (no error)", async () => {
+    customersSearch.mockResolvedValueOnce({ data: [] });
+    const exit = await run(StripeService.getCustomerByGuildId("guild_1"));
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) expect(exit.value).toBeNull();
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it("getCustomerByGuildId returns id when found", async () => {
+    customersSearch.mockResolvedValueOnce({ data: [{ id: "cus_42" }] });
+    const exit = await run(StripeService.getCustomerByGuildId("guild_1"));
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) expect(exit.value).toBe("cus_42");
+  });
+
+  it("cancelSubscription returns false on SDK error", async () => {
+    subscriptionsCancel.mockRejectedValueOnce(new Error("boom"));
+    const exit = await run(StripeService.cancelSubscription("sub_1"));
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) expect(exit.value).toBe(false);
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancelSubscription returns true on success", async () => {
+    subscriptionsCancel.mockResolvedValueOnce({});
+    const exit = await run(StripeService.cancelSubscription("sub_1"));
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) expect(exit.value).toBe(true);
+  });
+
+  it("listInvoices returns [] on SDK error", async () => {
+    invoicesList.mockRejectedValueOnce(new Error("boom"));
+    const exit = await run(StripeService.listInvoices("cus_1"));
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) expect(exit.value).toEqual([]);
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it("listPaymentMethods returns [] on SDK error", async () => {
+    listPaymentMethods.mockRejectedValueOnce(new Error("boom"));
+    const exit = await run(StripeService.listPaymentMethods("cus_1"));
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) expect(exit.value).toEqual([]);
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/models/stripe.server.ts
+++ b/app/models/stripe.server.ts
@@ -1,8 +1,9 @@
+import { Effect } from "effect";
 import Stripe from "stripe";
 
-import { NotFoundError } from "#~/effects/errors.ts";
+import { NotFoundError, StripeError } from "#~/effects/errors.ts";
+import { logEffect } from "#~/effects/observability";
 import { stripeSecretKey, stripeWebhookSecret } from "#~/helpers/env.server.js";
-import { log, trackPerformance } from "#~/helpers/observability";
 import Sentry from "#~/helpers/sentry.server";
 
 const stripe = new Stripe(stripeSecretKey, {
@@ -10,281 +11,342 @@ const stripe = new Stripe(stripeSecretKey, {
   typescript: true,
 });
 
-export const StripeService = {
-  async createCheckoutSession(
-    variant: string,
-    coupon: string,
-    guildId: string,
-    baseUrl: string,
-    customerEmail?: string,
-  ): Promise<string> {
-    return trackPerformance(
-      "createCheckoutSession",
-      async () => {
-        log("info", "Stripe", "Creating checkout session", {
-          guildId,
-          baseUrl,
-          hasEmail: !!customerEmail,
-          variant,
-          coupon,
-        });
+// Wrap a Stripe SDK promise, mapping any rejection to a typed StripeError that
+// also reports the raw cause to Sentry (preserving prior side-effect behavior).
+const tryStripe = <A>(operation: string, fn: () => Promise<A>) =>
+  Effect.tryPromise({
+    try: fn,
+    catch: (cause) => {
+      Sentry.captureException(cause);
+      return new StripeError({ operation, cause });
+    },
+  });
 
-        const successUrl = `${baseUrl}/payment/success?session_id={CHECKOUT_SESSION_ID}&guild_id=${guildId}`;
-        const settingsUrl = `${baseUrl}/app/${guildId}/settings`;
-        let priceId = "";
-        const prices = await stripe.prices.list({ lookup_keys: [variant] });
-        const price = prices.data.at(0);
-        if (!price) {
-          log("error", "Stripe", "Failed to load pricing data");
-          throw new NotFoundError({ resource: "Price", id: variant });
-        }
-        priceId = price.id;
+const createCheckoutSession = (
+  variant: string,
+  coupon: string,
+  guildId: string,
+  baseUrl: string,
+  customerEmail?: string,
+): Effect.Effect<string, StripeError | NotFoundError, never> =>
+  Effect.gen(function* () {
+    yield* logEffect("info", "Stripe", "Creating checkout session", {
+      guildId,
+      baseUrl,
+      hasEmail: !!customerEmail,
+      variant,
+      coupon,
+    });
 
-        try {
-          const session = await stripe.checkout.sessions.create({
-            mode: "subscription",
-            payment_method_types: ["card"],
-            line_items: [{ price: priceId, quantity: 1 }],
-            discounts: coupon ? [{ coupon }] : [],
-            success_url: successUrl,
-            cancel_url: settingsUrl,
-            client_reference_id: guildId,
-            customer_email: customerEmail,
-            metadata: { guild_id: guildId },
-            subscription_data: {
-              metadata: { guild_id: guildId },
-              trial_period_days: 90,
-            },
-          });
+    const successUrl = `${baseUrl}/payment/success?session_id={CHECKOUT_SESSION_ID}&guild_id=${guildId}`;
+    const settingsUrl = `${baseUrl}/app/${guildId}/settings`;
 
-          log("info", "Stripe", "Checkout session created successfully", {
-            guildId,
-            sessionId: session.id,
-          });
-
-          return session.url ?? "";
-        } catch (error) {
-          log("error", "Stripe", "Failed to create checkout session", {
-            guildId,
-            error,
-          });
-          Sentry.captureException(error);
-          throw error;
-        }
-      },
-      { guildId, customerEmail },
+    const prices = yield* tryStripe("createCheckoutSession.listPrices", () =>
+      stripe.prices.list({ lookup_keys: [variant] }),
     );
-  },
+    const price = prices.data.at(0);
+    if (!price) {
+      yield* logEffect("error", "Stripe", "Failed to load pricing data");
+      return yield* Effect.fail(
+        new NotFoundError({ resource: "Price", id: variant }),
+      );
+    }
+    const priceId = price.id;
 
-  async verifyCheckoutSession(sessionId: string): Promise<{
+    const session = yield* tryStripe("createCheckoutSession", () =>
+      stripe.checkout.sessions.create({
+        mode: "subscription",
+        payment_method_types: ["card"],
+        line_items: [{ price: priceId, quantity: 1 }],
+        discounts: coupon ? [{ coupon }] : [],
+        success_url: successUrl,
+        cancel_url: settingsUrl,
+        client_reference_id: guildId,
+        customer_email: customerEmail,
+        metadata: { guild_id: guildId },
+        subscription_data: {
+          metadata: { guild_id: guildId },
+          trial_period_days: 90,
+        },
+      }),
+    ).pipe(
+      Effect.tapError((error) =>
+        logEffect("error", "Stripe", "Failed to create checkout session", {
+          guildId,
+          error,
+        }),
+      ),
+    );
+
+    yield* logEffect(
+      "info",
+      "Stripe",
+      "Checkout session created successfully",
+      {
+        guildId,
+        sessionId: session.id,
+      },
+    );
+
+    return session.url ?? "";
+  }).pipe(
+    Effect.withSpan("Stripe.createCheckoutSession", {
+      attributes: { guildId, customerEmail },
+    }),
+  );
+
+const verifyCheckoutSession = (
+  sessionId: string,
+): Effect.Effect<
+  {
     payment_status: string;
     client_reference_id: string | null;
     customer: string | null;
     subscription: string | null;
     amount_total: number | null;
-  } | null> {
-    return trackPerformance(
-      "verifyCheckoutSession",
-      async () => {
-        log("info", "Stripe", "Verifying checkout session", { sessionId });
+  } | null,
+  StripeError,
+  never
+> =>
+  Effect.gen(function* () {
+    yield* logEffect("info", "Stripe", "Verifying checkout session", {
+      sessionId,
+    });
 
-        try {
-          const session = await stripe.checkout.sessions.retrieve(sessionId);
-
-          log("info", "Stripe", "Checkout session retrieved", {
-            sessionId,
-            paymentStatus: session.payment_status,
-            customerId: session.customer,
-          });
-
-          return {
-            payment_status: session.payment_status,
-            client_reference_id: session.client_reference_id,
-            customer:
-              typeof session.customer === "string" ? session.customer : null,
-            subscription:
-              typeof session.subscription === "string"
-                ? session.subscription
-                : null,
-            amount_total: session.amount_total,
-          };
-        } catch (error) {
-          log("error", "Stripe", "Failed to verify checkout session", {
-            sessionId,
-            error,
-          });
-          Sentry.captureException(error);
-          return null;
-        }
-      },
-      { sessionId },
+    const session = yield* tryStripe("verifyCheckoutSession", () =>
+      stripe.checkout.sessions.retrieve(sessionId),
+    ).pipe(
+      Effect.tapError((error) =>
+        logEffect("error", "Stripe", "Failed to verify checkout session", {
+          sessionId,
+          error,
+        }),
+      ),
+      // Prior behavior: errors recover as null rather than propagate.
+      Effect.catchTag("StripeError", () => Effect.succeed(null)),
     );
-  },
 
-  async createCustomer(
-    email: string,
-    guildId: string,
-    guildName?: string,
-  ): Promise<string> {
-    return trackPerformance(
-      "createCustomer",
-      async () => {
-        log("info", "Stripe", "Creating Stripe customer", {
+    if (!session) {
+      return null;
+    }
+
+    yield* logEffect("info", "Stripe", "Checkout session retrieved", {
+      sessionId,
+      paymentStatus: session.payment_status,
+      customerId: session.customer,
+    });
+
+    return {
+      payment_status: session.payment_status,
+      client_reference_id: session.client_reference_id,
+      customer: typeof session.customer === "string" ? session.customer : null,
+      subscription:
+        typeof session.subscription === "string" ? session.subscription : null,
+      amount_total: session.amount_total,
+    };
+  }).pipe(
+    Effect.withSpan("Stripe.verifyCheckoutSession", {
+      attributes: { sessionId },
+    }),
+  );
+
+const createCustomer = (
+  email: string,
+  guildId: string,
+  guildName?: string,
+): Effect.Effect<string, StripeError, never> =>
+  Effect.gen(function* () {
+    yield* logEffect("info", "Stripe", "Creating Stripe customer", {
+      guildId,
+      email,
+    });
+
+    const customer = yield* tryStripe("createCustomer", () =>
+      stripe.customers.create({
+        email,
+        metadata: { guild_id: guildId, guild_name: guildName ?? "" },
+      }),
+    ).pipe(
+      Effect.tapError((error) =>
+        logEffect("error", "Stripe", "Failed to create customer", {
           guildId,
-          email,
-        });
-
-        try {
-          const customer = await stripe.customers.create({
-            email,
-            metadata: { guild_id: guildId, guild_name: guildName ?? "" },
-          });
-
-          log("info", "Stripe", "Customer created successfully", {
-            guildId,
-            customerId: customer.id,
-          });
-
-          return customer.id;
-        } catch (error) {
-          log("error", "Stripe", "Failed to create customer", {
-            guildId,
-            error,
-          });
-          Sentry.captureException(error);
-          throw error;
-        }
-      },
-      { guildId },
+          error,
+        }),
+      ),
     );
-  },
 
-  /**
-   * Get customer by guild ID
-   */
-  async getCustomerByGuildId(guildId: string): Promise<string | null> {
-    return trackPerformance(
-      "getCustomerByGuildId",
-      async () => {
-        log("debug", "Stripe", "Searching for customer by guild ID", {
+    yield* logEffect("info", "Stripe", "Customer created successfully", {
+      guildId,
+      customerId: customer.id,
+    });
+
+    return customer.id;
+  }).pipe(
+    Effect.withSpan("Stripe.createCustomer", { attributes: { guildId } }),
+  );
+
+const getCustomerByGuildId = (
+  guildId: string,
+): Effect.Effect<string | null, StripeError, never> =>
+  Effect.gen(function* () {
+    yield* logEffect("debug", "Stripe", "Searching for customer by guild ID", {
+      guildId,
+    });
+
+    const customers = yield* tryStripe("getCustomerByGuildId", () =>
+      stripe.customers.search({
+        query: `metadata['guild_id']:'${guildId}'`,
+        limit: 1,
+      }),
+    ).pipe(
+      Effect.tapError((error) =>
+        logEffect("error", "Stripe", "Failed to search for customer", {
           guildId,
-        });
-
-        try {
-          const customers = await stripe.customers.search({
-            query: `metadata['guild_id']:'${guildId}'`,
-            limit: 1,
-          });
-
-          if (customers.data.length > 0) {
-            log("debug", "Stripe", "Customer found", {
-              guildId,
-              customerId: customers.data[0].id,
-            });
-            return customers.data[0].id;
-          }
-
-          log("debug", "Stripe", "No customer found", { guildId });
-          return null;
-        } catch (error) {
-          log("error", "Stripe", "Failed to search for customer", {
-            guildId,
-            error,
-          });
-          Sentry.captureException(error);
-          return null;
-        }
-      },
-      { guildId },
+          error,
+        }),
+      ),
+      // Prior behavior: errors recover as null.
+      Effect.catchTag("StripeError", () => Effect.succeed(null)),
     );
-  },
 
-  /**
-   * Cancel a subscription
-   */
-  async cancelSubscription(subscriptionId: string): Promise<boolean> {
-    return trackPerformance(
-      "cancelSubscription",
-      async () => {
-        log("info", "Stripe", "Cancelling subscription", { subscriptionId });
+    if (customers && customers.data.length > 0) {
+      yield* logEffect("debug", "Stripe", "Customer found", {
+        guildId,
+        customerId: customers.data[0].id,
+      });
+      return customers.data[0].id;
+    }
 
-        try {
-          await stripe.subscriptions.cancel(subscriptionId);
+    yield* logEffect("debug", "Stripe", "No customer found", { guildId });
+    return null;
+  }).pipe(
+    Effect.withSpan("Stripe.getCustomerByGuildId", { attributes: { guildId } }),
+  );
 
-          log("info", "Stripe", "Subscription cancelled successfully", {
-            subscriptionId,
-          });
+const cancelSubscription = (
+  subscriptionId: string,
+): Effect.Effect<boolean, StripeError, never> =>
+  Effect.gen(function* () {
+    yield* logEffect("info", "Stripe", "Cancelling subscription", {
+      subscriptionId,
+    });
 
-          return true;
-        } catch (error) {
-          log("error", "Stripe", "Failed to cancel subscription", {
-            subscriptionId,
-            error,
-          });
-          Sentry.captureException(error);
-          return false;
-        }
-      },
-      { subscriptionId },
+    const cancelled = yield* tryStripe("cancelSubscription", () =>
+      stripe.subscriptions.cancel(subscriptionId),
+    ).pipe(
+      Effect.tapError((error) =>
+        logEffect("error", "Stripe", "Failed to cancel subscription", {
+          subscriptionId,
+          error,
+        }),
+      ),
+      Effect.as(true),
+      // Prior behavior: errors recover as false.
+      Effect.catchTag("StripeError", () => Effect.succeed(false)),
     );
-  },
 
-  async listInvoices(customerId: string) {
-    return trackPerformance(
-      "listInvoices",
-      async () => {
-        log("debug", "Stripe", "Listing invoices", { customerId });
-        try {
-          const invoices = await stripe.invoices.list({
-            customer: customerId,
-            limit: 20,
-          });
-          return invoices.data;
-        } catch (error) {
-          log("error", "Stripe", "Failed to list invoices", {
-            customerId,
-            error,
-          });
-          Sentry.captureException(error);
-          return [];
-        }
-      },
-      { customerId },
-    );
-  },
+    if (cancelled) {
+      yield* logEffect(
+        "info",
+        "Stripe",
+        "Subscription cancelled successfully",
+        {
+          subscriptionId,
+        },
+      );
+    }
 
-  async listPaymentMethods(customerId: string) {
-    return trackPerformance(
-      "listPaymentMethods",
-      async () => {
-        log("debug", "Stripe", "Listing payment methods", { customerId });
-        try {
-          const methods = await stripe.customers.listPaymentMethods(customerId);
-          return methods.data;
-        } catch (error) {
-          log("error", "Stripe", "Failed to list payment methods", {
-            customerId,
-            error,
-          });
-          Sentry.captureException(error);
-          return [];
-        }
-      },
-      { customerId },
-    );
-  },
+    return cancelled;
+  }).pipe(
+    Effect.withSpan("Stripe.cancelSubscription", {
+      attributes: { subscriptionId },
+    }),
+  );
 
-  /**
-   * Construct webhook event from raw body and signature
-   */
-  constructWebhookEvent(
-    payload: string | Buffer,
-    signature: string,
-  ): Stripe.Event {
-    return stripe.webhooks.constructEvent(
-      payload,
-      signature,
-      stripeWebhookSecret,
+const listInvoices = (
+  customerId: string,
+): Effect.Effect<Stripe.Invoice[], StripeError, never> =>
+  Effect.gen(function* () {
+    yield* logEffect("debug", "Stripe", "Listing invoices", { customerId });
+
+    const invoices = yield* tryStripe("listInvoices", () =>
+      stripe.invoices.list({ customer: customerId, limit: 20 }),
+    ).pipe(
+      Effect.tapError((error) =>
+        logEffect("error", "Stripe", "Failed to list invoices", {
+          customerId,
+          error,
+        }),
+      ),
+      Effect.map((invoices) => invoices.data),
+      // Prior behavior: errors recover as an empty list.
+      Effect.catchTag("StripeError", () =>
+        Effect.succeed([] as Stripe.Invoice[]),
+      ),
     );
-  },
+
+    return invoices;
+  }).pipe(
+    Effect.withSpan("Stripe.listInvoices", { attributes: { customerId } }),
+  );
+
+const listPaymentMethods = (
+  customerId: string,
+): Effect.Effect<Stripe.PaymentMethod[], StripeError, never> =>
+  Effect.gen(function* () {
+    yield* logEffect("debug", "Stripe", "Listing payment methods", {
+      customerId,
+    });
+
+    const methods = yield* tryStripe("listPaymentMethods", () =>
+      stripe.customers.listPaymentMethods(customerId),
+    ).pipe(
+      Effect.tapError((error) =>
+        logEffect("error", "Stripe", "Failed to list payment methods", {
+          customerId,
+          error,
+        }),
+      ),
+      Effect.map((methods) => methods.data),
+      // Prior behavior: errors recover as an empty list.
+      Effect.catchTag("StripeError", () =>
+        Effect.succeed([] as Stripe.PaymentMethod[]),
+      ),
+    );
+
+    return methods;
+  }).pipe(
+    Effect.withSpan("Stripe.listPaymentMethods", {
+      attributes: { customerId },
+    }),
+  );
+
+const constructWebhookEvent = (
+  payload: string | Buffer,
+  signature: string,
+): Effect.Effect<Stripe.Event, StripeError, never> =>
+  Effect.try({
+    try: () =>
+      stripe.webhooks.constructEvent(payload, signature, stripeWebhookSecret),
+    catch: (cause) => {
+      Sentry.captureException(cause);
+      return new StripeError({ operation: "constructWebhookEvent", cause });
+    },
+  });
+
+/**
+ * Stripe service: each method is a free Effect function (no service requirement).
+ *
+ * Web-async callers: await runEffect(StripeService.method(...))
+ * Effect callers:    yield* StripeService.method(...)
+ */
+export const StripeService = {
+  createCheckoutSession,
+  verifyCheckoutSession,
+  createCustomer,
+  getCustomerByGuildId,
+  cancelSubscription,
+  listInvoices,
+  listPaymentMethods,
+  constructWebhookEvent,
 };

--- a/app/routes/__auth.tsx
+++ b/app/routes/__auth.tsx
@@ -5,6 +5,7 @@ import {
   useSearchParams,
 } from "react-router";
 
+import { runEffect } from "#~/AppRuntime";
 import { Login } from "#~/basics/login";
 import { DiscordLayout } from "#~/components/DiscordLayout";
 import { ssrDiscordSdk, userDiscordSdkFromRequest } from "#~/discord/api.js";
@@ -30,7 +31,9 @@ export async function loader({ request }: Route.LoaderArgs) {
 
   try {
     const userRest = await userDiscordSdkFromRequest(request);
-    const guilds = await getCachedGuilds(user.id, userRest, ssrDiscordSdk);
+    const guilds = await runEffect(
+      getCachedGuilds(user.id, userRest, ssrDiscordSdk),
+    );
     const manageableGuilds = guilds.filter((g) => g.hasBot);
 
     log("info", "auth", "Guilds fetched for authenticated user", {

--- a/app/routes/__auth/admin.$guildId.tsx
+++ b/app/routes/__auth/admin.$guildId.tsx
@@ -56,7 +56,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
     });
   }
 
-  const featureFlags = await fetchFeatureFlags(guildId);
+  const featureFlags = await runEffect(fetchFeatureFlags(guildId));
 
   let paymentMethods: PaymentMethods = [];
   let invoices: Invoices = [];
@@ -64,8 +64,8 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   let stripeSubscriptionUrl: string | null = null;
 
   if (subscription?.stripe_customer_id) {
-    ({ paymentMethods, invoices } = await fetchStripeDetails(
-      subscription.stripe_customer_id,
+    ({ paymentMethods, invoices } = await runEffect(
+      fetchStripeDetails(subscription.stripe_customer_id),
     ));
     stripeCustomerUrl = `https://dashboard.stripe.com/customers/${subscription.stripe_customer_id}`;
   }

--- a/app/routes/__auth/admin.jobs.tsx
+++ b/app/routes/__auth/admin.jobs.tsx
@@ -1,3 +1,4 @@
+import { runEffect } from "#~/AppRuntime";
 import { Page } from "#~/basics/page.js";
 import {
   JobProgressBar,
@@ -13,7 +14,7 @@ import type { Route } from "./+types/admin.jobs";
 
 export async function loader({ request }: Route.LoaderArgs) {
   await requireAdmin(request);
-  const jobs = await fetchAdminJobs();
+  const jobs = await runEffect(fetchAdminJobs());
   return { jobs };
 }
 

--- a/app/routes/__auth/admin.tsx
+++ b/app/routes/__auth/admin.tsx
@@ -72,9 +72,9 @@ export async function loader({ request }: Route.LoaderArgs) {
       };
 
       const [featureFlags, stripeData] = await Promise.all([
-        fetchFeatureFlags(guildId),
+        runEffect(fetchFeatureFlags(guildId)),
         sub?.stripe_customer_id
-          ? fetchStripeDetails(sub.stripe_customer_id)
+          ? runEffect(fetchStripeDetails(sub.stripe_customer_id))
           : Promise.resolve({
               paymentMethods: [] as PaymentMethods,
               invoices: [] as Invoices,

--- a/app/routes/__auth/app.tsx
+++ b/app/routes/__auth/app.tsx
@@ -34,7 +34,9 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   const userRest = await userDiscordSdkFromRequest(request);
-  const guilds = await getCachedGuilds(user.id, userRest, ssrDiscordSdk);
+  const guilds = await runEffect(
+    getCachedGuilds(user.id, userRest, ssrDiscordSdk),
+  );
 
   const manageable = guilds.filter((g) => g.hasBot);
   const invitable = guilds.filter((g) => !g.hasBot);

--- a/app/routes/__auth/guild.tsx
+++ b/app/routes/__auth/guild.tsx
@@ -33,7 +33,9 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   }
 
   const userRest = await userDiscordSdkFromRequest(request);
-  const guilds = await getCachedGuilds(user.id, userRest, ssrDiscordSdk);
+  const guilds = await runEffect(
+    getCachedGuilds(user.id, userRest, ssrDiscordSdk),
+  );
   const guild = guilds.find((g) => g.id === guildId);
 
   if (!guild?.hasBot) {

--- a/app/routes/__auth/settings.tsx
+++ b/app/routes/__auth/settings.tsx
@@ -2,7 +2,7 @@ import { data } from "react-router";
 
 import { runEffect } from "#~/AppRuntime";
 import { GuildSettingsForm } from "#~/components/GuildSettingsForm";
-import { fetchGuildData, type GuildData } from "#~/helpers/guildData.server";
+import { fetchGuildData } from "#~/helpers/guildData.server";
 import { log, trackPerformance } from "#~/helpers/observability";
 import { fetchSettings, setSettings, SETTINGS } from "#~/models/guilds.server";
 import { requireUser } from "#~/models/session.server";
@@ -28,13 +28,7 @@ export async function loader({ params, request }: Route.LoaderArgs) {
         SETTINGS.restricted,
       ]),
     ).catch(() => undefined),
-    fetchGuildData(guildId).catch(
-      () =>
-        ({
-          roles: [],
-          channels: [],
-        }) as GuildData,
-    ),
+    runEffect(fetchGuildData(guildId)),
   ]);
 
   return {

--- a/app/routes/__auth/upgrade.tsx
+++ b/app/routes/__auth/upgrade.tsx
@@ -73,8 +73,8 @@ export async function action({ request }: Route.ActionArgs) {
       };
     }
 
-    const cancelled = await StripeService.cancelSubscription(
-      subscription.stripe_subscription_id,
+    const cancelled = await runEffect(
+      StripeService.cancelSubscription(subscription.stripe_subscription_id),
     );
 
     if (!cancelled) {
@@ -119,12 +119,14 @@ export async function action({ request }: Route.ActionArgs) {
       const baseUrl = requestOrigin(request);
 
       // Create Stripe checkout session
-      const checkoutUrl = await StripeService.createCheckoutSession(
-        variant,
-        coupon,
-        guildId,
-        baseUrl,
-        user.email ?? undefined,
+      const checkoutUrl = await runEffect(
+        StripeService.createCheckoutSession(
+          variant,
+          coupon,
+          guildId,
+          baseUrl,
+          user.email ?? undefined,
+        ),
       );
 
       log("info", "Upgrade", "Redirecting to Stripe checkout", {
@@ -134,12 +136,23 @@ export async function action({ request }: Route.ActionArgs) {
 
       // Redirect to Stripe checkout
       return redirect(checkoutUrl);
-    } catch (error) {
+    } catch (caught) {
       log("error", "Upgrade", "Failed to create checkout session", {
         guildId,
         userId: user.id,
-        error,
+        error: caught,
       });
+
+      // StripeService now rejects with a typed StripeError whose `.cause` is the
+      // raw Stripe SDK error; unwrap it so config-error detection sees the same
+      // shape it did before the Effect migration.
+      const error =
+        typeof caught === "object" &&
+        caught !== null &&
+        "_tag" in caught &&
+        (caught as { _tag: unknown })._tag === "StripeError"
+          ? (caught as unknown as { cause: unknown }).cause
+          : caught;
 
       // Check for Stripe configuration errors (missing/empty lookup key)
       const isStripeConfigError =

--- a/app/routes/payment.success.tsx
+++ b/app/routes/payment.success.tsx
@@ -21,7 +21,9 @@ export async function loader({ request }: Route.LoaderArgs) {
   }
 
   // Verify Stripe session
-  const stripeSession = await StripeService.verifyCheckoutSession(sessionId);
+  const stripeSession = await runEffect(
+    StripeService.verifyCheckoutSession(sessionId),
+  );
 
   if (stripeSession?.payment_status !== "paid") {
     throw data({ message: "Payment verification failed" }, { status: 400 });

--- a/app/routes/webhooks.stripe.tsx
+++ b/app/routes/webhooks.stripe.tsx
@@ -29,7 +29,9 @@ export async function action({ request }: Route.ActionArgs) {
     const body = await request.text();
 
     // Verify webhook signature and construct event
-    const event = StripeService.constructWebhookEvent(body, signature);
+    const event = await runEffect(
+      StripeService.constructWebhookEvent(body, signature),
+    );
 
     log("info", "Webhook", "Received Stripe webhook", {
       type: event.type,


### PR DESCRIPTION
## Summary

Completes the **#386** track — migrating the remaining domain/model + helper layer from Promise contracts to Effect contracts. Every remaining server-side Promise/async module is now Effect-native, while the **network boundary is unchanged**: web route loaders/actions stay plain async and reach Effect through the existing `runEffect` bridge, so **no Effect reaches the web client bundle** (enforced by the lint rule + `check:client-bundle`, both green here).

8 files migrated, sequentially in dependency order (each its own commit):

| # | Module | Notes |
|---|--------|-------|
| 1 | `features/Admin/jobHelpers.server` | lift inner Effect to the export boundary |
| 2 | `helpers/guildData.server` | Discord REST via `tryDiscord`; preserves swallow-to-empty fallback |
| 3 | `models/discord.server` | `fetchUser`/`applyRestriction`/`kick`/`ban`/`timeout`/`fetchGuilds`; **deletes the `applyRestriction` `runPromise`+`Layer.succeed` cycle hack**; adds `OAuthFetchError` |
| 4 | `helpers/guildCache.server` | folds `fetchGuilds` via `yield*`; keeps module-level TTLCache |
| 5 | `models/stripe.server` | `StripeService` methods return Effects + typed `StripeError`; throw-vs-default semantics + Sentry preserved; +9 unit tests |
| 6 | `models/session.server` | the three token functions → Effect; see boundary note below |
| 7 | `features/Admin/helpers.server` | `fetchStripeDetails`/`fetchFeatureFlags` → Effect; `requireAdmin` stays async |
| 8 | `helpers/setupAll.server` | one `Effect.gen`, orchestration preserved 1:1; Discord REST via `tryDiscord` |

Also retires the legacy `log()`/`trackPerformance()` calls in all 8 files (part of #381), and updates in-Effect callers (`escalate/*`, `spamResponseHandler`, `setupHandlers`) from `tryDiscord`/`tryPromise` wrappers to direct `yield*`.

## Verification (all green at HEAD)

- `npm run typecheck` — clean
- `npm run lint` — zero warnings (`--max-warnings=0`)
- `npm run check:client-bundle` — no Effect modules in the client bundle (36 sourcemaps)
- `npm test` — 489 passing (46 files)

## Two decisions to review

**1. The session/auth boundary is drawn at "throws a redirect Response."**
Functions whose primary output is a thrown `redirect()`/`logout()`/`data(403)` Response stay **async** — empirically, `runEffect` converts a thrown `Response` into a `FiberFailure`, which would break React-Router redirect control flow (i.e. break login). So `requireUser`, `requireUserId`, `getUser`, `getUserId`, `initOauthLogin`, `completeOauthLogin`, `logout`, and `requireAdmin` remain async (their *data access* still flows through `UserService`/Effect internally). The data-shaped functions — `retrieveDiscordToken`, `refreshDiscordSession`, `refreshAndPersistDiscordSession` — became Effects. `getUser`/`getUserId` were trialled as Effects and reverted: they `throw await logout(request)` for stale-cookie clearing, so moving them across the boundary dropped a defensive `Set-Cookie` on public loaders. They belong on the async side.

**2. Possible future conflict with the setup-wizard branch.**
This PR branches off `main`; the in-flight `worktree-remove-duplicate-setup` branch also touches `setupAll.server.ts`. Whichever merges second resolves that one file. The other 7 files don't overlap.

Minor, justified deviations are noted per-commit: `setupAll` keeps `isFeatureEnabled`/`createJob` as Promise-bridges (jobRunner is out of scope; keeps the Requirements channel `DatabaseService`-only).

## Scope: what this does and does NOT cover

This finishes **#386** (Promise→Effect contracts for the model/helper layer). It does **not** address the three sibling bot-only Effect refactors, which remain open and are deliberately out of this PR's scope:

- **#318** — Create a `DiscordService` Layer to replace the `discordSdk.ts` wrappers (this PR keeps using the existing wrappers/`tryDiscord`).
- **#319** — Replace raw timers with Effect `Schedule`/`Ref`.
- **#320** — Migrate module-level singletons to Effect Layers (this PR intentionally keeps singletons — TTLCache, Stripe client, session storage — per YAGNI).

Relates to #318, #319, #320.