### PR TITLE
fix(billing): treat Stripe resource_missing as success when cancelling

### DIFF
--- a/app/models/stripe.server.test.ts
+++ b/app/models/stripe.server.test.ts
@@ -112,6 +112,20 @@ describe("StripeService recover-as-default branches", () => {
     if (Exit.isSuccess(exit)) expect(exit.value).toBe(true);
   });
 
+  it("cancelSubscription treats an already-gone subscription (resource_missing) as success", async () => {
+    // Stripe returns code "resource_missing" (HTTP 404) when the stored
+    // subscription id no longer exists — already cancelled or deleted.
+    // Cancelling is idempotent, so this must succeed, not surface CANCEL_FAILED.
+    subscriptionsCancel.mockRejectedValueOnce(
+      Object.assign(new Error("No such subscription: 'sub_1'"), {
+        code: "resource_missing",
+      }),
+    );
+    const exit = await run(StripeService.cancelSubscription("sub_1"));
+    expect(Exit.isSuccess(exit)).toBe(true);
+    if (Exit.isSuccess(exit)) expect(exit.value).toBe(true);
+  });
+
   it("listInvoices returns [] on SDK error", async () => {
     invoicesList.mockRejectedValueOnce(new Error("boom"));
     const exit = await run(StripeService.listInvoices("cus_1"));

--- a/app/models/stripe.server.ts
+++ b/app/models/stripe.server.ts
@@ -22,6 +22,15 @@ const tryStripe = <A>(operation: string, fn: () => Promise<A>) =>
     },
   });
 
+// Stripe reports code "resource_missing" (HTTP 404) when an id no longer exists
+// in its system. Structural check (no instanceof / no string-cast) so we can
+// branch on the raw SDK error carried in StripeError.cause.
+const isStripeResourceMissing = (cause: unknown): boolean =>
+  typeof cause === "object" &&
+  cause !== null &&
+  "code" in cause &&
+  (cause as { code?: unknown }).code === "resource_missing";
+
 const createCheckoutSession = (
   variant: string,
   coupon: string,
@@ -231,32 +240,32 @@ const cancelSubscription = (
       subscriptionId,
     });
 
-    const cancelled = yield* tryStripe("cancelSubscription", () =>
+    return yield* tryStripe("cancelSubscription", () =>
       stripe.subscriptions.cancel(subscriptionId),
     ).pipe(
-      Effect.tapError((error) =>
-        logEffect("error", "Stripe", "Failed to cancel subscription", {
+      Effect.flatMap(() =>
+        logEffect("info", "Stripe", "Subscription cancelled successfully", {
           subscriptionId,
-          error,
-        }),
+        }).pipe(Effect.as(true)),
       ),
-      Effect.as(true),
-      // Prior behavior: errors recover as false.
-      Effect.catchTag("StripeError", () => Effect.succeed(false)),
+      Effect.catchTag("StripeError", (error) =>
+        // A stale/already-removed subscription id (resource_missing, 404) means
+        // there is nothing left to cancel — cancellation is idempotent, so treat
+        // it as success rather than surfacing CANCEL_FAILED to the user.
+        isStripeResourceMissing(error.cause)
+          ? logEffect(
+              "info",
+              "Stripe",
+              "Subscription already cancelled or no longer exists; treating as success",
+              { subscriptionId },
+            ).pipe(Effect.as(true))
+          : // Prior behavior: other errors recover as false.
+            logEffect("error", "Stripe", "Failed to cancel subscription", {
+              subscriptionId,
+              error,
+            }).pipe(Effect.as(false)),
+      ),
     );
-
-    if (cancelled) {
-      yield* logEffect(
-        "info",
-        "Stripe",
-        "Subscription cancelled successfully",
-        {
-          subscriptionId,
-        },
-      );
-    }
-
-    return cancelled;
   }).pipe(
     Effect.withSpan("Stripe.cancelSubscription", {
       attributes: { subscriptionId },


### PR DESCRIPTION
## What

`cancelSubscription` recovered **all** `StripeError`s to `false`, so a stale or already-removed `stripe_subscription_id` surfaced **"Failed to cancel subscription, please contact support"** (`CANCEL_FAILED`) to the user. Stripe returns code `resource_missing` (HTTP 404) when the subscription no longer exists. Cancellation is idempotent, so this commit treats `resource_missing` as **success** (the caller then marks the subscription cancelled). All other Stripe errors still recover to `false` as before.

Detection is a structural check on the SDK error's `code` (`isStripeResourceMissing`) — no `instanceof`, no string-casting, consistent with the error-taxonomy conventions.

## Why

Found during the UAT QA pass of `rc/v2026.26` (see PR #392 QA report): the comped test guild carries a placeholder subscription id (`sub_test_e2e`) that doesn't exist in Stripe, so cancel 404'd into a dead-end "contact support" error. The placeholder is test-data-specific, but **any guild with a stale stored subscription id hits the same path**. Pre-existing since #195/#204 — not a regression in this RC.

## Test

- RED: new test `cancelSubscription treats an already-gone subscription (resource_missing) as success` failed (`expected false to be true`) against the old code.
- GREEN: full suite passes — **505 tests, 48 files**. ESLint clean.

Closes #400.