### PR TITLE
fix(automod): resolve rule name in action log + element-level keyword diff

### DIFF
--- a/app/commands/report/automodRuleLog.test.ts
+++ b/app/commands/report/automodRuleLog.test.ts
@@ -1,0 +1,124 @@
+import type { AutoModerationRule } from "discord.js";
+
+import { buildUpdateDiff } from "./automodRuleLog";
+
+// Minimal stub builder — buildUpdateDiff only reads name, enabled,
+// triggerMetadata, actions, exemptRoles.size, exemptChannels.size.
+const makeRule = (overrides: {
+  name?: string;
+  enabled?: boolean;
+  keywordFilter?: string[];
+  regexPatterns?: string[];
+  allowList?: string[];
+  actionTypes?: number[];
+  exemptRoles?: number;
+  exemptChannels?: number;
+}): AutoModerationRule =>
+  ({
+    name: overrides.name ?? "rule",
+    enabled: overrides.enabled ?? true,
+    triggerMetadata: {
+      keywordFilter: overrides.keywordFilter ?? [],
+      regexPatterns: overrides.regexPatterns ?? [],
+      allowList: overrides.allowList ?? [],
+    },
+    actions: (overrides.actionTypes ?? []).map((type) => ({ type })),
+    exemptRoles: { size: overrides.exemptRoles ?? 0 },
+    exemptChannels: { size: overrides.exemptChannels ?? 0 },
+  }) as unknown as AutoModerationRule;
+
+test("returns generic message when old rule is unavailable", () => {
+  expect(buildUpdateDiff(null, makeRule({}))).toBe("configuration changed");
+});
+
+test("same-count keyword swap surfaces the actual changed keywords", () => {
+  const oldRule = makeRule({ keywordFilter: ["spam", "scam"] });
+  const newRule = makeRule({ keywordFilter: ["spam", "phish"] });
+
+  const result = buildUpdateDiff(oldRule, newRule);
+
+  // Regression for #398: a same-count swap must NOT fall through to the
+  // "minor configuration change" fallback.
+  expect(result).not.toContain("minor configuration change");
+  expect(result).toContain("keywords:");
+  expect(result).toContain("`phish`"); // added
+  expect(result).toContain("`scam`"); // removed
+  expect(result).not.toContain("`spam`"); // unchanged, not listed
+});
+
+test("added-only keywords show a + segment", () => {
+  const result = buildUpdateDiff(
+    makeRule({ keywordFilter: ["a"] }),
+    makeRule({ keywordFilter: ["a", "b", "c"] }),
+  );
+  expect(result).toContain("keywords:");
+  expect(result).toContain("+");
+  expect(result).toContain("`b`");
+  expect(result).toContain("`c`");
+});
+
+test("removed-only keywords show a − segment", () => {
+  const result = buildUpdateDiff(
+    makeRule({ keywordFilter: ["a", "b"] }),
+    makeRule({ keywordFilter: ["a"] }),
+  );
+  expect(result).toContain("keywords:");
+  expect(result).toContain("−");
+  expect(result).toContain("`b`");
+});
+
+test("regex pattern swap is surfaced element-by-element", () => {
+  const result = buildUpdateDiff(
+    makeRule({ regexPatterns: ["foo.*"] }),
+    makeRule({ regexPatterns: ["bar.*"] }),
+  );
+  expect(result).not.toContain("minor configuration change");
+  expect(result).toContain("regex:");
+  expect(result).toContain("`bar.*`");
+  expect(result).toContain("`foo.*`");
+});
+
+test("action/response type changes are surfaced", () => {
+  // 1 = BlockMessage, 3 = Timeout (AutoModerationActionType values)
+  const result = buildUpdateDiff(
+    makeRule({ actionTypes: [1] }),
+    makeRule({ actionTypes: [1, 3] }),
+  );
+  expect(result).toContain("actions:");
+  expect(result).toContain("`3`");
+});
+
+test("long keyword lists are truncated with an overflow count", () => {
+  const result = buildUpdateDiff(
+    makeRule({ keywordFilter: [] }),
+    makeRule({ keywordFilter: ["1", "2", "3", "4", "5", "6", "7"] }),
+  );
+  expect(result).toContain("more");
+});
+
+test("name and enabled changes still render", () => {
+  const result = buildUpdateDiff(
+    makeRule({ name: "old", enabled: true }),
+    makeRule({ name: "new", enabled: false }),
+  );
+  expect(result).toContain("**old** → **new**");
+  expect(result).toContain("enabled: true → false");
+});
+
+test("falls back to minor configuration change when nothing comparable changed", () => {
+  // Exempt-role count changes can't be expressed element-wise here, but an
+  // identical rule must still produce the fallback.
+  const rule = makeRule({ keywordFilter: ["x"] });
+  expect(buildUpdateDiff(rule, makeRule({ keywordFilter: ["x"] }))).toBe(
+    "minor configuration change",
+  );
+});
+
+test("exempt role/channel count deltas still render", () => {
+  const result = buildUpdateDiff(
+    makeRule({ exemptRoles: 1, exemptChannels: 0 }),
+    makeRule({ exemptRoles: 2, exemptChannels: 1 }),
+  );
+  expect(result).toContain("+1 exempt role");
+  expect(result).toContain("+1 exempt channel");
+});

