### PR TITLE
Effect migration polish + QA bug fixes (#393, #394)

### DIFF
--- a/app/commands/checkRequirements.ts
+++ b/app/commands/checkRequirements.ts
@@ -135,7 +135,7 @@ export const Command = {
         SETTINGS.deletionLog,
         SETTINGS.restricted,
       ]).pipe(
-        Effect.catchAll(() =>
+        Effect.catchTag("NotFoundError", () =>
           Effect.succeed(null as null | Record<string, string | undefined>),
         ),
       );

--- a/app/commands/escalate/service.ts
+++ b/app/commands/escalate/service.ts
@@ -12,7 +12,6 @@ import {
 } from "#~/effects/errors";
 import { logEffect } from "#~/effects/observability";
 import { calculateScheduledFor } from "#~/helpers/escalationVotes";
-import { formatError } from "#~/helpers/formatError";
 import type { Resolution, VotingStrategy } from "#~/helpers/modResponse";
 import { applyRestriction, ban, kick, timeout } from "#~/models/discord.server";
 
@@ -318,11 +317,26 @@ export const EscalationServiceLive = Layer.effect(
             },
           );
 
-          // Try to fetch the member - they may have left
+          // Try to fetch the member - they may have left. ONLY a genuine 404
+          // (ResourceMissingError) means "member gone → skip"; any other
+          // DiscordError (rate limit, transient 5xx, forbidden, etc.) must
+          // propagate as ResolutionExecutionError so a community-voted action
+          // is not silently dropped. Mirror the action fold's field shape so
+          // the public contract and downstream logging stay consistent.
           const reportedMember = yield* fetchMember(
             guild,
             escalation.reported_user_id,
-          ).pipe(Effect.catchAll(() => Effect.succeed(null)));
+          ).pipe(
+            Effect.catchTag("ResourceMissingError", () => Effect.succeed(null)),
+            Effect.mapError(
+              (caught) =>
+                new ResolutionExecutionError({
+                  escalationId: escalation.id,
+                  resolution,
+                  cause: caught,
+                }),
+            ),
+          );
 
           if (!reportedMember) {
             yield* logEffect(
@@ -365,10 +379,7 @@ export const EscalationServiceLive = Layer.effect(
                 new ResolutionExecutionError({
                   escalationId: escalation.id,
                   resolution,
-                  cause:
-                    caught instanceof Error
-                      ? caught
-                      : new Error(formatError(caught)),
+                  cause: caught,
                 }),
             ),
           );

--- a/app/commands/memberApplications.ts
+++ b/app/commands/memberApplications.ts
@@ -93,7 +93,7 @@ const resolveLogMessage = (
 
     if (!app?.log_message_id) return;
 
-    yield* Effect.tryPromise(() =>
+    yield* tryDiscord("memberApp.updateLogMessage", () =>
       rest.patch(Routes.channelMessage(modLog, app.log_message_id!), {
         body: {
           content,
@@ -175,7 +175,9 @@ export const Command = [
         // @ts-expect-error busted types
         modal.addComponents(aboutRow, referralRow, goalsRow);
 
-        yield* Effect.tryPromise(() => interaction.showModal(modal));
+        yield* tryDiscord("memberApp.showModal", () =>
+          interaction.showModal(modal),
+        );
       }).pipe(
         Effect.catchAll(() => Effect.void),
         Effect.withSpan("applyToJoinModal", {
@@ -244,13 +246,15 @@ export const Command = [
           return;
         }
 
-        const thread = yield* Effect.tryPromise(() =>
-          applyChannel.threads.create({
-            name: `Application: ${user.username}`,
-            autoArchiveDuration: 60 * 24 * 7,
-            type: ChannelType.PrivateThread,
-            invitable: false,
-          }),
+        const thread = yield* tryDiscord(
+          "memberApp.createApplicantThread",
+          () =>
+            applyChannel.threads.create({
+              name: `Application: ${user.username}`,
+              autoArchiveDuration: 60 * 24 * 7,
+              type: ChannelType.PrivateThread,
+              invitable: false,
+            }),
         );
 
         // Record the application in the database
@@ -279,7 +283,7 @@ export const Command = [
         ];
 
         // Post application receipt to the applicant's private thread
-        yield* Effect.tryPromise(() =>
+        yield* tryDiscord("memberApp.postApplicantReceipt", () =>
           rest.post(Routes.channelMessages(thread.id), {
             body: {
               flags: MessageFlags.IsComponentsV2,
@@ -315,43 +319,45 @@ export const Command = [
         // Post review message with approve/deny buttons to the mod-log user thread
         const modThread = yield* getOrCreateUserThread(interaction.guild, user);
 
-        const reviewMsg = (yield* Effect.tryPromise(() =>
-          rest.post(Routes.channelMessages(modThread.id), {
-            body: {
-              flags: MessageFlags.IsComponentsV2,
-              components: [
-                {
-                  type: ComponentType.Container,
-                  components: [
-                    {
-                      type: ComponentType.TextDisplay,
-                      content: `## Application from ${user.displayName}\nApplicant thread: <#${thread.id}>`,
-                    },
-                    { type: ComponentType.Separator },
-                    ...applicationComponents,
-                    { type: ComponentType.Separator },
-                    {
-                      type: ComponentType.ActionRow,
-                      components: [
-                        {
-                          type: ComponentType.Button,
-                          custom_id: `app-approve||${user.id}`,
-                          label: "Approve",
-                          style: ButtonStyle.Success,
-                        },
-                        {
-                          type: ComponentType.Button,
-                          custom_id: `app-deny||${user.id}`,
-                          label: "Deny",
-                          style: ButtonStyle.Danger,
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            },
-          }),
+        const reviewMsg = (yield* tryDiscord(
+          "memberApp.postReviewMessage",
+          () =>
+            rest.post(Routes.channelMessages(modThread.id), {
+              body: {
+                flags: MessageFlags.IsComponentsV2,
+                components: [
+                  {
+                    type: ComponentType.Container,
+                    components: [
+                      {
+                        type: ComponentType.TextDisplay,
+                        content: `## Application from ${user.displayName}\nApplicant thread: <#${thread.id}>`,
+                      },
+                      { type: ComponentType.Separator },
+                      ...applicationComponents,
+                      { type: ComponentType.Separator },
+                      {
+                        type: ComponentType.ActionRow,
+                        components: [
+                          {
+                            type: ComponentType.Button,
+                            custom_id: `app-approve||${user.id}`,
+                            label: "Approve",
+                            style: ButtonStyle.Success,
+                          },
+                          {
+                            type: ComponentType.Button,
+                            custom_id: `app-deny||${user.id}`,
+                            label: "Deny",
+                            style: ButtonStyle.Danger,
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            }),
         )) as { id: string };
 
         // Post summary to mod-log channel with link to the review message
@@ -360,7 +366,7 @@ export const Command = [
           [SETTINGS.modLog],
         );
         const reviewLink = `https://discord.com/channels/${interaction.guild.id}/${modThread.id}/${reviewMsg.id}`;
-        const logMsg = (yield* Effect.tryPromise(() =>
+        const logMsg = (yield* tryDiscord("memberApp.postLogSummary", () =>
           rest.post(Routes.channelMessages(modLog), {
             body: {
               content: `<@${user.id}> applied to join — [review application](${reviewLink})`,
@@ -485,7 +491,7 @@ export const Command = [
           })
           .where("id", "=", appRow.id);
 
-        yield* Effect.tryPromise(() =>
+        yield* tryDiscord("memberApp.addMemberRole", () =>
           rest.put(
             Routes.guildMemberRole(guildId, applicantUserId, config.role_id),
           ),
@@ -497,15 +503,19 @@ export const Command = [
         });
 
         // Attempt to notify the applicant via DM
-        yield* Effect.tryPromise(async () => {
-          const dmChannel = (await rest.post(Routes.userChannels(), {
-            body: { recipient_id: applicantUserId },
-          })) as { id: string };
-          await rest.post(Routes.channelMessages(dmChannel.id), {
-            body: {
-              content: `Your application to **${interaction.guild!.name}** has been approved! Welcome to the community!`,
-            },
-          });
+        yield* Effect.gen(function* () {
+          const dmChannel = (yield* tryDiscord("memberApp.dmOpenChannel", () =>
+            rest.post(Routes.userChannels(), {
+              body: { recipient_id: applicantUserId },
+            }),
+          )) as { id: string };
+          yield* tryDiscord("memberApp.dmSendMessage", () =>
+            rest.post(Routes.channelMessages(dmChannel.id), {
+              body: {
+                content: `Your application to **${interaction.guild!.name}** has been approved! Welcome to the community!`,
+              },
+            }),
+          );
         }).pipe(Effect.catchAll(() => Effect.void));
 
         const appMsgLink = `https://discord.com/channels/${guildId}/${interaction.channelId}/${interaction.message?.id}`;
@@ -593,20 +603,24 @@ export const Command = [
         }
 
         // Notify the applicant via DM before kicking, fall back to thread
-        const dmSent = yield* Effect.tryPromise(async () => {
-          const dmChannel = (await rest.post(Routes.userChannels(), {
-            body: { recipient_id: applicantUserId },
-          })) as { id: string };
-          await rest.post(Routes.channelMessages(dmChannel.id), {
-            body: {
-              content: `Your application to **${interaction.guild!.name}** has been denied.`,
-            },
-          });
+        const dmSent = yield* Effect.gen(function* () {
+          const dmChannel = (yield* tryDiscord("memberApp.dmOpenChannel", () =>
+            rest.post(Routes.userChannels(), {
+              body: { recipient_id: applicantUserId },
+            }),
+          )) as { id: string };
+          yield* tryDiscord("memberApp.dmSendMessage", () =>
+            rest.post(Routes.channelMessages(dmChannel.id), {
+              body: {
+                content: `Your application to **${interaction.guild!.name}** has been denied.`,
+              },
+            }),
+          );
           return true;
         }).pipe(Effect.catchAll(() => Effect.succeed(false)));
 
         if (!dmSent && denyAppRow.thread_id) {
-          yield* Effect.tryPromise(() =>
+          yield* tryDiscord("memberApp.postDenyThreadFallback", () =>
             rest.post(Routes.channelMessages(denyAppRow.thread_id), {
               body: {
                 content: `<@${applicantUserId}>, your application has been denied.`,
@@ -625,7 +639,7 @@ export const Command = [
           .where("id", "=", denyAppRow.id);
 
         // Kick the applicant
-        yield* Effect.tryPromise(() =>
+        yield* tryDiscord("memberApp.kickApplicant", () =>
           rest.delete(Routes.guildMember(guildId, applicantUserId), {
             reason: `Application denied by ${denierId}`,
           }),
@@ -724,13 +738,15 @@ export const Command = [
 
         if (retractAppRow?.review_message_id && modThreadRow?.thread_id) {
           // Fetch the existing message to preserve application content
-          const existingMsg = (yield* Effect.tryPromise(() =>
-            rest.get(
-              Routes.channelMessage(
-                modThreadRow.thread_id,
-                retractAppRow.review_message_id!,
+          const existingMsg = (yield* tryDiscord(
+            "memberApp.fetchReviewMessage",
+            () =>
+              rest.get(
+                Routes.channelMessage(
+                  modThreadRow.thread_id,
+                  retractAppRow.review_message_id!,
+                ),
               ),
-            ),
           ).pipe(Effect.catchAll(() => Effect.succeed(null)))) as {
             components?: { components?: unknown[] }[];
           } | null;
@@ -777,7 +793,7 @@ export const Command = [
               },
             );
 
-            yield* Effect.tryPromise(() =>
+            yield* tryDiscord("memberApp.disableReviewButtons", () =>
               rest.patch(
                 Routes.channelMessage(
                   modThreadRow.thread_id,
@@ -810,7 +826,7 @@ export const Command = [
           `<@${applicantUserId}> retracted their application`,
         );
 
-        yield* Effect.tryPromise(() =>
+        yield* tryDiscord("memberApp.archiveApplicantThread", () =>
           rest.patch(Routes.channel(interaction.channelId), {
             body: { archived: true, locked: true },
           }),

--- a/app/commands/purgeMessages.ts
+++ b/app/commands/purgeMessages.ts
@@ -10,10 +10,13 @@ import {
   StringSelectMenuBuilder,
   StringSelectMenuOptionBuilder,
   type Message,
+  type ThreadChannel,
 } from "discord.js";
-import { Effect } from "effect";
+import { Effect, Ref } from "effect";
 
+import { tryDiscord } from "#~/effects/classifyDiscordError";
 import {
+  deleteMessage,
   interactionEditReply,
   interactionReply,
   interactionUpdate,
@@ -259,7 +262,7 @@ export const PurgeMessagesConfirmHandler = {
         return;
       }
 
-      let deletedCount = 0;
+      const deletedRef = yield* Ref.make(0);
 
       // Collect all text channels and active threads.
       const textChannels = guild.channels.cache.filter(
@@ -270,29 +273,38 @@ export const PurgeMessagesConfirmHandler = {
       );
 
       // Also include active threads (public and private).
-      const activeThreads = yield* Effect.tryPromise(() =>
+      const activeThreads = yield* tryDiscord("fetchActiveThreads", () =>
         guild.channels.fetchActiveThreads(),
-      ).pipe(Effect.orElseSucceed(() => ({ threads: new Map() })));
+      ).pipe(
+        Effect.orElseSucceed(() => ({
+          threads: new Map<string, ThreadChannel>(),
+        })),
+      );
 
       const channelsToScan = [
         ...textChannels.values(),
         ...activeThreads.threads.values(),
       ];
 
-      // Scan channels in an async function so we can use await + per-channel
-      // try/catch to gracefully skip channels the bot cannot access.
-      yield* Effect.tryPromise(async () => {
-        for (const channel of channelsToScan) {
-          if (!channel.isTextBased()) continue;
-          try {
+      // Scan channels sequentially. Each channel's scan is wrapped in
+      // `catchAll` so a channel the bot cannot read/manage is gracefully
+      // skipped instead of aborting the whole run.
+      yield* Effect.forEach(
+        channelsToScan,
+        (channel) => {
+          if (!channel.isTextBased()) return Effect.void;
+
+          // Paginate through channel history oldest-first within the window.
+          const scanChannel = Effect.gen(function* () {
             let lastId: string | undefined;
 
-            // Paginate through channel history oldest-first within the window.
             for (;;) {
-              const messages = await channel.messages.fetch({
-                limit: 100,
-                ...(lastId ? { before: lastId } : {}),
-              });
+              const messages = yield* tryDiscord("fetchMessages", () =>
+                channel.messages.fetch({
+                  limit: 100,
+                  ...(lastId ? { before: lastId } : {}),
+                }),
+              );
 
               if (messages.size === 0) break;
 
@@ -304,13 +316,15 @@ export const PurgeMessagesConfirmHandler = {
 
               if (toDelete.size > 0) {
                 if (toDelete.size === 1) {
-                  await toDelete.first()!.delete();
+                  yield* deleteMessage(toDelete.first()!);
                 } else {
                   // bulkDelete requires messages < 2 weeks old; our max window
                   // is 7 days so this is always safe.
-                  await channel.bulkDelete(toDelete);
+                  yield* tryDiscord("bulkDelete", () =>
+                    channel.bulkDelete(toDelete),
+                  );
                 }
-                deletedCount += toDelete.size;
+                yield* Ref.update(deletedRef, (n) => n + toDelete.size);
               }
 
               // Stop paging if we've gone past the time window.
@@ -318,12 +332,16 @@ export const PurgeMessagesConfirmHandler = {
               if (!oldest || oldest.createdTimestamp < since) break;
               lastId = oldest.id;
             }
-          } catch {
-            // Skip channels the bot lacks permission to read/manage.
-            // This is expected for some channels and should not abort the whole run.
-          }
-        }
-      });
+          });
+
+          // Skip channels the bot lacks permission to read/manage. This is
+          // expected for some channels and should not abort the whole run.
+          return scanChannel.pipe(Effect.catchAll(() => Effect.void));
+        },
+        { concurrency: 1 },
+      );
+
+      const deletedCount = yield* Ref.get(deletedRef);
 
       yield* logEffect("info", "Commands", "Purge messages completed", {
         guildId: interaction.guildId,

--- a/app/commands/setup.ts
+++ b/app/commands/setup.ts
@@ -39,12 +39,10 @@ export const Command = {
       const guildChannelIds = new Set(
         interaction.guild.channels.cache.map((c) => c.id),
       );
-      const form = yield* Effect.tryPromise(() =>
-        initSetupForm(
-          interaction.guildId!,
-          interaction.user.id,
-          guildChannelIds,
-        ),
+      const form = yield* initSetupForm(
+        interaction.guildId,
+        interaction.user.id,
+        guildChannelIds,
       );
 
       yield* interactionReply(

--- a/app/commands/setupHandlers.ts
+++ b/app/commands/setupHandlers.ts
@@ -8,7 +8,7 @@ import {
 } from "discord.js";
 import { Effect } from "effect";
 
-import { db, runEffect, runTakeFirst } from "#~/AppRuntime";
+import { DatabaseService, type SqlError } from "#~/Database";
 import {
   interactionDeferUpdate,
   interactionEditReply,
@@ -117,63 +117,63 @@ const v2Update = v2Payload;
 
 // --- Public: initialize state and return the form payload for slash command use ---
 
-export async function initSetupForm(
+export const initSetupForm = (
   guildId: string,
   userId: string,
   guildChannelIds?: Set<string>,
-): Promise<object> {
-  cleanupStaleSetups();
+): Effect.Effect<object, SqlError, DatabaseService> =>
+  Effect.gen(function* () {
+    cleanupStaleSetups();
 
-  // Try to populate from existing guild settings
-  const defaults = defaultSetup();
-  const guild = await runEffect(fetchGuild(guildId));
-  if (guild?.settings) {
-    const settings = JSON.parse(guild.settings) as Record<string, string>;
+    // Try to populate from existing guild settings
+    const defaults = defaultSetup();
+    const db = yield* DatabaseService;
+    const guild = yield* fetchGuild(guildId);
+    if (guild?.settings) {
+      const settings = JSON.parse(guild.settings) as Record<string, string>;
 
-    if (settings.moderator) defaults.modRoleId = settings.moderator;
-    if (settings.modLog) defaults.modLogChannel = settings.modLog;
-    // If guild is configured but deletionLog is absent, treat as disabled
-    defaults.deletionLogChannel = settings.deletionLog ?? null;
-    if (settings.restricted) defaults.restrictedRoleId = settings.restricted;
+      if (settings.moderator) defaults.modRoleId = settings.moderator;
+      if (settings.modLog) defaults.modLogChannel = settings.modLog;
+      // If guild is configured but deletionLog is absent, treat as disabled
+      defaults.deletionLogChannel = settings.deletionLog ?? null;
+      if (settings.restricted) defaults.restrictedRoleId = settings.restricted;
 
-    // Check for existing honeypot channel
-    const honeypot = await runTakeFirst(
-      db
+      // Check for existing honeypot channel
+      const honeypotRows = yield* db
         .selectFrom("honeypot_config")
         .select("channel_id")
-        .where("guild_id", "=", guildId),
-    );
-    if (honeypot) {
-      defaults.honeypotChannel = honeypot.channel_id;
-    } else {
-      defaults.honeypotChannel = null;
-    }
+        .where("guild_id", "=", guildId);
+      const honeypot = honeypotRows[0];
+      if (honeypot) {
+        defaults.honeypotChannel = honeypot.channel_id;
+      } else {
+        defaults.honeypotChannel = null;
+      }
 
-    // tickets_config has no guild_id, so match by channel ownership
-    if (guildChannelIds) {
-      const ticketRows = await runTakeFirst(
-        db
+      // tickets_config has no guild_id, so match by channel ownership
+      if (guildChannelIds) {
+        const ticketRowsResult = yield* db
           .selectFrom("tickets_config")
           .select("channel_id")
-          .where("channel_id", "is not", null),
-      );
-      if (
-        ticketRows?.channel_id &&
-        guildChannelIds.has(ticketRows.channel_id)
-      ) {
-        defaults.ticketChannel = ticketRows.channel_id;
+          .where("channel_id", "is not", null);
+        const ticketRows = ticketRowsResult[0];
+        if (
+          ticketRows?.channel_id &&
+          guildChannelIds.has(ticketRows.channel_id)
+        ) {
+          defaults.ticketChannel = ticketRows.channel_id;
+        } else {
+          defaults.ticketChannel = null;
+        }
       } else {
         defaults.ticketChannel = null;
       }
-    } else {
-      defaults.ticketChannel = null;
     }
-  }
 
-  const state: PendingSetup = { ...defaults, createdAt: Date.now() };
-  pendingSetups.set(setupKey(guildId, userId), state);
-  return buildSetupScreen1Message(guildId, state);
-}
+    const state: PendingSetup = { ...defaults, createdAt: Date.now() };
+    pendingSetups.set(setupKey(guildId, userId), state);
+    return buildSetupScreen1Message(guildId, state);
+  });
 
 export function renderScreen(
   guildId: string,

--- a/app/discord/api.test.ts
+++ b/app/discord/api.test.ts
@@ -1,0 +1,160 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Effect } from "effect";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { userDiscordSdkFromRequest } from "./api";
+
+// `userDiscordSdkFromRequest` stays plain-async (it throws react-router
+// `redirect()` Responses), so we exercise it directly and mock only its
+// collaborators: the Effect runner and the session-server token helpers.
+
+vi.mock("#~/AppRuntime", () => ({
+  // The real runEffect runs against the app ManagedRuntime; in tests the mocked
+  // session helpers return plain Effects, so a bare runPromise is enough.
+  runEffect: (effect: any) => Effect.runPromise(effect),
+}));
+
+vi.mock("#~/helpers/env.server", () => ({
+  discordToken: "test-bot-token",
+}));
+
+vi.mock("#~/helpers/observability", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  log: () => {},
+}));
+
+const session = vi.hoisted(() => ({
+  retrieveDiscordToken: vi.fn(),
+  refreshAndPersistDiscordSession: vi.fn(),
+}));
+
+vi.mock("#~/models/session.server.js", () => session);
+
+const REFRESH_TOKEN = "single-use-refresh-token";
+
+function makeToken(opts: { expired: boolean; accessToken: string }) {
+  return {
+    token: {
+      access_token: opts.accessToken,
+      refresh_token: REFRESH_TOKEN,
+    },
+    expired: () => opts.expired,
+  };
+}
+
+const request = () => new Request("https://example.com/app");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("userDiscordSdkFromRequest token refresh single-flight (#393)", () => {
+  test("two concurrent expired-token calls trigger exactly ONE Discord refresh POST", async () => {
+    let refreshPosts = 0;
+    let refreshed = false;
+
+    // The DB session starts holding an expired token. Once a refresh persists a
+    // new token, subsequent reads see it as fresh.
+    session.retrieveDiscordToken.mockImplementation(() =>
+      Effect.sync(() =>
+        makeToken({ expired: !refreshed, accessToken: "fresh-access-token" }),
+      ),
+    );
+
+    // Each call here represents one POST of the single-use refresh_token to
+    // Discord. A real second POST would 400; we assert it never happens.
+    session.refreshAndPersistDiscordSession.mockImplementation(() =>
+      Effect.promise(async () => {
+        refreshPosts += 1;
+        await new Promise((r) => setTimeout(r, 10));
+        refreshed = true;
+        return "__session=refreshed";
+      }),
+    );
+
+    // Both loaders run in parallel and BOTH redirect to self with the new
+    // cookie (success path) — neither bounces to /login.
+    const results = await Promise.allSettled([
+      userDiscordSdkFromRequest(request()),
+      userDiscordSdkFromRequest(request()),
+    ]);
+
+    expect(refreshPosts).toBe(1);
+    expect(session.refreshAndPersistDiscordSession).toHaveBeenCalledTimes(1);
+
+    for (const r of results) {
+      // Success path throws a self-redirect Response carrying the fresh cookie.
+      expect(r.status).toBe("rejected");
+      const reason = (r as PromiseRejectedResult).reason as Response;
+      expect(reason).toBeInstanceOf(Response);
+      const location = reason.headers.get("Location");
+      // Both loaders redirect back to the same URL (success path) carrying the
+      // fresh token's cookie — crucially NOT bounced to /login.
+      expect(location).toBe("/app");
+      expect(location).not.toContain("/login");
+    }
+  });
+
+  test("non-expired token returns a Bearer REST client without refreshing", async () => {
+    session.retrieveDiscordToken.mockImplementation(() =>
+      Effect.sync(() =>
+        makeToken({ expired: false, accessToken: "still-valid" }),
+      ),
+    );
+
+    const rest = await userDiscordSdkFromRequest(request());
+    expect(rest).toBeDefined();
+    expect(session.refreshAndPersistDiscordSession).not.toHaveBeenCalled();
+  });
+
+  test("400 refresh failure but session now holds a fresh token → proceeds instead of redirecting to /login", async () => {
+    let reads = 0;
+    // First read: expired (triggers refresh attempt).
+    // Refresh POST fails (simulating Discord 400: token already consumed by
+    // another process). Re-read: a fresh token is now present.
+    session.retrieveDiscordToken.mockImplementation(() =>
+      Effect.sync(() => {
+        reads += 1;
+        const expired = reads === 1;
+        return makeToken({
+          expired,
+          accessToken: expired ? "stale" : "fresh-from-other-process",
+        });
+      }),
+    );
+
+    session.refreshAndPersistDiscordSession.mockImplementation(() =>
+      Effect.promise(() =>
+        Promise.reject(new Error("400 Bad Request: invalid_grant")),
+      ),
+    );
+
+    // Should NOT throw a redirect — it re-reads, finds a fresh token, proceeds.
+    const rest = await userDiscordSdkFromRequest(request());
+    expect(rest).toBeDefined();
+    expect(reads).toBe(2);
+  });
+
+  test("400 refresh failure and re-read still expired → redirects to /login preserving redirectTo", async () => {
+    session.retrieveDiscordToken.mockImplementation(() =>
+      Effect.sync(() => makeToken({ expired: true, accessToken: "stale" })),
+    );
+
+    session.refreshAndPersistDiscordSession.mockImplementation(() =>
+      Effect.promise(() =>
+        Promise.reject(new Error("400 Bad Request: invalid_grant")),
+      ),
+    );
+
+    await expect(
+      userDiscordSdkFromRequest(new Request("https://example.com/app?foo=bar")),
+    ).rejects.toSatisfy((err: unknown) => {
+      expect(err).toBeInstanceOf(Response);
+      const location = (err as Response).headers.get("Location");
+      expect(location).toMatch(/^\/login\?/);
+      expect(location).toContain("redirectTo=");
+      expect(decodeURIComponent(location ?? "")).toContain("/app?foo=bar");
+      return true;
+    });
+  });
+});

--- a/app/discord/api.ts
+++ b/app/discord/api.ts
@@ -11,6 +11,29 @@ import {
 
 export const ssrDiscordSdk = new REST({ version: "10" }).setToken(discordToken);
 
+// Single-flight dedupe for Discord OAuth token refresh (#393).
+//
+// The OAuth `refresh_token` is single-use: the first POST to Discord consumes
+// it and Discord rejects any subsequent POST of the same token with 400. But a
+// single page load runs the `__auth` layout loader and the `__auth/app` child
+// loader in PARALLEL, and BOTH call `userDiscordSdkFromRequest`. With an expired
+// token, both would independently POST the same refresh_token: one wins and
+// persists the new token, the other gets a 400 and (previously) bounced the user
+// to /login — a spurious login bounce once per token lifetime.
+//
+// This map collapses concurrent refreshes of the SAME refresh_token (within one
+// process) into ONE Discord POST. Keyed on the refresh_token string because
+// that is exactly what Discord dedupes on. The entry is deleted once settled
+// (success OR failure) so a later, genuinely-needed refresh isn't blocked.
+const inFlightRefresh = new Map<string, Promise<string>>();
+
+function refreshTokenKey(userToken: {
+  token: Record<string, unknown>;
+}): string | undefined {
+  const refreshToken = userToken.token.refresh_token;
+  return typeof refreshToken === "string" ? refreshToken : undefined;
+}
+
 export async function userDiscordSdkFromRequest(request: Request) {
   const userToken = await runEffect(retrieveDiscordToken(request));
 
@@ -21,28 +44,72 @@ export async function userDiscordSdkFromRequest(request: Request) {
       "Discord OAuth token expired, refreshing and persisting",
     );
     try {
-      // Persist the refreshed token to the DB session and get the new cookie.
+      // De-dupe parallel refreshes of the same single-use refresh_token. If
+      // another loader in this process already kicked off the refresh, await
+      // its in-flight promise and reuse the resulting cookie instead of POSTing
+      // the (now-consumed) refresh_token a second time.
+      const key = refreshTokenKey(userToken);
+      let refreshCookie: string;
+      const existing = key ? inFlightRefresh.get(key) : undefined;
+      if (existing) {
+        refreshCookie = await existing;
+      } else {
+        // Persist the refreshed token to the DB session and get the new cookie.
+        const refreshPromise = runEffect(
+          refreshAndPersistDiscordSession(request),
+        );
+        if (key) {
+          inFlightRefresh.set(key, refreshPromise);
+          // Clear our own entry once settled (success OR failure) so a later,
+          // genuinely-needed refresh isn't blocked. `void` + `.catch` keeps this
+          // cleanup branch from surfacing as an unhandled rejection — the actual
+          // failure is observed by the `await refreshPromise` below.
+          void refreshPromise
+            .catch(() => undefined)
+            .finally(() => {
+              // Only clear our own entry; a newer refresh may have replaced it.
+              if (inFlightRefresh.get(key) === refreshPromise) {
+                inFlightRefresh.delete(key);
+              }
+            });
+        }
+        refreshCookie = await refreshPromise;
+      }
       // We redirect back to the same URL so the next request reads the new token
       // from the session instead of finding the expired one again.
-      const refreshCookie = await runEffect(
-        refreshAndPersistDiscordSession(request),
-      );
       const url = new URL(request.url);
       throw redirect(url.pathname + url.search, {
         headers: { "Set-Cookie": refreshCookie },
       });
     } catch (refreshError) {
       if (refreshError instanceof Response) throw refreshError;
+
+      // Defense in depth for the cross-process / cross-instance race that the
+      // in-process single-flight map can't cover: another worker may have
+      // already refreshed and persisted a fresh token to the same session row.
+      // Re-read the session token from the DB before giving up — if it's now
+      // fresh, use it and proceed instead of bouncing the user to /login (#393).
+      try {
+        const reReadToken = await runEffect(retrieveDiscordToken(request));
+        if (!reReadToken.expired()) {
+          log(
+            "info",
+            "api",
+            "Discord OAuth refresh failed but session now holds a fresh token; proceeding",
+          );
+          return new REST({ version: "10", authPrefix: "Bearer" }).setToken(
+            reReadToken.token.access_token as string,
+          );
+        }
+      } catch {
+        // Fall through to the login redirect below.
+      }
+
       log(
         "warn",
         "api",
         "Discord OAuth token refresh failed, redirecting to login",
-        {
-          error:
-            refreshError instanceof Error
-              ? refreshError.message
-              : String(refreshError),
-        },
+        { error: refreshError },
       );
       // Preserve where the user was so login returns them there (#373).
       const url = new URL(request.url);

--- a/app/discord/pipelines/deletionLogHandlers.ts
+++ b/app/discord/pipelines/deletionLogHandlers.ts
@@ -86,7 +86,7 @@ export const handleDelete = (
 
     const settings = yield* fetchSettings(guild.id, [
       SETTINGS.deletionLog,
-    ]).pipe(Effect.catchAll(() => Effect.succeed(null)));
+    ]).pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)));
 
     if (!settings?.deletionLog) return;
 
@@ -253,7 +253,7 @@ export const handleEdit = (
 
     const settings = yield* fetchSettings(guild.id, [
       SETTINGS.deletionLog,
-    ]).pipe(Effect.catchAll(() => Effect.succeed(null)));
+    ]).pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)));
 
     if (!settings?.deletionLog) return;
 
@@ -339,7 +339,7 @@ export const handleBulkDelete = (
 
     const settings = yield* fetchSettings(guild.id, [
       SETTINGS.deletionLog,
-    ]).pipe(Effect.catchAll(() => Effect.succeed(null)));
+    ]).pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(null)));
 
     if (!settings?.deletionLog) return;
 

--- a/app/features/Admin/jobHelpers.server.test.tsx
+++ b/app/features/Admin/jobHelpers.server.test.tsx
@@ -1,0 +1,294 @@
+import {
+  Deferred,
+  Effect,
+  Fiber,
+  FiberRef,
+  Layer,
+  ManagedRuntime,
+} from "effect";
+import type { ComponentProps } from "react";
+import { renderToString } from "react-dom/server";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import * as Reactivity from "@effect/experimental/Reactivity";
+import { SqlClient } from "@effect/sql";
+import * as Sqlite from "@effect/sql-kysely/Sqlite";
+import { SqliteClient } from "@effect/sql-sqlite-node";
+
+import { DatabaseService, type DB } from "#~/Database";
+import {
+  jobMetaRef,
+  SupervisorServiceLive,
+  type ActiveJobMeta,
+} from "#~/effects/supervisor";
+import type { Job } from "#~/jobs/jobRunner";
+import AdminJobs from "#~/routes/__auth/admin.jobs";
+
+import { fetchAdminJobs, type AdminJob } from "./jobHelpers.server";
+
+// The route module is a server entrypoint: its loader pulls in AppRuntime (full
+// app Layer) and requireAdmin (-> stripe.server, which throws at import without
+// a key). The COMPONENT under test touches neither, so we stub both so importing
+// the default export only drags in the client-safe render tree.
+vi.mock("#~/AppRuntime", () => ({
+  runEffect: vi.fn(),
+}));
+vi.mock("#~/features/Admin/helpers.server", () => ({
+  requireAdmin: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// In-memory SQLite + real SupervisorServiceLive (mirrors jobRunner.test.ts)
+// ---------------------------------------------------------------------------
+
+const TestSqliteLive = Layer.scoped(
+  SqlClient.SqlClient,
+  SqliteClient.make({ filename: ":memory:" }),
+).pipe(Layer.provide(Reactivity.layer));
+
+const TestKyselyLive = Layer.effect(DatabaseService, Sqlite.make<DB>()).pipe(
+  Layer.provide(TestSqliteLive),
+);
+
+// Use the REAL SupervisorServiceLive so getActiveJobMeta inspects genuine
+// tracked fibers rather than a stub.
+const TestLayer = Layer.mergeAll(
+  TestSqliteLive,
+  TestKyselyLive,
+  SupervisorServiceLive,
+);
+
+const testRuntime = ManagedRuntime.make(TestLayer);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const runTest = <A,>(effect: Effect.Effect<A, any, any>) =>
+  testRuntime.runPromise(effect);
+
+beforeAll(async () => {
+  await runTest(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql.unsafe(`
+        CREATE TABLE IF NOT EXISTS background_jobs (
+          id TEXT PRIMARY KEY NOT NULL,
+          guild_id TEXT NOT NULL,
+          job_type TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'pending',
+          payload TEXT NOT NULL,
+          cursor TEXT,
+          final_cursor TEXT,
+          phase INTEGER NOT NULL DEFAULT 1,
+          total_phases INTEGER NOT NULL DEFAULT 1,
+          progress_count INTEGER NOT NULL DEFAULT 0,
+          error_count INTEGER NOT NULL DEFAULT 0,
+          last_error TEXT,
+          notify_channel_id TEXT,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          completed_at TEXT
+        )
+      `);
+    }),
+  );
+});
+
+beforeEach(async () => {
+  await runTest(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      yield* sql.unsafe("DELETE FROM background_jobs");
+    }),
+  );
+});
+
+afterAll(async () => {
+  await testRuntime.dispose();
+});
+
+const insertJob = (overrides: Partial<Job> = {}) => {
+  const now = new Date().toISOString();
+  const job: Job = {
+    id: crypto.randomUUID(),
+    guild_id: "guild-1",
+    job_type: "bulk_role_assignment",
+    status: "pending",
+    payload: "{}",
+    cursor: null,
+    final_cursor: null,
+    phase: 1,
+    total_phases: 1,
+    progress_count: 0,
+    error_count: 0,
+    last_error: null,
+    notify_channel_id: null,
+    created_at: now,
+    updated_at: now,
+    completed_at: null,
+    ...overrides,
+  };
+
+  return Effect.gen(function* () {
+    const db = yield* DatabaseService;
+    yield* db.insertInto("background_jobs").values(job);
+    return job;
+  });
+};
+
+/**
+ * Forks a child fiber that tags itself via `jobMetaRef` for the given job and
+ * then blocks forever, so the real Supervisor reports it as active. Returns the
+ * fiber (caller must interrupt it) once the metadata is guaranteed installed.
+ */
+const forkActiveJobFiber = (job: Job) =>
+  Effect.gen(function* () {
+    const installed = yield* Deferred.make<void>();
+    const block = yield* Deferred.make<void>();
+
+    const fiber = yield* Effect.gen(function* () {
+      yield* FiberRef.set(jobMetaRef, {
+        jobId: job.id,
+        jobType: job.job_type,
+        guildId: job.guild_id,
+        startedAt: new Date().toISOString(),
+      } satisfies ActiveJobMeta);
+      yield* Deferred.succeed(installed, undefined);
+      // Block forever so the fiber stays alive and visible to the Supervisor.
+      yield* Deferred.await(block);
+    }).pipe(Effect.forkScoped);
+
+    yield* Deferred.await(installed);
+    return fiber;
+  });
+
+describe("fetchAdminJobs serializability guard (#394)", () => {
+  it("annotates a DB job with genuine fiberMeta from a tracked fiber and stays serializable", async () => {
+    const jobs = await runTest(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const job = yield* insertJob({ status: "processing" });
+          const fiber = yield* forkActiveJobFiber(job);
+
+          const result = yield* fetchAdminJobs();
+
+          // Tidy up the blocked fiber before leaving the scope.
+          yield* Fiber.interrupt(fiber);
+          return result;
+        }),
+      ),
+    );
+
+    expect(jobs).toHaveLength(1);
+    const [row] = jobs;
+
+    // The fiber was live, so this row should be flagged active with real meta.
+    expect(row.fiberActive).toBe(true);
+    expect(row.fiberMeta).not.toBeNull();
+    expect(row.fiberMeta).toMatchObject({
+      jobId: row.id,
+      jobType: row.job_type,
+      guildId: row.guild_id,
+    });
+    expect(typeof row.fiberMeta!.startedAt).toBe("string");
+
+    // Round-trips through JSON unchanged: no Proxy / Fiber / Map / Date leaks.
+    expect(JSON.parse(JSON.stringify(jobs))).toEqual(jobs);
+
+    // Each value is a scalar, except the two annotations we add.
+    for (const [key, value] of Object.entries(row)) {
+      if (key === "fiberActive") {
+        expect(typeof value).toBe("boolean");
+      } else if (key === "fiberMeta") {
+        // null OR a plain object of 4 strings — already asserted above.
+        expect(typeof value === "object").toBe(true);
+      } else {
+        expect(["string", "number"]).toContain(
+          value === null ? "string" : typeof value,
+        );
+      }
+    }
+
+    // fiberMeta carries only the 4 ActiveJobMeta string fields.
+    expect(Object.keys(row.fiberMeta!).sort()).toEqual([
+      "guildId",
+      "jobId",
+      "jobType",
+      "startedAt",
+    ]);
+    for (const v of Object.values(row.fiberMeta!)) {
+      expect(typeof v).toBe("string");
+    }
+  });
+
+  it("returns fiberActive=false / fiberMeta=null when no fiber is tracking the job", async () => {
+    const jobs = await runTest(
+      Effect.gen(function* () {
+        yield* insertJob({ status: "completed" });
+        return yield* fetchAdminJobs();
+      }),
+    );
+
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].fiberActive).toBe(false);
+    expect(jobs[0].fiberMeta).toBeNull();
+    expect(JSON.parse(JSON.stringify(jobs))).toEqual(jobs);
+  });
+});
+
+// The component only destructures `loaderData`; `params`/`matches` are required
+// by Route.ComponentProps but unused, so we stub them via a cast.
+const adminJobsProps = (jobs: AdminJob[]) =>
+  ({ loaderData: { jobs } }) as ComponentProps<typeof AdminJobs>;
+
+describe("AdminJobs render smoke test (#394)", () => {
+  // NOTE: This runs under vitest module resolution, NOT the Vite SSR dev
+  // bundle, so it guards the DATA-SHAPE angle (the loader payload renders
+  // without throwing). It does NOT reproduce the React-duplication `_store`
+  // crash, which is specific to Vite's dev resolver — the vite.config.ts
+  // `resolve.dedupe` is the fix for that.
+  it("renders <tr> rows for a real job shape without throwing", () => {
+    const jobs: AdminJob[] = [
+      {
+        id: "job-1",
+        guild_id: "guild-1",
+        job_type: "bulk_role_assignment",
+        status: "processing",
+        payload: "{}",
+        cursor: null,
+        final_cursor: null,
+        phase: 1,
+        total_phases: 2,
+        progress_count: 42,
+        error_count: 1,
+        last_error: "transient",
+        notify_channel_id: null,
+        created_at: "2026-06-21T00:00:00.000Z",
+        updated_at: "2026-06-21T00:01:00.000Z",
+        completed_at: null,
+        fiberActive: true,
+        fiberMeta: {
+          jobId: "job-1",
+          jobType: "bulk_role_assignment",
+          guildId: "guild-1",
+          startedAt: "2026-06-21T00:00:00.000Z",
+        },
+      },
+    ];
+
+    const html = renderToString(<AdminJobs {...adminJobsProps(jobs)} />);
+    expect(html).toContain("<tr");
+    expect(html).toContain("bulk_role_assignment");
+  });
+
+  it("renders the empty state without throwing", () => {
+    const html = renderToString(<AdminJobs {...adminJobsProps([])} />);
+    expect(html).toContain("No background jobs found.");
+  });
+});

--- a/app/features/spam/service.ts
+++ b/app/features/spam/service.ts
@@ -149,7 +149,17 @@ export const SpamDetectionServiceLive = Layer.effect(
         // matching the pre-Effect behavior: absent/unreadable settings → not a mod.
         const settings = yield* fetchSettings(guildId, [
           SETTINGS.moderator,
-        ]).pipe(Effect.catchAll(() => Effect.succeed(null)));
+        ]).pipe(
+          Effect.catchTag("NotFoundError", () => Effect.succeed(null)),
+          Effect.catchTag("SqlError", (error) =>
+            logEffect(
+              "warn",
+              "SpamDetection",
+              "Failed to fetch guild settings for moderator check",
+              { error },
+            ).pipe(Effect.as(null)),
+          ),
+        );
 
         if (!settings?.moderator) return false;
 

--- a/app/helpers/setupAll.server.ts
+++ b/app/helpers/setupAll.server.ts
@@ -12,18 +12,18 @@ import {
 } from "discord-api-types/v10";
 import { Effect } from "effect";
 
-import { isFeatureEnabled } from "#~/AppRuntime";
 import { DatabaseService, type SqlError } from "#~/Database";
 import { ssrDiscordSdk } from "#~/discord/api";
-import { toError, tryDiscord } from "#~/effects/classifyDiscordError";
-import { TransientError, type DiscordError } from "#~/effects/errors";
+import { tryDiscord } from "#~/effects/classifyDiscordError";
+import { type DiscordError } from "#~/effects/errors";
+import { FeatureFlagService } from "#~/effects/featureFlags";
 import { logEffect } from "#~/effects/observability";
 import { applicationId } from "#~/helpers/env.server";
 import {
   DEFAULT_BUTTON_TEXT,
   DEFAULT_MESSAGE_TEXT,
 } from "#~/helpers/setupDefaults";
-import { createJob } from "#~/jobs/jobRunner";
+import { createJobEffect } from "#~/jobs/jobRunner";
 import { registerGuild, setSettings, SETTINGS } from "#~/models/guilds.server";
 import { SubscriptionService } from "#~/models/subscriptions.server";
 
@@ -102,7 +102,11 @@ const sendChannelMessage = (
 
 export const setupAll = (
   options: SetupAllOptions,
-): Effect.Effect<SetupAllResult, DiscordError | SqlError, DatabaseService> =>
+): Effect.Effect<
+  SetupAllResult,
+  DiscordError | SqlError,
+  DatabaseService | FeatureFlagService
+> =>
   Effect.gen(function* () {
     const {
       guildId,
@@ -319,25 +323,16 @@ export const setupAll = (
       // assign the role in batches with checkpointing, and finally update
       // permissions once all members have the role.
       const bulkRoleId = resolvedMemberRoleId;
-      yield* Effect.tryPromise({
-        try: () =>
-          createJob({
-            guildId,
-            jobType: "bulk_role_assignment",
-            payload: {
-              roleId: bulkRoleId,
-              everyonePermissions: String(everyonePerms),
-              memberPermissions: String(memberPerms),
-            },
-            totalPhases: 1,
-            notifyChannelId: modLogChannelId,
-          }),
-        catch: (rejection) =>
-          new TransientError({
-            source: "discord",
-            operation: "createJob",
-            cause: toError(rejection),
-          }),
+      yield* createJobEffect({
+        guildId,
+        jobType: "bulk_role_assignment",
+        payload: {
+          roleId: bulkRoleId,
+          everyonePermissions: String(everyonePerms),
+          memberPermissions: String(memberPerms),
+        },
+        totalPhases: 1,
+        notifyChannelId: modLogChannelId,
       });
 
       yield* logEffect(
@@ -400,19 +395,9 @@ export const setupAll = (
     // user who later clicks it (#370). Skip the whole section when disabled.
     let ticketChannelId: string | undefined;
     const ticketRequested = ticketChannel !== undefined;
-    // isFeatureEnabled (AppRuntime) Promise-bridges a PostHog flag check through
-    // the ManagedRuntime, which provides FeatureFlagService itself — so the flag
-    // check does NOT add FeatureFlagService to this function's requirements.
+    const flags = yield* FeatureFlagService;
     const ticketingEnabled = ticketRequested
-      ? yield* Effect.tryPromise({
-          try: () => isFeatureEnabled("ticketing", guildId),
-          catch: (rejection) =>
-            new TransientError({
-              source: "discord",
-              operation: "isFeatureEnabled",
-              cause: toError(rejection),
-            }),
-        })
+      ? yield* flags.isPostHogEnabled("ticketing", guildId)
       : false;
 
     if (ticketRequested && !ticketingEnabled) {

--- a/app/helpers/setupPermissionCheck.test.ts
+++ b/app/helpers/setupPermissionCheck.test.ts
@@ -14,7 +14,7 @@ vi.mock("#~/jobs/jobRunner", () => ({
   registerNotificationBuilder: () => {
     /* noop for test */
   },
-  createJob: vi.fn(),
+  createJobEffect: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------

--- a/app/jobs/jobRunner.ts
+++ b/app/jobs/jobRunner.ts
@@ -2,7 +2,6 @@ import { Routes } from "discord-api-types/v10";
 import { Deferred, Effect, Fiber, FiberRef } from "effect";
 import type { Selectable } from "kysely";
 
-import { runEffect } from "#~/AppRuntime";
 import { DatabaseService, type SqlError } from "#~/Database";
 import type { DB } from "#~/db";
 import { ssrDiscordSdk } from "#~/discord/api";
@@ -253,13 +252,6 @@ export const getJobEffect = (jobId: string) =>
       .where("id", "=", jobId);
     return job as Job | undefined;
   }).pipe(Effect.withSpan("getJob", { attributes: { jobId } }));
-
-// ---------------------------------------------------------------------------
-// Async wrapper (kept for setupAll.server.ts)
-// ---------------------------------------------------------------------------
-
-export const createJob = (options: CreateJobOptions): Promise<Job> =>
-  runEffect(createJobEffect(options));
 
 // ---------------------------------------------------------------------------
 // Handler registry and polling loop

--- a/app/server.ts
+++ b/app/server.ts
@@ -174,17 +174,41 @@ const startup = Effect.gen(function* () {
 
     // Graceful shutdown handler to checkpoint WAL and dispose the runtime
     // (tears down PostHog finalizer, feature flag interval, and SQLite connection)
-    const handleShutdown = (signal: string) =>
-      runtime
-        .runPromise(
+    // Graceful shutdown: checkpoint WAL, THEN dispose the runtime so AppLayer
+    // finalizers run (PostHog flush/shutdown, feature-flag interval clear,
+    // SQLite connection close) before the process exits. The exit must come
+    // after dispose — an earlier `process.exit` here skips every finalizer.
+    let shuttingDown = false;
+    const handleShutdown = async (signal: string) => {
+      if (shuttingDown) return;
+      shuttingDown = true;
+
+      // Failsafe: if teardown hangs (a finalizer blocks), force-exit rather
+      // than wait for the orchestrator's SIGKILL. unref() so this timer can
+      // never keep the process alive on its own.
+      const forceExit = setTimeout(() => {
+        console.error("Graceful shutdown timed out; forcing exit");
+        process.exit(1);
+      }, 10_000);
+      forceExit.unref();
+
+      try {
+        await runtime.runPromise(
           Effect.gen(function* () {
             yield* logEffect("info", "Server", `Received ${signal}`);
             yield* checkpointWal();
             yield* logEffect("info", "Server", "Database WAL checkpointed");
-            process.exit(0);
           }),
-        )
-        .then(() => runtime.dispose().then(() => console.log("ok")));
+        );
+      } catch (error) {
+        console.error("Shutdown WAL checkpoint failed:", error);
+      } finally {
+        await runtime
+          .dispose()
+          .catch((error) => console.error("Runtime dispose failed:", error));
+        process.exit(0);
+      }
+    };
 
     yield* logEffect("debug", "Server", "setting signal handlers");
     process.on("SIGTERM", () => void handleShutdown("SIGTERM"));

--- a/notes/EFFECT.md
+++ b/notes/EFFECT.md
@@ -36,6 +36,43 @@ Two guards enforce this so it can't regress:
   sourcemap policy is a separate concern not changed here). Wired into CI as the
   `client-bundle` job; run it locally with `npm run check:client-bundle`.
 
+## Runtime & Boundaries
+
+Effects are lazy descriptions — nothing runs until something executes them. This
+codebase has exactly **one** runtime: a `ManagedRuntime` built from `AppLayer`
+and exported as `runtime` in `app/AppRuntime.ts`. `AppLayer` merges every
+service (Database, PostHog, FeatureFlag, MessageCache, DiscordEventBus,
+Supervisor, SpamDetection, User) and stays open for the whole process lifetime,
+so its resources — the SQLite connection, the PostHog flush finalizer, the
+broadcast event queue — live as long as the bot does.
+
+Because the services live in `AppLayer`, code that `yield* DatabaseService` (or
+any other app service) **never needs a per-call `Layer.provide`** — the runtime
+already supplies the whole context. The requirement type these effects carry is
+`RuntimeContext` (`AppRuntime.ts`).
+
+You only execute an effect at a **boundary** — the edge between Effect-land and
+the outside (an HTTP request, a Discord callback, process startup):
+
+| Boundary helper | What it does | Used at |
+| --- | --- | --- |
+| `runEffect(effect)` | `runtime.runPromise` — run to a `Promise<A>` | route loaders/actions, the gateway interaction handler, schedulers |
+| `runEffectExit(effect)` | `runtime.runPromiseExit` — run to an `Exit` (no throw) | callers that must inspect success/failure |
+| `Effect.forkDaemon` | fork a long-lived background fiber off the runtime | the six event pipelines, started in `server.ts` |
+
+**`forkDaemon`, not `fork`.** The pipelines are forked with `Effect.forkDaemon`
+(`server.ts`) specifically so they outlive the `startup` fiber that spawns them —
+a plain `Effect.fork` would tie their lifetime to startup and they'd be
+interrupted the moment it finished. On HMR the previous fibers are
+`Fiber.interrupt`ed and re-forked. This distinction is load-bearing; don't
+"simplify" it to `fork`.
+
+> Legacy async/await callers reach Effect through `runEffect`. A handful of
+> `@deprecated` Promise bridges (`run`, `runTakeFirst`, `runTakeFirstOrThrow`,
+> and the lazy `db` proxy in `AppRuntime.ts`) remain for not-yet-migrated call
+> sites (notably `session.server.ts`). Don't reach for them in new code — use
+> `runEffect` with a real Effect.
+
 ## Reading Effect Code
 
 ### The Mental Model
@@ -276,9 +313,122 @@ const results = yield* Effect.forEach(due, (escalation) =>
 
 **See:** `app/commands/escalate/escalationResolver.ts:186-197`
 
+### Event Pipelines (Streams)
+
+Discord events are processed through **Effect `Stream` pipelines** — this is the
+backbone of the bot, not an advanced extra. The flow:
+
+1. `DiscordEventBus` (`app/discord/eventBus.ts`) is a `Layer.scoped` service that
+   registers ~18 `client.on(...)` discord.js listeners. Each listener enriches
+   the raw event into a tagged `DiscordEvent` and offers it to a
+   `Queue.sliding(1024)` (drops oldest under load rather than blocking the
+   callback). The queue is exposed as a `Stream.broadcastDynamic` so every
+   pipeline gets its own independently-backpressured copy.
+2. Each of the six pipelines (`app/discord/pipelines/*`) subscribes to that
+   stream, narrows by event type, optionally gates on a feature flag, and
+   dispatches a handler — all as `Effect.Effect<void, never, RuntimeContext>`.
+3. `server.ts` forks all six with `Effect.forkDaemon` at startup.
+
+The canonical pipeline body (`app/discord/pipelines/automod.ts`):
+
+```typescript
+export const automodPipeline: Effect.Effect<void, never, RuntimeContext> =
+  Effect.gen(function* () {
+    const { stream } = yield* DiscordEventBus;
+    const spamService = yield* SpamDetectionService;
+
+    yield* stream.pipe(
+      Stream.filter(isGuildMemberMessage), // type-guard narrows the event
+      Stream.mapEffect((e) =>
+        handleMessage(e, spamService).pipe(
+          // per-event recovery: one failure must NOT kill the stream
+          Effect.catchAll((err) =>
+            logEffect("warn", "Automod", "Pipeline handler failed", {
+              ...logContext(e),
+              error: err, // tagged error passed whole, never stringified
+            }),
+          ),
+        ),
+      ),
+      Stream.runDrain,
+    );
+  });
+```
+
+Key idioms:
+
+- **`never` error channel is structural.** Every handler ends in
+  `Effect.catchAll`, so the pipeline type is `…, never, …`. A pipeline that can
+  fail would tear down on the first bad event; the type makes that impossible.
+- **`Stream.filter` with a type-guard** narrows `DiscordEvent` to the variant a
+  pipeline cares about. Use `Stream.filterEffect` when the gate is itself an
+  Effect (e.g. a feature-flag check — `deletionLogger.ts`).
+- **`filterLog`** (`app/effects/observability.ts`) filters *and* logs the drop,
+  so "not flagged" is distinguishable from "never evaluated."
+- **`Stream.tap`** for side effects that don't change the value (cache touches).
+- **`Stream.runDrain`** consumes the stream forever.
+
+To add a pipeline: write an `Effect<void, never, RuntimeContext>` with this
+shape, then fork it in `server.ts` alongside the others. The pure `enrich*`
+functions in `eventBus.ts` are extracted precisely so the interesting logic is
+unit-testable without a runtime.
+
+**See:** `app/discord/eventBus.ts`, `app/discord/pipelines/*.ts`, `app/server.ts`
+
+### Data Access: Free Effect Functions
+
+**This is the dominant pattern in the codebase.** Most data access is *not* a
+service — it's a plain exported function that returns an `Effect` and pulls the
+database out of context on its first line:
+
+```typescript
+// app/models/guilds.server.ts — the shape almost every model function takes
+export const fetchGuild = (guildId: string) =>
+  Effect.gen(function* () {
+    const db = yield* DatabaseService;
+    const row = yield* db
+      .selectFrom("guilds")
+      .selectAll()
+      .where("id", "=", guildId)
+      .pipe(/* ...takeFirst... */);
+    if (!row) return yield* Effect.fail(new NotFoundError({ resource: "guild", id: guildId }));
+    return row;
+  }).pipe(Effect.withSpan("Guild.fetchGuild", { attributes: { guildId } }));
+```
+
+These functions have requirement type `DatabaseService` (satisfied by the
+runtime). Callers compose them with `yield*` inside larger Effects, or cross a
+boundary with `await runEffect(fetchGuild(id))`. The Kysely builder is itself
+yieldable — `yield* db.selectFrom(...)` runs the query; there's no `.execute()`.
+DB failures surface automatically as `SqlError` in the error channel; domain
+"not found" is a deliberate `Effect.fail(new NotFoundError(...))`.
+
+The model files (`app/models/*.server.ts`) are the reference for this pattern.
+`subscriptions.server.ts` and `stripe.server.ts` group their free functions
+under an exported object (`SubscriptionService` / `StripeService`) for
+namespacing — note these are **plain objects of functions, not `Context.Tag`
+services** despite the name.
+
+> There are no DB transactions in the codebase — idempotency leans on SQLite
+> upserts (`onConflict`) plus in-process `Ref`/`Deferred` single-flight for
+> cross-request dedup (`app/models/userThreads.ts`). If you need atomicity
+> across multiple writes, that's new ground; design it deliberately.
+
 ### Services & Dependency Injection
 
-Services have three parts: an interface, a tag, and a live implementation.
+Reach for a `Context.Tag` service only when a free function won't do — when you
+need **lifetime-held state** (an in-memory cache, a Supervisor registration, a
+long-lived connection) or a **swappable implementation**. The nine production
+services are `DatabaseService`, `DiscordEventBus`, `MessageCacheService`,
+`SpamDetectionService`, `UserService`, `EscalationService`, `FeatureFlagService`,
+`PostHogService`, and `SupervisorService` — everything else in the model/helper
+layers is free functions.
+
+`UserService` is the one model-layer service: it captures `db` once at layer
+construction, so its methods require nothing (`R = never`) rather than
+`DatabaseService` per call.
+
+A service has three parts: an interface, a tag, and a live implementation.
 
 **1. Define the interface:**
 
@@ -306,7 +456,7 @@ export class EscalationService extends Context.Tag("EscalationService")<
 export const EscalationServiceLive = Layer.effect(
   EscalationService,
   Effect.gen(function* () {
-    const db = yield* DatabaseService;
+    const db = yield* DatabaseService; // satisfied by AppLayer — no Layer.provide
     return {
       getEscalation: (id) =>
         Effect.gen(function* () {
@@ -314,7 +464,7 @@ export const EscalationServiceLive = Layer.effect(
         }),
     };
   }),
-).pipe(Layer.provide(DatabaseLayer));
+);
 ```
 
 **4. Use in handlers:**
@@ -358,18 +508,32 @@ yield* Effect.annotateCurrentSpan({ processed: due.length });
 
 ### Promise Integration
 
-Use `Effect.tryPromise` to wrap external Promise-based APIs:
+**For Discord calls, use `tryDiscord`** — don't hand-roll `Effect.tryPromise`
+with a hand-constructed error. `tryDiscord(operation, () => promise)` wraps the
+call and classifies any rejection into a typed `DiscordError` at the boundary
+(see "Decision-oriented errors" above):
 
 ```typescript
 export const fetchGuild = (client: Client, guildId: string) =>
+  tryDiscord("fetchGuild", () => client.guilds.fetch(guildId)).pipe(
+    Effect.withSpan("discord.fetchGuild", { attributes: { guildId } }),
+  );
+```
+
+**For other Promise-based APIs** (Stripe, OAuth fetches, the PostHog SDK), use
+`Effect.tryPromise` directly and map to the relevant tagged error — e.g.
+`StripeError`, `OAuthFetchError`:
+
+```typescript
+const tryStripe = (operation: string, fn: () => Promise<T>) =>
   Effect.tryPromise({
-    try: () => client.guilds.fetch(guildId),
-    catch: (error) =>
-      new DiscordApiError({ operation: "fetchGuild", cause: error }),
+    try: fn,
+    catch: (cause) => new StripeError({ operation, cause }),
   });
 ```
 
-For cases where failure is acceptable (returns null):
+For cases where failure is acceptable (returns null), drop the typed error and
+recover (error channel becomes `never`):
 
 ```typescript
 export const fetchMemberOrNull = (guild: Guild, userId: string) =>
@@ -379,20 +543,27 @@ export const fetchMemberOrNull = (guild: Guild, userId: string) =>
   }).pipe(Effect.catchAll(() => Effect.succeed(null)));
 ```
 
-**See:** `app/effects/discordSdk.ts` for all Discord SDK wrappers
+**See:** `app/effects/discordSdk.ts` (Discord wrappers),
+`app/effects/classifyDiscordError.ts` (`tryDiscord`),
+`app/models/stripe.server.ts` (`tryStripe`)
 
 ## Writing New Code
 
 ### Checklist
 
-1. **Define errors** — add to `app/effects/errors.ts` using `Data.TaggedError`
-2. **Define service interface** — see `app/commands/escalate/service.ts` for the
-   pattern
-3. **Implement with `Effect.gen`** — see `escalationResolver.ts` for complex
-   examples
-4. **Create a Layer** — see `app/Database.ts` for Layer composition
-5. **Add observability** — use `Effect.withSpan()` on every public function, use
-   `logEffect()` for important events
+1. **Reach for a free function first** — an exported `(args) => Effect.gen(...)`
+   that does `const db = yield* DatabaseService`. Only define a `Context.Tag`
+   service if you need lifetime-held state or a swappable implementation.
+2. **Define errors** — add to `app/effects/errors.ts` using `Data.TaggedError`;
+   for Discord calls, let `tryDiscord` produce the `DiscordError` for you
+3. **Implement with `Effect.gen`** — see `guilds.server.ts` for a typical model
+   function, `escalationResolver.ts` for complex orchestration
+4. **If it's an event reaction, write a pipeline** — not an ad-hoc
+   `client.on(...)`; add a `Stream` pipeline and fork it in `server.ts`
+5. **Add observability** — `Effect.withSpan()` on every public function;
+   `logEffect()` (with the tagged error passed whole) for important events
+6. **A new service?** — then also define the interface + tag + Layer and merge
+   it into `AppLayer` (`app/AppRuntime.ts`)
 
 ### Template: New Handler
 
@@ -525,15 +696,23 @@ const add = (a: number, b: number): number => a + b;
 
 These are the best files to study when learning how Effect is used here:
 
+- **`app/AppRuntime.ts`** — the single `ManagedRuntime`, `AppLayer` composition,
+  and the `runEffect` boundary
+- **`app/discord/eventBus.ts`** + **`app/discord/pipelines/automod.ts`** — the
+  Stream-based event-pipeline architecture (queue → broadcast → filter →
+  mapEffect → runDrain)
+- **`app/models/guilds.server.ts`** — the dominant free-Effect-function data
+  pattern (`yield* DatabaseService`, yieldable Kysely, `withSpan`)
 - **`app/commands/escalate/escalationResolver.ts`** — parallel operations,
-  sequential processing, error recovery, span annotations
-- **`app/effects/discordSdk.ts`** — Promise wrapping, error mapping,
-  null-safe variants
-- **`app/commands/escalate/service.ts`** — full service pattern with interface,
-  tag, Layer, and dependency injection
+  sequential rate-limited processing, error recovery, span annotations
+- **`app/effects/discordSdk.ts`** + **`app/effects/classifyDiscordError.ts`** —
+  `tryDiscord` Promise wrapping and boundary error classification
+- **`app/commands/escalate/service.ts`** — the full `Context.Tag` service pattern
+  (interface, tag, Layer) for the cases that need one
 - **`app/Database.ts`** — Layer composition, merging independent layers
-- **`app/effects/observability.ts`** — `logEffect` and `tapLog` utilities
-- **`app/effects/errors.ts`** — `Data.TaggedError` definitions
+- **`app/effects/observability.ts`** — `logEffect`, `tapLog`, `filterLog`
+- **`app/effects/errors.ts`** + **`app/effects/errorHandling.ts`** —
+  `Data.TaggedError` taxonomy and the `withRetry`/`toUserResponse` helpers
 
 ## Unit Testing
 
@@ -641,5 +820,7 @@ unabridged versions of the documentation are
 [indexed here](https://effect.website/llms.txt); you can retrieve a URL with
 more detailed information from there.
 
-For patterns not used in this codebase (Streams, etc.), see
-[EFFECT_ADVANCED.md](./EFFECT_ADVANCED.md).
+For Effect patterns we don't use yet (Sink, the Config module, callback→Effect
+adapters), see [EFFECT_ADVANCED.md](./EFFECT_ADVANCED.md). Streams, Queues,
+Schedule, Ref, and Fiber supervision are all core here and documented above or
+in [EFFECT_REFERENCE.md](./EFFECT_REFERENCE.md).

--- a/notes/EFFECT_ADVANCED.md
+++ b/notes/EFFECT_ADVANCED.md
@@ -1,10 +1,29 @@
 # Effect Advanced Patterns
 
-Some of these patterns are now used in the codebase (Streams, Queues) while
-others remain documented for future reference. For patterns we actually use, see
-[EFFECT.md](./EFFECT.md) and [EFFECT_REFERENCE.md](./EFFECT_REFERENCE.md).
+Deeper reference for constructs beyond the day-to-day. Each section is tagged:
+
+- **🟢 Core** — load-bearing in the codebase; the real usage is documented in
+  [EFFECT.md](./EFFECT.md) / [EFFECT_REFERENCE.md](./EFFECT_REFERENCE.md) and this
+  section is just extra background.
+- **🟡 Used** — appears in a few places.
+- **⚪ Not used yet** — documented for when we need it; no current call sites.
+
+| Pattern | Status | Where it lives |
+| --- | --- | --- |
+| Stream processing | 🟢 Core | `app/discord/eventBus.ts`, `app/discord/pipelines/*` |
+| Queues | 🟢 Core | the broadcast queue in `eventBus.ts` |
+| Schedule combinators | 🟡 Used | `withRetry` (`errorHandling.ts`), 6h integrity repeat (`Database.ts`) |
+| Ref | 🟡 Used | single-flight dedup (`models/userThreads.ts`), in-memory caches |
+| Fiber supervision | 🟡 Used | `forkDaemon` pipelines + `SupervisorService` (`supervisor.ts`) |
+| Sink | ⚪ Not used yet | — |
+| Config module | ⚪ Not used yet | env read via `app/helpers/env.server.ts` instead |
+| `acquireUseRelease` | ⚪ Not used yet | `Layer.scoped` + `acquireRelease` used at the Layer level instead |
 
 ## Stream Processing
+
+🟢 **Core.** This is the bot's event-processing backbone. The walkthrough below
+is background; for the actual pipeline pattern you should copy, see EFFECT.md →
+"Event Pipelines (Streams)".
 
 For large or potentially infinite data pipelines:
 
@@ -50,6 +69,10 @@ to process events. See the design spec at
 
 ## Sink Patterns
 
+⚪ **Not used yet.** Our pipelines all terminate in `Stream.runDrain` (process
+forever, discard output). Custom `Sink` accumulation would only matter if we
+needed to collect/fold a finite stream — documented here for that day.
+
 Custom accumulation logic for Streams:
 
 ```typescript
@@ -68,7 +91,10 @@ const customSink = Sink.fold(
 
 ## Schedule Combinators
 
-For retry and repeat logic beyond simple patterns:
+🟡 **Used.** Our retry policy `withRetry` (`app/effects/errorHandling.ts`) is
+`Schedule.exponential("200 millis", 2) |> jittered |> compose(recurs(3))`, and
+`Database.ts` repeats the integrity check on `Schedule.fixed("6 hours")`. More
+combinators, for reference:
 
 | Pattern             | Schedule                             | Use Case                    |
 | ------------------- | ------------------------------------ | --------------------------- |
@@ -92,6 +118,10 @@ effect.pipe(Effect.retry(policy));
 
 ## Config Module
 
+⚪ **Not used yet.** Environment access currently goes through
+`app/helpers/env.server.ts`, not Effect's `Config`. If we want validated,
+typed, redacted config wired into the layer graph, this is the path.
+
 Type-safe configuration from environment variables:
 
 ```typescript
@@ -105,6 +135,12 @@ const config = yield* Config.struct({
 ```
 
 ## Resource Management
+
+⚪ **Not used at the effect level.** We manage resource lifetimes at the **Layer**
+boundary instead — `Layer.scoped` + `Effect.acquireRelease` (e.g.
+`PostHogService` flush-on-shutdown in `app/effects/posthog.ts`, the SQLite client
+in `app/Database.ts`). Reach for `acquireUseRelease` only for a resource scoped
+to a single operation rather than the app lifetime.
 
 Safe acquire/use/release pattern:
 
@@ -121,7 +157,7 @@ const managed = Effect.acquireUseRelease(
 
 ## Queue Patterns
 
-Bounded and unbounded queues for producer/consumer patterns:
+🟢 **Core.** Bounded and unbounded queues for producer/consumer patterns:
 
 ```typescript
 import { Queue } from "effect";
@@ -144,7 +180,10 @@ Effect without blocking.
 
 ## Ref / TRef State Management
 
-Mutable references for state within Effect:
+🟡 **Used.** Mutable references for state within Effect. In the codebase, `Ref`
++ `Deferred` implement cross-request single-flight (so two concurrent requests
+for the same thread don't both create it) in `app/models/userThreads.ts` and
+`app/models/deletionLogThreads.ts`.
 
 ```typescript
 import { Ref } from "effect";
@@ -154,22 +193,38 @@ yield* Ref.update(counter, (n) => n + 1);
 const value = yield* Ref.get(counter);
 ```
 
+> Note: the in-memory caches (`guildCache.server.ts`, the spam honeypot cache)
+> currently use a plain `TTLCache`/`Map` read inside the Effect, **not** `Ref`.
+> That's a known inconsistency, not the recommended target — prefer `Ref` (or
+> `SynchronizedRef` for compute-on-miss) for new mutable state so access goes
+> through the Effect runtime.
+
 ## Fiber Supervision
 
-For advanced concurrent execution control:
+🟡 **Used.** The six event pipelines are `Effect.forkDaemon`ed at startup and
+`Fiber.interrupt`ed + re-forked on HMR (`app/server.ts`); `SupervisorService`
+(`app/effects/supervisor.ts`) registers an Effect `Supervisor` so background job
+fibers are observable. Note the distinction: **`forkDaemon`** (not `fork`) for
+anything that must outlive the fiber that spawned it — see EFFECT.md →
+"Runtime & Boundaries".
 
 ```typescript
-// Fork a background task
+// Fork a background task tied to the current scope
 const fiber = yield* Effect.fork(backgroundTask);
 
-// Wait for it later
-const result = yield* Fiber.join(fiber);
+// Fork a daemon that outlives the spawning fiber (what the pipelines use)
+const daemon = yield* Effect.forkDaemon(longLivedTask);
 
-// Or interrupt it
-yield* Fiber.interrupt(fiber);
+// Wait for it later, or interrupt it
+const result = yield* Fiber.join(fiber);
+yield* Fiber.interrupt(daemon);
 ```
 
-## Migration: Callback-based Code
+## Adapting Callback-based APIs
+
+⚪ **Rare.** The Promise→Effect migration is essentially complete; most external
+APIs we touch are Promise-based (use `Effect.tryPromise` / `tryDiscord`). Reach
+for `Effect.async` only for a genuinely callback-style API (no Promise):
 
 ```typescript
 // Convert callback-based APIs to Effect
@@ -182,7 +237,13 @@ const readFile = (path: string): Effect.Effect<string, FileError, never> =>
   });
 ```
 
-## Migration: Class-based Services
+## Class-based Service → Effect Service
+
+🟡 This is exactly how `UserService` (`app/models/user.server.ts`) is built — it
+captures `db` once at layer construction, so its methods require nothing
+(`R = never`). It's the one model-layer `Context.Tag`; the rest of the models are
+free functions (see EFFECT.md → "Data Access"). Keep this shape in mind when a
+class needs to become a service:
 
 ```typescript
 // Before: class-based

--- a/notes/EFFECT_REFERENCE.md
+++ b/notes/EFFECT_REFERENCE.md
@@ -1,8 +1,10 @@
 # Effect Quick Reference
 
 Quick lookup for patterns used in this codebase. For onboarding and
-explanations, see [EFFECT.md](./EFFECT.md). For patterns not used here
-(Streams, Schedules, etc.), see [EFFECT_ADVANCED.md](./EFFECT_ADVANCED.md).
+explanations — including the runtime boundary and the Stream-based event
+pipelines that form the core architecture — see [EFFECT.md](./EFFECT.md). For
+patterns we don't use yet (Sink, Config module, callback adapters), see
+[EFFECT_ADVANCED.md](./EFFECT_ADVANCED.md).
 
 ## Error Handling
 
@@ -23,19 +25,47 @@ export class MyError extends Data.TaggedError("MyError")<{
 
 ### Our Error Types
 
-| Error                      | Tag                        | Used For                           |
-| -------------------------- | -------------------------- | ---------------------------------- |
-| `NotFoundError`            | `"NotFoundError"`          | Missing DB records                 |
-| `NotAuthorizedError`       | `"NotAuthorizedError"`     | Permission failures                |
-| `DiscordApiError`          | `"DiscordApiError"`        | Discord SDK call failures          |
-| `StripeApiError`           | `"StripeApiError"`         | Stripe SDK call failures           |
-| `ValidationError`          | `"ValidationError"`        | Input validation failures          |
-| `ConfigError`              | `"ConfigError"`            | Missing/invalid configuration      |
-| `DatabaseCorruptionError`  | `"DatabaseCorruptionError"`| Integrity check failures           |
-| `AlreadyResolvedError`     | `"AlreadyResolvedError"`   | Double-resolution attempts         |
-| `NoLeaderError`            | `"NoLeaderError"`          | Vote tallying with no clear winner |
-| `ResolutionExecutionError` | `"ResolutionExecutionError"`| Mod action execution failures     |
-| `SqlError`                 | `"SqlError"`               | Database query failures            |
+**Domain & infrastructure errors** (`app/effects/errors.ts`). `_tag` always
+equals the class name.
+
+| Error                      | Fields                                              | Used For                           |
+| -------------------------- | -------------------------------------------------- | ---------------------------------- |
+| `NotFoundError`            | `resource, id`                                      | Missing DB records                 |
+| `NotAuthorizedError`       | `operation, userId, requiredRole?`                  | Permission failures                |
+| `ValidationError`          | `field, message`                                    | Input validation failures          |
+| `ConfigError`              | `key, message`                                      | Missing/invalid configuration      |
+| `DatabaseCorruptionError`  | `errors`                                            | Integrity check failures           |
+| `AlreadyResolvedError`     | `escalationId, resolvedAt`                          | Double-resolution attempts         |
+| `NoLeaderError`            | `escalationId, reason, tiedResolutions?`            | Vote tallying with no clear winner |
+| `ResolutionExecutionError` | `escalationId, resolution, cause`                   | Mod action execution failures      |
+| `FeatureDisabledError`     | `feature, guildId, reason`                          | Hard feature-flag gate (`guardFeature`) |
+| `SubscriptionNotFoundError`| `guildId`                                           | Missing guild subscription         |
+| `StripeError`              | `operation, cause`                                  | Stripe SDK call failures           |
+| `OAuthFetchError`          | `operation, status?, cause`                         | Discord OAuth fetch failures       |
+| `SqlError`                 | (re-exported from `@effect/sql`)                    | Database query failures            |
+
+**Discord transport taxonomy** — named by the *decision* they drive, not the
+HTTP family. The first six are the `DiscordError` union, produced only by
+`classifyDiscordError` (`app/effects/classifyDiscordError.ts`). See EFFECT.md →
+"Decision-oriented errors" for the full rationale.
+
+| Error                    | Retriable? | Fields                                       |
+| ------------------------ | ---------- | -------------------------------------------- |
+| `RateLimitError`         | ✅ retriable | `source, operation, retryAfterMs, cause`    |
+| `TransientError`         | ✅ retriable | `source, operation, status?, cause`         |
+| `ForbiddenError`         | ❌          | `source, operation, cause`                   |
+| `ResourceMissingError`   | ❌          | `source, operation, cause`                   |
+| `ClientError`            | ❌          | `source, operation, status, code?, cause`    |
+| `ServerError`            | ❌          | `source, operation, status, cause` (declared; no classifier branch emits it yet) |
+| `ServiceUnavailableError`| —          | `source, lastCause` — escalation product of `escalateExhausted`, **not** in `DiscordError` |
+
+`AppError` (`errors.ts`) is the app-wide union — `DiscordError` + all the domain
+errors above + `SqlError` + `Cause.UnknownException` — used for `toUserResponse`
+exhaustiveness.
+
+> **Gone:** `DiscordApiError` and `StripeApiError` no longer exist. Discord
+> failures are now the `DiscordError` union (classified at the boundary); Stripe
+> failures are `StripeError`.
 
 ### catchAll vs catchTag
 
@@ -50,8 +80,11 @@ effect.pipe(
   Effect.catchTag("NotFoundError", (e) =>
     Effect.succeed(defaultValue),
   ),
+  // Pass the whole tagged error as `error` — never e.message / String(e).
+  // The custom logger serializes _tag, fields, and cause; stringifying drops
+  // all of it (enforced by the local/no-error-string-cast lint rule).
   Effect.catchTag("SqlError", (e) =>
-    logEffect("error", "Handler", "DB error", { error: e.message }),
+    logEffect("error", "Handler", "DB error", { error: e }),
   ),
 );
 ```
@@ -65,7 +98,7 @@ yield* Effect.forEach(items, (item) =>
     Effect.catchAll((error) =>
       logEffect("error", "Handler", "Item failed", {
         itemId: item.id,
-        error: String(error),
+        error, // pass the tagged error through — not String(error)
       }),
     ),
   ),
@@ -106,9 +139,18 @@ const results = yield* Effect.forEach(items, (item) =>
 
 ## Services
 
+Most code does **not** define a service. The default for data access is a free
+`Effect`-returning function that does `const db = yield* DatabaseService` — see
+EFFECT.md → "Data Access: Free Effect Functions". Reach for a `Context.Tag`
+service only when you need lifetime-held state or a swappable implementation. The
+nine production Tag services are: `DatabaseService`, `DiscordEventBus`,
+`MessageCacheService`, `SpamDetectionService`, `UserService`, `EscalationService`,
+`FeatureFlagService`, `PostHogService`, `SupervisorService`.
+
 ### Context.Tag Class Pattern
 
-This is the current pattern — use this, not `Context.GenericTag`:
+When you do define a service, use the class-`Tag` pattern — not
+`Context.GenericTag` (which appears only in test doubles):
 
 ```typescript
 export class MyService extends Context.Tag("MyService")<
@@ -119,20 +161,29 @@ export class MyService extends Context.Tag("MyService")<
 
 ### Layer.effect Implementation
 
+Acquire dependencies with `yield* Dependency` inside the constructor. If the
+dependency (e.g. `DatabaseService`) is already in `AppLayer`, you don't chain
+`Layer.provide` — the runtime supplies it. Add `Layer.provide(...)` only to
+close a requirement that `AppLayer` does *not* satisfy.
+
 ```typescript
 export const MyServiceLive = Layer.effect(
   MyService,
   Effect.gen(function* () {
-    const dep = yield* SomeDependency;
+    const db = yield* DatabaseService; // satisfied by AppLayer
     return {
       method: (arg) =>
         Effect.gen(function* () {
-          // use dep
+          // use db
         }).pipe(Effect.withSpan("method")),
     };
   }),
-).pipe(Layer.provide(DependencyLayer));
+);
 ```
+
+`Layer.scoped` (acquire/release finalizers — `PostHogService`,
+`FeatureFlagService`, `DiscordEventBus`) and `Layer.unwrapEffect`
+(`SupervisorService`) are the other two construction shapes in use.
 
 ### Layer Composition
 
@@ -140,13 +191,15 @@ export const MyServiceLive = Layer.effect(
 // Merge independent layers
 const AppLayer = Layer.mergeAll(LayerA, LayerB, LayerC);
 
-// Chain dependent layers
+// Chain a dependency a layer needs but the merge doesn't provide
 const ServiceLayer = Layer.effect(MyService, impl).pipe(
   Layer.provide(DependencyLayer),
 );
 ```
 
-**Files:** `app/Database.ts:33-38` (mergeAll), `app/commands/escalate/service.ts:429` (provide)
+**Files:** `app/AppRuntime.ts` (`AppLayer` via `Layer.mergeAll`),
+`app/Database.ts` (`DatabaseLayer`), `app/effects/supervisor.ts`
+(`Layer.unwrapEffect`)
 
 ## Observability
 
@@ -199,50 +252,71 @@ yield* Effect.annotateCurrentSpan({ processed: items.length });
 
 ## Discord SDK Helpers
 
-Wrappers for Discord.js operations that provide consistent error handling.
+Wrappers for Discord.js operations. Each routes through `tryDiscord` (so
+rejections become a classified `DiscordError`) and adds an
+`Effect.withSpan("discord.<op>")`. The `*OrNull` / `*Safe` variants instead
+swallow failures (error channel `never`) — use them only where a missing target
+is genuinely fine.
 
 ### Available Functions
 
-| Function                | Returns                            | Error         |
-| ----------------------- | ---------------------------------- | ------------- |
-| `fetchGuild`            | `Guild`                            | `DiscordApiError` |
-| `fetchChannel`          | `Channel \| null`                  | `DiscordApiError` |
-| `fetchChannelFromClient`| `T` (generic)                      | `DiscordApiError` |
-| `fetchMember`           | `GuildMember`                      | `DiscordApiError` |
-| `fetchMemberOrNull`     | `GuildMember \| null`              | never         |
-| `fetchUser`             | `User`                             | `DiscordApiError` |
-| `fetchUserOrNull`       | `User \| null`                     | never         |
-| `fetchMessage`          | `Message`                          | `DiscordApiError` |
-| `sendMessage`           | `Message`                          | `DiscordApiError` |
-| `editMessage`           | `Message`                          | `DiscordApiError` |
-| `forwardMessageSafe`    | `void`                             | never (logs)  |
-| `replyAndForwardSafe`   | `Message \| null`                  | never (logs)  |
-| `resolveMessagePartial` | `Message`                          | `DiscordApiError` |
+| Function                  | Returns               | Error         |
+| ------------------------- | --------------------- | ------------- |
+| `createChannel`           | created channel       | `DiscordError`|
+| `fetchGuild`              | `Guild`               | `DiscordError`|
+| `fetchChannel`            | channel               | `DiscordError`|
+| `fetchChannelFromClient`  | `T` (generic)         | `DiscordError`|
+| `fetchMember`             | `GuildMember`         | `DiscordError`|
+| `fetchMemberOrNull`       | `GuildMember \| null` | never         |
+| `fetchUser`               | `User`                | `DiscordError`|
+| `fetchUserOrNull`         | `User \| null`        | never         |
+| `fetchMessage`            | `Message`             | `DiscordError`|
+| `deleteMessage`           | delete result         | `DiscordError`|
+| `sendMessage`             | `Message`             | `DiscordError`|
+| `editMessage`             | `Message`             | `DiscordError`|
+| `messageReply`            | reply `Message`       | `DiscordError`|
+| `resolveMessagePartial`   | `Message`             | `DiscordError`|
+| `softbanMember`           | `void`                | `DiscordError`|
+| `interactionReply`        | reply result          | `DiscordError`|
+| `interactionDeferReply`   | defer result          | `DiscordError`|
+| `interactionEditReply`    | edited reply          | `DiscordError`|
+| `interactionFollowUp`     | follow-up `Message`   | `DiscordError`|
+| `interactionUpdate`       | update result         | `DiscordError`|
+| `interactionDeferUpdate`  | defer-update result   | `DiscordError`|
+| `forwardMessageSafe`      | `void`                | never (logs)  |
+| `replyAndForwardSafe`     | `Message \| null`     | never (logs)  |
 
 ### Pattern: Adding a New Helper
 
-Follow the existing pattern — wrap with `tryPromise`, map error to `DiscordApiError`:
+Wrap the SDK call with `tryDiscord(operation, () => promise)` and add a span —
+`tryDiscord` does the rejection→`DiscordError` classification for you, so you
+never hand-construct a Discord error:
 
 ```typescript
+import { tryDiscord } from "#~/effects/classifyDiscordError";
+
 export const myNewHelper = (guild: Guild, arg: string) =>
-  Effect.tryPromise({
-    try: () => guild.someMethod(arg),
-    catch: (error) =>
-      new DiscordApiError({ operation: "myNewHelper", cause: error }),
-  });
+  tryDiscord("myNewHelper", () => guild.someMethod(arg)).pipe(
+    Effect.withSpan("discord.myNewHelper", { attributes: { arg } }),
+  );
 ```
 
-For null-safe variants, catch and return null:
+For null-safe variants, drop to raw `tryPromise` and recover to `null` (error
+channel becomes `never`):
 
 ```typescript
 export const myNewHelperOrNull = (guild: Guild, arg: string) =>
   Effect.tryPromise({
     try: () => guild.someMethod(arg),
     catch: () => null,
-  }).pipe(Effect.catchAll(() => Effect.succeed(null)));
+  }).pipe(
+    Effect.catchAll(() => Effect.succeed(null)),
+    Effect.withSpan("discord.myNewHelperOrNull"),
+  );
 ```
 
-**File:** `app/effects/discordSdk.ts`
+**File:** `app/effects/discordSdk.ts` (wrappers),
+`app/effects/classifyDiscordError.ts` (`tryDiscord`)
 
 ## Database Patterns
 
@@ -286,17 +360,28 @@ yield* db
 ### Layer Setup
 
 ```typescript
-// Base SQLite client
-const SqliteLive = SqliteClient.layer({ filename: databaseUrl });
+// Base SQLite client (WAL on by default). busy_timeout pragma applied on
+// acquire; Reactivity is a required dependency of @effect/sql-kysely.
+const SqliteLive = Layer.scoped(
+  SqlClient.SqlClient,
+  SqliteClient.make({ filename: databaseUrl }).pipe(
+    Effect.tap((sql) => sql.unsafe("PRAGMA busy_timeout = 5000")),
+  ),
+).pipe(Layer.provide(Reactivity.layer));
 
-// Kysely service on top of SQLite
+// Kysely builder, exposed as DatabaseService, on top of the SQLite client
 const KyselyLive = Layer.effect(DatabaseService, Sqlite.make<DB>()).pipe(
   Layer.provide(SqliteLive),
 );
 
-// Combined layer provides both
+// Combined layer exposes BOTH the raw SqlClient (for sql.unsafe / PRAGMA /
+// integrity checks) and the Kysely DatabaseService
 export const DatabaseLayer = Layer.mergeAll(SqliteLive, KyselyLive);
 ```
+
+`DatabaseLayer` is merged into `AppLayer` in `app/AppRuntime.ts`, so effects
+that `yield* DatabaseService` need no per-call `Layer.provide` — the
+`ManagedRuntime` already supplies it (see EFFECT.md → "Runtime & Boundaries").
 
 **File:** `app/Database.ts`
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,5 +10,10 @@ export default defineConfig(({ isSsrBuild }) => ({
     rollupOptions: isSsrBuild ? { input: "./app/server.ts" } : undefined,
   },
   server: { port: 3000, origin: "localhost:3000" },
+  // Force a single React instance in the SSR dev bundle. Without this, Vite's
+  // dev resolver can pull in duplicate copies of React across the SSR graph,
+  // which trips React's DEV-only child-key validation with a `_store` proxy
+  // invariant error (#394: GET /app/admin/jobs 500 in dev only).
+  resolve: { dedupe: ["react", "react-dom"] },
   plugins: [tailwindcss(), reactRouter()],
 }));


### PR DESCRIPTION
Post-migration polish on top of #391 (already merged to `main`). Six self-contained commits.

## What's here
- **Promise→Effect cleanup** (`49f3413`) — convert the remaining bare `Effect.tryPromise` Discord calls to classified `tryDiscord` (spans + typed `DiscordError`), make `initSetupForm` return an Effect (drop the deprecated `runEffect`/`runTakeFirst` bridges), and remove the `createJob`/`isFeatureEnabled` Effect→Promise→Effect round-trips in `setupAll`.
- **Error granularity** (`5bc8dab`) — narrow 5 over-broad `catchAll` sites to `catchTag` so a real `SqlError` surfaces (logged at the existing boundary) instead of masquerading as a default value. Also fixes escalate enforcement: a transient Discord failure during a community-voted ban/kick/timeout was misread as "member left, skip"; now only a genuine 404 (`ResourceMissingError`) skips, and other failures fold into `ResolutionExecutionError` so the escalation stays unresolved and retries on the next due-check pass.
- **Graceful shutdown** (`68fc8e6`) — run AppLayer finalizers on SIGTERM/SIGINT (previously `process.exit(0)` ran before `dispose()`, skipping finalizers).
- **Docs** (`31c7644`) — `EFFECT.md` refreshed to match post-migration code.
- **Fixes #393** (`595737a`) — dedupe parallel Discord token refresh: single-flight keyed on the refresh token so two parallel `/app` loaders share one POST, plus a re-read of the freshly-persisted token before redirecting. Removes the spurious `/login` bounce on token expiry. Path stays async by design (a thrown `redirect()` can't go through `runEffect`).
- **Fixes #394** (`6954fe7`) — `resolve.dedupe` for `react`/`react-dom` in `vite.config.ts` fixes the dev-only `/app/admin/jobs` 500 caused by React module duplication tripping dev child-key validation.

## Verification
- Full gate green: **typecheck**, **lint** (0 warnings), **504/504 tests** (+8 new regression tests).
- ⚠️ **Shipped on tests, not live-verified** (deliberate): #394's dev-500 needs a `npm run dev` → `/app/admin/jobs` confirm, and #393's live double-loader behavior needs a forced-token-expiry repro. The committed tests cover the dedupe logic and loader data-shape, not the dev-bundle/runtime symptoms. If dev verification fails for #394, the documented fallback is inlining the `JobRow` `<tr>` in `admin.jobs.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)