--- a/app/commands/report/automodRuleLog.ts
+++ b/app/commands/report/automodRuleLog.ts
@@ -41,7 +41,56 @@ const timestampSuffix = () => `<t:${Math.floor(Date.now() / 1000)}:R>`;
 
 // ─── Build diff summary for updates ─────────────────────────────────────────
 
-const buildUpdateDiff = (
+/**
+ * Element-level diff for two string lists. Returns the items present in `next`
+ * but not `prev` (added) and the items present in `prev` but not `next`
+ * (removed). Order-insensitive; duplicates collapse via Set semantics.
+ */
+const diffStringLists = (
+  prev: readonly string[],
+  next: readonly string[],
+): { added: string[]; removed: string[] } => {
+  const prevSet = new Set(prev);
+  const nextSet = new Set(next);
+  return {
+    added: next.filter((item) => !prevSet.has(item)),
+    removed: prev.filter((item) => !nextSet.has(item)),
+  };
+};
+
+/** Truncate a long list of changed items so the log line stays readable. */
+const summarizeItems = (items: string[], max = 5): string => {
+  const shown = items.slice(0, max).map((item) => `\`${item}\``);
+  const overflow = items.length - shown.length;
+  return overflow > 0
+    ? `${shown.join(", ")} +${overflow} more`
+    : shown.join(", ");
+};
+
+const formatListChange = (
+  label: string,
+  { added, removed }: { added: string[]; removed: string[] },
+): string | null => {
+  if (added.length === 0 && removed.length === 0) return null;
+  const segments: string[] = [];
+  if (added.length > 0) segments.push(`+${summarizeItems(added)}`);
+  if (removed.length > 0) segments.push(`−${summarizeItems(removed)}`);
+  return `${label}: ${segments.join(" ")}`;
+};
+
+const countDelta = (
+  label: string,
+  oldCount: number,
+  newCount: number,
+): string | null => {
+  const delta = newCount - oldCount;
+  if (delta === 0) return null;
+  const sign = delta > 0 ? "+" : "";
+  const abs = Math.abs(delta);
+  return `${sign}${delta} ${label}${abs !== 1 ? "s" : ""}`;
+};
+
+export const buildUpdateDiff = (
   oldRule: AutoModerationRule | null,
   newRule: AutoModerationRule,
 ): string => {
@@ -61,45 +110,61 @@ const buildUpdateDiff = (
     );
   }
 
-  // Keyword filter count diff
-  const oldKeywords = oldRule.triggerMetadata?.keywordFilter ?? [];
-  const newKeywords = newRule.triggerMetadata?.keywordFilter ?? [];
-  const keywordDelta = newKeywords.length - oldKeywords.length;
-  if (keywordDelta !== 0) {
-    const sign = keywordDelta > 0 ? "+" : "";
-    const abs = Math.abs(keywordDelta);
-    parts.push(`${sign}${keywordDelta} keyword${abs !== 1 ? "s" : ""}`);
-  }
+  // Keyword filter element-level diff (surface the actual added/removed words)
+  const keywordChange = formatListChange(
+    "keywords",
+    diffStringLists(
+      oldRule.triggerMetadata?.keywordFilter ?? [],
+      newRule.triggerMetadata?.keywordFilter ?? [],
+    ),
+  );
+  if (keywordChange) parts.push(keywordChange);
 
-  // Regex pattern count diff
-  const oldPatterns = oldRule.triggerMetadata?.regexPatterns ?? [];
-  const newPatterns = newRule.triggerMetadata?.regexPatterns ?? [];
-  const patternDelta = newPatterns.length - oldPatterns.length;
-  if (patternDelta !== 0) {
-    const sign = patternDelta > 0 ? "+" : "";
-    const abs = Math.abs(patternDelta);
-    parts.push(`${sign}${patternDelta} regex pattern${abs !== 1 ? "s" : ""}`);
-  }
+  // Regex pattern element-level diff
+  const regexChange = formatListChange(
+    "regex",
+    diffStringLists(
+      oldRule.triggerMetadata?.regexPatterns ?? [],
+      newRule.triggerMetadata?.regexPatterns ?? [],
+    ),
+  );
+  if (regexChange) parts.push(regexChange);
+
+  // Allow-list element-level diff
+  const allowChange = formatListChange(
+    "allow-list",
+    diffStringLists(
+      oldRule.triggerMetadata?.allowList ?? [],
+      newRule.triggerMetadata?.allowList ?? [],
+    ),
+  );
+  if (allowChange) parts.push(allowChange);
+
+  // Action / response types (e.g. block message, timeout, send alert)
+  const actionChange = formatListChange(
+    "actions",
+    diffStringLists(
+      (oldRule.actions ?? []).map((a) => String(a.type)),
+      (newRule.actions ?? []).map((a) => String(a.type)),
+    ),
+  );
+  if (actionChange) parts.push(actionChange);
 
   // Exempt roles count diff
-  const oldExemptRoles = oldRule.exemptRoles?.size ?? 0;
-  const newExemptRoles = newRule.exemptRoles?.size ?? 0;
-  const roleDelta = newExemptRoles - oldExemptRoles;
-  if (roleDelta !== 0) {
-    const sign = roleDelta > 0 ? "+" : "";
-    const abs = Math.abs(roleDelta);
-    parts.push(`${sign}${roleDelta} exempt role${abs !== 1 ? "s" : ""}`);
-  }
+  const roleChange = countDelta(
+    "exempt role",
+    oldRule.exemptRoles?.size ?? 0,
+    newRule.exemptRoles?.size ?? 0,
+  );
+  if (roleChange) parts.push(roleChange);
 
   // Exempt channels count diff
-  const oldExemptChannels = oldRule.exemptChannels?.size ?? 0;
-  const newExemptChannels = newRule.exemptChannels?.size ?? 0;
-  const channelDelta = newExemptChannels - oldExemptChannels;
-  if (channelDelta !== 0) {
-    const sign = channelDelta > 0 ? "+" : "";
-    const abs = Math.abs(channelDelta);
-    parts.push(`${sign}${channelDelta} exempt channel${abs !== 1 ? "s" : ""}`);
-  }
+  const channelChange = countDelta(
+    "exempt channel",
+    oldRule.exemptChannels?.size ?? 0,
+    newRule.exemptChannels?.size ?? 0,
+  );
+  if (channelChange) parts.push(channelChange);
 
   return parts.length > 0 ? parts.join(" · ") : "minor configuration change";
 };

--- a/app/commands/report/modActionLogger.test.ts
+++ b/app/commands/report/modActionLogger.test.ts
@@ -1,0 +1,22 @@
+import type { AutoModerationRule } from "discord.js";
+
+import { resolveRuleName } from "./modActionLogger";
+
+const rule = (name: string) => ({ name }) as unknown as AutoModerationRule;
+
+test("prefers the freshly fetched rule name", () => {
+  expect(resolveRuleName(rule("Keyword filter"), rule("stale cache"))).toBe(
+    "Keyword filter",
+  );
+});
+
+test("falls back to the cached rule name when fetch returned null", () => {
+  // Regression for #399: the action-execution payload's cached rule is usually
+  // empty, but if a fetch fails we still prefer any name we have over the
+  // "Unknown rule" placeholder.
+  expect(resolveRuleName(null, rule("Cached name"))).toBe("Cached name");
+});
+
+test("falls back to a stable placeholder when no rule is resolvable", () => {
+  expect(resolveRuleName(null, null)).toBe("Unknown rule");
+});

--- a/app/commands/report/modActionLogger.ts
+++ b/app/commands/report/modActionLogger.ts
@@ -2,6 +2,7 @@ import { formatDistanceToNowStrict } from "date-fns";
 import {
   AuditLogEvent,
   type AutoModerationActionExecution,
+  type AutoModerationRule,
   type Guild,
   type GuildBan,
   type GuildMember,
@@ -13,10 +14,20 @@ import { Effect } from "effect";
 import { resolveApplicationsForDeparture } from "#~/commands/memberApplications";
 import { logAutomod } from "#~/commands/report/automodLog.ts";
 import { AUDIT_LOG_WINDOW_MS, fetchAuditLogEntry } from "#~/discord/auditLog";
-import { fetchUser } from "#~/effects/discordSdk.ts";
+import { fetchAutomodRuleOrNull, fetchUser } from "#~/effects/discordSdk.ts";
 import { logEffect } from "#~/effects/observability.ts";
 
 import { logModAction } from "./modActionLog";
+
+/**
+ * Resolve the display name for an automod rule, preferring a freshly fetched
+ * rule, then the (often-empty) cached rule on the execution payload, then a
+ * stable fallback. Pure so it can be unit-tested without a Discord client.
+ */
+export const resolveRuleName = (
+  fetchedRule: AutoModerationRule | null,
+  cachedRule: AutoModerationRule | null,
+): string => fetchedRule?.name ?? cachedRule?.name ?? "Unknown rule";
 
 export const banAddEffect = (ban: GuildBan) =>
   Effect.gen(function* () {
@@ -200,10 +211,17 @@ export const automodActionEffect = (execution: AutoModerationActionExecution) =>
       messageId,
       content,
       action,
+      ruleId,
       matchedContent,
       matchedKeyword,
       autoModerationRule,
     } = execution;
+
+    // The execution payload's `autoModerationRule` getter reads from a cache
+    // that is usually empty at action time, so fetch the rule by id to get a
+    // reliable name (falling back to the cached rule, then a stable default).
+    const fetchedRule = yield* fetchAutomodRuleOrNull(guild, ruleId);
+    const ruleName = resolveRuleName(fetchedRule, autoModerationRule);
 
     yield* logEffect("info", "Automod", "Automod action executed", {
       userId,
@@ -211,7 +229,8 @@ export const automodActionEffect = (execution: AutoModerationActionExecution) =>
       channelId,
       messageId,
       actionType: action.type,
-      ruleName: autoModerationRule?.name,
+      ruleId,
+      ruleName,
       matchedKeyword,
     });
 
@@ -223,7 +242,7 @@ export const automodActionEffect = (execution: AutoModerationActionExecution) =>
       content: content ?? matchedContent ?? "[Content not available]",
       channelId: channelId ?? undefined,
       messageId: messageId ?? undefined,
-      ruleName: autoModerationRule?.name ?? "Unknown rule",
+      ruleName,
       matchedKeyword: matchedKeyword ?? matchedContent ?? undefined,
       actionType: action.type,
     });

--- a/app/effects/discordSdk.ts
+++ b/app/effects/discordSdk.ts
@@ -8,6 +8,7 @@
  * performance tracing. Span names use a `discord.` prefix consistently.
  */
 import type {
+  AutoModerationRule,
   ChatInputCommandInteraction,
   Client,
   Guild,
@@ -59,6 +60,31 @@ export const fetchChannelFromClient = <T = GuildTextBasedChannel>(
   ).pipe(
     Effect.withSpan("discord.fetchChannel", {
       attributes: { channelId, variant: "fromClient" },
+    }),
+  );
+
+/**
+ * Resolve an automod rule by id, returning `null` instead of failing when the
+ * rule can't be fetched (e.g. it was deleted, or the bot lacks permission).
+ *
+ * The `AutoModerationActionExecution` event payload only reliably carries
+ * `ruleId`; its `autoModerationRule` getter reads from a cache that is usually
+ * empty at action time, so callers that need the rule name must fetch it.
+ */
+export const fetchAutomodRuleOrNull = (
+  guild: Guild,
+  ruleId: string,
+): Effect.Effect<AutoModerationRule | null, never, never> =>
+  Effect.tryPromise({
+    try: () => guild.autoModerationRules.fetch(ruleId),
+    catch: () => null,
+  }).pipe(
+    Effect.catchAll(() => Effect.succeed(null)),
+    Effect.tap((result) =>
+      Effect.annotateCurrentSpan({ found: result !== null }),
+    ),
+    Effect.withSpan("discord.fetchAutomodRule", {
+      attributes: { guildId: guild.id, ruleId, variant: "orNull" },
     }),
   );
 


### PR DESCRIPTION
## Summary

Two independent automod-logging bug fixes.

### Bug 1 — #399: action log showed "Unknown rule"
The `AutoModerationActionExecution` payload's `autoModerationRule` getter reads from a Discord.js cache that is usually empty at action time, so `autoModerationRule?.name ?? "Unknown rule"` resolved to the placeholder.

- Added `fetchAutomodRuleOrNull(guild, ruleId)` to `app/effects/discordSdk.ts` — `ruleId` is always present on the execution payload. Fetches the rule, returns `null` (never fails) if it's gone or unfetchable.
- Added a pure `resolveRuleName(fetched, cached)` in `app/commands/report/modActionLogger.ts` (fetched name → cached name → `"Unknown rule"`), and wired it into `automodActionEffect` so both the structured log and the mod-log message get the real name. Also added `ruleId` to the info log.

### Bug 2 — #398: rule-update log omitted changed keywords
`buildUpdateDiff()` only compared list **lengths**, so same-count keyword/regex swaps fell through to `"minor configuration change"`.

- `buildUpdateDiff` (now exported) computes element-level added/removed diffs for `keywordFilter`, `regexPatterns`, and `allowList`, plus a diff of action/response types. Changed values are surfaced inline (e.g. `keywords: +\`phish\` −\`scam\``), truncated with a `+N more` overflow for long lists. Count-delta fallback retained for exempt roles/channels.

## Testing
- New `app/commands/report/automodRuleLog.test.ts` (10 cases) — covers same-count swaps, add/remove-only, regex, actions, truncation, and the fallback.
- New `app/commands/report/modActionLogger.test.ts` (3 cases) — `resolveRuleName` precedence.
- `npm run lint` clean (zero warnings); report + effects suites green (75 tests).

Closes #399
Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)